### PR TITLE
Use architect 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@0.4.5
+  architect: giantswarm/architect@0.6.0
 
 workflows:
   build:

--- a/flag/flag.go
+++ b/flag/flag.go
@@ -2,6 +2,7 @@ package flag
 
 import (
 	"github.com/giantswarm/microkit/flag"
+
 	"github.com/giantswarm/prometheus-meta-operator/flag/service"
 )
 

--- a/service/controller/resource/alert/resource.go
+++ b/service/controller/resource/alert/resource.go
@@ -5,6 +5,7 @@ import (
 	promclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/alert/rules"
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )

--- a/service/controller/resource/alert/rules/apiserver.go
+++ b/service/controller/resource/alert/rules/apiserver.go
@@ -2,10 +2,11 @@ package rules
 
 import (
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 func APIServer(cluster *v1alpha2.Cluster) *promv1.PrometheusRule {

--- a/service/controller/resource/certificates/resource.go
+++ b/service/controller/resource/certificates/resource.go
@@ -6,9 +6,10 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/frontend/resource.go
+++ b/service/controller/resource/frontend/resource.go
@@ -4,10 +4,11 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -6,10 +6,11 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/namespace/resource.go
+++ b/service/controller/resource/namespace/resource.go
@@ -4,9 +4,10 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -7,10 +7,11 @@ import (
 	promclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/service/resource.go
+++ b/service/controller/resource/service/resource.go
@@ -4,9 +4,10 @@ import (
 	"github.com/giantswarm/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/servicemonitor/services.go
+++ b/service/controller/resource/servicemonitor/services.go
@@ -5,9 +5,10 @@ import (
 
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 func toServiceMonitors(obj interface{}) ([]*promv1.ServiceMonitor, error) {

--- a/service/service.go
+++ b/service/service.go
@@ -17,10 +17,11 @@ import (
 	"k8s.io/client-go/rest"
 
 	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
+	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+
 	"github.com/giantswarm/prometheus-meta-operator/flag"
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 )
 
 // Config represents the configuration used to create a new service.


### PR DESCRIPTION
Adds additional checks for import rules in go code and stops injecting
version from git at build time.
