### PR TITLE
move to monitoring namespace

### DIFF
--- a/helm/prometheus-meta-operator/templates/_resource.tpl
+++ b/helm/prometheus-meta-operator/templates/_resource.tpl
@@ -24,5 +24,5 @@ room for such suffix.
 {{- end -}}
 
 {{- define "resource.default.namespace" -}}
-giantswarm
+monitoring
 {{- end -}}

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -53,20 +53,20 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name" . }}
+    namespace: {{ include "resource.default.namespace" . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.default.name  . }}
+  name: {{ include "resource.default.name" . }}
   apiGroup: rbac.authorization.k8s.io
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
 rules:
   - apiGroups:
       - extensions
@@ -75,17 +75,17 @@ rules:
     verbs:
       - use
     resourceNames:
-      - {{ tpl .Values.resource.psp.name . }}
+      - {{ include "resource.psp.name" . }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ tpl .Values.resource.default.name  . }}
-    namespace: {{ tpl .Values.resource.default.namespace  . }}
+    name: {{ include "resource.default.name" . }}
+    namespace: {{ include "resource.default.namespace" . }}
 roleRef:
   kind: ClusterRole
-  name: {{ tpl .Values.resource.psp.name . }}
+  name: {{ include "resource.psp.name" . }}
   apiGroup: rbac.authorization.k8s.io

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -11,26 +11,5 @@ pod:
   group:
     id: 1000
 project:
-  name: "prometheus-meta-operator"
-  version: "[[ .Version ]]"
-# Resource names are truncated to 47 characters.
-#
-# Kubernetes allows 63 characters limit for resource names. When pods for
-# deployments are created they have additional 16 characters suffix, e.g.
-# "-957c9d6ff-pkzgw" and we want to have room for those suffixes.
-#
-# NOTE: All values under resource key need to be used with `tpl` to render them
-# correctly in the templates. This is because helm doesn't template values.yaml
-# file and it has to be a valid json. Example usage:
-#
-#     {{ tpl .Values.resource.default.name . }}.
-#
-resource:
-  default:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}'
-    namespace: "monitoring"
-  psp:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-psp'
-  pullSecret:
-    name: '{{ .Release.Name | replace "." "-" | trunc 47 }}-pull-secret'
-    namespace: "monitoring"
+  branch: "[[ .Branch ]]"
+  commit: "[[ .SHA ]]"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10899

* change chart namespace to monitoring
* remove old chart resources definition