### PR TITLE
Adds cortex frontend

### DIFF
--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -33,6 +33,7 @@ rules:
   - apiGroups:
       - extensions
     resources:
+      - deployments
       - ingresses
     verbs:
       - create

--- a/service/controller/controller_resource_set.go
+++ b/service/controller/controller_resource_set.go
@@ -11,9 +11,11 @@ import (
 	"github.com/giantswarm/operatorkit/resource/wrapper/retryresource"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/certificates"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/frontend"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/ingress"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/prometheus"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/service"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/servicemonitor"
 )
 
@@ -67,6 +69,32 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 		}
 	}
 
+	var frontendResource resource.Interface
+	{
+		c := frontend.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		frontendResource, err = frontend.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var serviceResource resource.Interface
+	{
+		c := service.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		serviceResource, err = service.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var ingressResource resource.Interface
 	{
 		c := ingress.Config{
@@ -99,6 +127,8 @@ func newResourceSet(config resourceSetConfig) (*controller.ResourceSet, error) {
 		namespaceResource,
 		certificatesResource,
 		prometheusResource,
+		frontendResource,
+		serviceResource,
 		ingressResource,
 		serviceMonitorResource,
 	}

--- a/service/controller/resource/frontend/create.go
+++ b/service/controller/resource/frontend/create.go
@@ -1,0 +1,24 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	frontend, err := toFrontend(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Create(frontend)
+	if apierrors.IsAlreadyExists(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/frontend/delete.go
+++ b/service/controller/resource/frontend/delete.go
@@ -1,0 +1,25 @@
+package frontend
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	frontend, err := toFrontend(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Delete(frontend.GetName(), &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/frontend/error.go
+++ b/service/controller/resource/frontend/error.go
@@ -1,0 +1,23 @@
+package frontend
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/resource/frontend/resource.go
+++ b/service/controller/resource/frontend/resource.go
@@ -1,0 +1,104 @@
+package frontend
+
+import (
+	"github.com/giantswarm/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	Name = "frontend"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func toFrontend(v interface{}) (*v1beta1.Deployment, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	var replicas int32 = 2
+
+	deployment := &v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "frontend",
+			Namespace: key.Namespace(cluster),
+		},
+		Spec: v1beta1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": "frontend",
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "frontend",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "frontend",
+							Image: "quay.io/cortexproject/cortex:v0.4.0",
+							Args: []string{
+								"-auth.enabled=false",
+								"-fifocache.duration=24h",
+								"-frontend.cache.enable-fifocache=true",
+								"-frontend.default-validity=24h",
+								"-frontend.downstream-url=http://prometheus-operated:9090",
+								"-frontend.fifocache.duration=24h",
+								"-frontend.fifocache.size=1024",
+								"-frontend.log-queries-longer-than=1s",
+								"-http.prefix=",
+								"-log.level=debug",
+								"-querier.align-querier-with-step=true",
+								"-querier.cache-results=true",
+								"-querier.compress-http-responses=true",
+								"-querier.split-queries-by-interval=24h",
+								"-server.http-listen-port=9091",
+								"-target=query-frontend",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return deployment, nil
+}

--- a/service/controller/resource/service/create.go
+++ b/service/controller/resource/service/create.go
@@ -1,0 +1,24 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	service, err := toService(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Create(service)
+	if apierrors.IsAlreadyExists(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/service/delete.go
+++ b/service/controller/resource/service/delete.go
@@ -1,0 +1,25 @@
+package service
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	service, err := toService(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Delete(service.GetName(), &metav1.DeleteOptions{})
+	if apierrors.IsNotFound(err) {
+		// fall through
+	} else if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/service/error.go
+++ b/service/controller/resource/service/error.go
@@ -1,0 +1,23 @@
+package service
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/8155

```
NAME                                     AGE
prometheus.monitoring.coreos.com/4ywny   4h

NAME                                                              AGE
servicemonitor.monitoring.coreos.com/kubernetes-apiserver-4ywny   4h

NAME                                READY   AGE
statefulset.apps/prometheus-4ywny   2/2     4h

NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
deployment.extensions/frontend   2/2     2            2           66s

NAME                       HOSTS
ADDRESS   PORTS   AGE
ingress.extensions/4ywny   4ywny-prometheus.g8s.geckon.gridscale.kvm.gigantic.io
          80      66s

NAME                          TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)
 AGE
service/prometheus            ClusterIP   172.31.218.212   <none>        9091/TCP
 66s
service/prometheus-operated   ClusterIP   None             <none>        9090/TCP
 4h

NAME                            READY   STATUS    RESTARTS   AGE
pod/frontend-6484475c95-fnb5t   1/1     Running   0          66s
pod/frontend-6484475c95-glv5n   1/1     Running   0          66s
pod/prometheus-4ywny-0          3/3     Running   1          4h
pod/prometheus-4ywny-1          3/3     Running   1          4h
```