### PR TITLE
use metav1.Object interface instead of v1alpha2.Cluster object

### DIFF
--- a/service/controller/resource/alert/rules/apiserver.go
+++ b/service/controller/resource/alert/rules/apiserver.go
@@ -4,12 +4,11 @@ import (
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
-func APIServer(cluster *v1alpha2.Cluster) *promv1.PrometheusRule {
+func APIServer(cluster metav1.Object) *promv1.PrometheusRule {
 	return &promv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "apiserver-rules",

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -7,9 +7,7 @@ import (
 	promclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
@@ -53,9 +51,9 @@ func toPrometheus(v interface{}) (*promv1.Prometheus, error) {
 		return nil, nil
 	}
 
-	cluster, ok := v.(*v1alpha2.Cluster)
-	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &corev1.Namespace{}, v)
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
 	}
 
 	name := cluster.GetName()

--- a/service/controller/resource/servicemonitor/services.go
+++ b/service/controller/resource/servicemonitor/services.go
@@ -6,7 +6,6 @@ import (
 	promv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/giantswarm/microerror"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
@@ -22,7 +21,7 @@ func toServiceMonitors(obj interface{}) ([]*promv1.ServiceMonitor, error) {
 	}, nil
 }
 
-func apiServer(cluster *v1alpha2.Cluster) *promv1.ServiceMonitor {
+func apiServer(cluster metav1.Object) *promv1.ServiceMonitor {
 	return &promv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("kubernetes-apiserver-%s", cluster.GetName()),

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -4,19 +4,19 @@ import (
 	"fmt"
 
 	"github.com/giantswarm/microerror"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ToCluster(obj interface{}) (*v1alpha2.Cluster, error) {
-	cluster, ok := obj.(*v1alpha2.Cluster)
+func ToCluster(obj interface{}) (metav1.Object, error) {
+	clusterMetaObject, ok := obj.(metav1.Object)
 	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "expected '%T', got '%T'", &v1alpha2.Cluster{}, obj)
+		return nil, microerror.Maskf(wrongTypeError, "'%T' does not implements '%T'", obj, clusterMetaObject)
 	}
 
-	return cluster, nil
+	return clusterMetaObject, nil
 }
 
-func Namespace(cluster *v1alpha2.Cluster) string {
+func Namespace(cluster metav1.Object) string {
 	return fmt.Sprintf("%s-prometheus", cluster.GetName())
 }
 
@@ -28,6 +28,6 @@ func ClusterIDKey() string {
 	return "cluster_id"
 }
 
-func ClusterID(cluster *v1alpha2.Cluster) string {
+func ClusterID(cluster metav1.Object) string {
 	return cluster.GetName()
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10898

Since we only read name of the given CR as cluster name, let's use the meta.Objet interface instead of the full v1alpha2.Cluster object. So we can later pass different CRs (awsconfig, azureconfig, kvmconfig) and re-use all resources.