### PR TITLE
Watch awsconfig CRs

### DIFF
--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -55,6 +55,16 @@ rules:
     verbs:
       - create
       - delete
+  - apiGroups:
+      - provider.giantswarm.io
+    resources:
+      - awsconfigs
+    verbs:
+      - watch
+      - get
+      - list
+      - update
+      - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -23,6 +23,13 @@ rules:
       - delete
       - get
   - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+  - apiGroups:
       - cluster.x-k8s.io
     resources:
       - clusters
@@ -35,7 +42,6 @@ rules:
   - apiGroups:
       - extensions
     resources:
-      - deployments
       - ingresses
     verbs:
       - create

--- a/service/controller/awsconfig/controller.go
+++ b/service/controller/awsconfig/controller.go
@@ -13,7 +13,6 @@ import (
 	"github.com/giantswarm/operatorkit/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
 )
 
@@ -47,7 +46,7 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		c := controller.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-			Name:      project.Name() + "-controller",
+			Name:      "awsconfig-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha1.AWSConfig)
 			},

--- a/service/controller/awsconfig/controller.go
+++ b/service/controller/awsconfig/controller.go
@@ -1,0 +1,68 @@
+package awsconfig
+
+import (
+	// If your operator watches a CRD import it here.
+	// "github.com/giantswarm/apiextensions/pkg/apis/application/v1alpha1"
+
+	promclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/operatorkit/controller"
+	"github.com/giantswarm/operatorkit/resource"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
+	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
+)
+
+type ControllerConfig struct {
+	K8sClient        k8sclient.Interface
+	Logger           micrologger.Logger
+	PrometheusClient promclient.Interface
+
+	BaseDomain string
+}
+
+type Controller struct {
+	*controller.Controller
+}
+
+func NewController(config ControllerConfig) (*Controller, error) {
+	var err error
+
+	var resources []resource.Interface
+	{
+		c := controllerresource.Config(config)
+
+		resources, err = controllerresource.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var operatorkitController *controller.Controller
+	{
+		c := controller.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			Name:      project.Name() + "-controller",
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(v1alpha1.AWSConfig)
+			},
+			Resources: resources,
+		}
+
+		operatorkitController, err = controller.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	c := &Controller{
+		Controller: operatorkitController,
+	}
+
+	return c, nil
+}

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -13,7 +13,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
-	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
 )
 
@@ -47,7 +46,7 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		c := controller.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-			Name:      project.Name() + "-controller",
+			Name:      "clusterapi-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha2.Cluster)
 			},

--- a/service/controller/resource/alert/create.go
+++ b/service/controller/resource/alert/create.go
@@ -13,7 +13,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating alert rules")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating alert rules")
 	for _, prometheusRule := range prometheusRules {
 		_, err = r.prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.GetNamespace()).Create(prometheusRule)
 		if apierrors.IsAlreadyExists(err) {
@@ -22,7 +22,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
-	r.logger.LogCtx(ctx, "created alert rules")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created alert rules")
 
 	return nil
 }

--- a/service/controller/resource/alert/create.go
+++ b/service/controller/resource/alert/create.go
@@ -13,6 +13,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating alert rules")
 	for _, prometheusRule := range prometheusRules {
 		_, err = r.prometheusClient.MonitoringV1().PrometheusRules(prometheusRule.GetNamespace()).Create(prometheusRule)
 		if apierrors.IsAlreadyExists(err) {
@@ -21,6 +22,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
+	r.logger.LogCtx(ctx, "created alert rules")
 
 	return nil
 }

--- a/service/controller/resource/alert/delete.go
+++ b/service/controller/resource/alert/delete.go
@@ -14,7 +14,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting alert rules")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting alert rules")
 	for _, prometheusRule := range prometheusRules {
 		err := r.prometheusClient.MonitoringV1().ServiceMonitors(prometheusRule.GetNamespace()).Delete(prometheusRule.GetName(), &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -23,7 +23,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
-	r.logger.LogCtx(ctx, "deleted alert rules")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted alert rules")
 
 	return nil
 }

--- a/service/controller/resource/alert/delete.go
+++ b/service/controller/resource/alert/delete.go
@@ -14,6 +14,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting alert rules")
 	for _, prometheusRule := range prometheusRules {
 		err := r.prometheusClient.MonitoringV1().ServiceMonitors(prometheusRule.GetNamespace()).Delete(prometheusRule.GetName(), &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -22,6 +23,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
+	r.logger.LogCtx(ctx, "deleted alert rules")
 
 	return nil
 }

--- a/service/controller/resource/certificates/create.go
+++ b/service/controller/resource/certificates/create.go
@@ -19,7 +19,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating certificates")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating certificates")
 	_, err = r.k8sClient.K8sClient().CoreV1().Secrets(targetSecret.GetNamespace()).Get(targetSecret.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		sourceSecret, err := r.k8sClient.K8sClient().CoreV1().Secrets(sourceSecret.GetNamespace()).Get(sourceSecret.GetName(), metav1.GetOptions{})
@@ -35,7 +35,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created certificates")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created certificates")
 
 	return nil
 }

--- a/service/controller/resource/certificates/create.go
+++ b/service/controller/resource/certificates/create.go
@@ -19,6 +19,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating certificates")
 	_, err = r.k8sClient.K8sClient().CoreV1().Secrets(targetSecret.GetNamespace()).Get(targetSecret.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		sourceSecret, err := r.k8sClient.K8sClient().CoreV1().Secrets(sourceSecret.GetNamespace()).Get(sourceSecret.GetName(), metav1.GetOptions{})
@@ -34,6 +35,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created certificates")
 
 	return nil
 }

--- a/service/controller/resource/certificates/delete.go
+++ b/service/controller/resource/certificates/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting certificates")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting certificates")
 	err = r.k8sClient.K8sClient().CoreV1().Secrets(secret.GetNamespace()).Delete(secret.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted certificates")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted certificates")
 
 	return nil
 }

--- a/service/controller/resource/certificates/delete.go
+++ b/service/controller/resource/certificates/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting certificates")
 	err = r.k8sClient.K8sClient().CoreV1().Secrets(secret.GetNamespace()).Delete(secret.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted certificates")
 
 	return nil
 }

--- a/service/controller/resource/frontend/create.go
+++ b/service/controller/resource/frontend/create.go
@@ -13,12 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating frontend")
 	_, err = r.k8sClient.K8sClient().AppsV1().Deployments(frontend.GetNamespace()).Create(frontend)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created frontend")
 
 	return nil
 }

--- a/service/controller/resource/frontend/create.go
+++ b/service/controller/resource/frontend/create.go
@@ -13,7 +13,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	_, err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Create(frontend)
+	_, err = r.k8sClient.K8sClient().AppsV1().Deployments(frontend.GetNamespace()).Create(frontend)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {

--- a/service/controller/resource/frontend/create.go
+++ b/service/controller/resource/frontend/create.go
@@ -13,14 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating frontend")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating frontend")
 	_, err = r.k8sClient.K8sClient().AppsV1().Deployments(frontend.GetNamespace()).Create(frontend)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created frontend")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created frontend")
 
 	return nil
 }

--- a/service/controller/resource/frontend/delete.go
+++ b/service/controller/resource/frontend/delete.go
@@ -15,7 +15,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	}
 
 	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting frontend")
-	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Delete(frontend.GetName(), &metav1.DeleteOptions{})
+	err = r.k8sClient.K8sClient().AppsV1().Deployments(frontend.GetNamespace()).Delete(frontend.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {

--- a/service/controller/resource/frontend/delete.go
+++ b/service/controller/resource/frontend/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting frontend")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting frontend")
 	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Delete(frontend.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted frontend")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted frontend")
 
 	return nil
 }

--- a/service/controller/resource/frontend/delete.go
+++ b/service/controller/resource/frontend/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting frontend")
 	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Deployments(frontend.GetNamespace()).Delete(frontend.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted frontend")
 
 	return nil
 }

--- a/service/controller/resource/frontend/resource.go
+++ b/service/controller/resource/frontend/resource.go
@@ -4,8 +4,8 @@ import (
 	"github.com/giantswarm/k8sclient/v3/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
@@ -45,7 +45,7 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func toFrontend(v interface{}) (*v1beta1.Deployment, error) {
+func toFrontend(v interface{}) (*v1.Deployment, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -53,12 +53,12 @@ func toFrontend(v interface{}) (*v1beta1.Deployment, error) {
 
 	var replicas int32 = 2
 
-	deployment := &v1beta1.Deployment{
+	deployment := &v1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "frontend",
 			Namespace: key.Namespace(cluster),
 		},
-		Spec: v1beta1.DeploymentSpec{
+		Spec: v1.DeploymentSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{

--- a/service/controller/resource/ingress/create.go
+++ b/service/controller/resource/ingress/create.go
@@ -13,14 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating ingress")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating ingress")
 	_, err = r.k8sClient.K8sClient().ExtensionsV1beta1().Ingresses(ingress.GetNamespace()).Create(ingress)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created ingress")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created ingress")
 
 	return nil
 }

--- a/service/controller/resource/ingress/create.go
+++ b/service/controller/resource/ingress/create.go
@@ -13,12 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating ingress")
 	_, err = r.k8sClient.K8sClient().ExtensionsV1beta1().Ingresses(ingress.GetNamespace()).Create(ingress)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created ingress")
 
 	return nil
 }

--- a/service/controller/resource/ingress/delete.go
+++ b/service/controller/resource/ingress/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting ingress")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting ingress")
 	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Ingresses(ingress.GetNamespace()).Delete(ingress.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted ingress")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted ingress")
 
 	return nil
 }

--- a/service/controller/resource/ingress/delete.go
+++ b/service/controller/resource/ingress/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting ingress")
 	err = r.k8sClient.K8sClient().ExtensionsV1beta1().Ingresses(ingress.GetNamespace()).Delete(ingress.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted ingress")
 
 	return nil
 }

--- a/service/controller/resource/namespace/create.go
+++ b/service/controller/resource/namespace/create.go
@@ -13,12 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating namespace")
 	_, err = r.k8sClient.K8sClient().CoreV1().Namespaces().Create(namespace)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created namespace")
 
 	return nil
 }

--- a/service/controller/resource/namespace/create.go
+++ b/service/controller/resource/namespace/create.go
@@ -13,14 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating namespace")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating namespace")
 	_, err = r.k8sClient.K8sClient().CoreV1().Namespaces().Create(namespace)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created namespace")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created namespace")
 
 	return nil
 }

--- a/service/controller/resource/namespace/delete.go
+++ b/service/controller/resource/namespace/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting namespace")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting namespace")
 	err = r.k8sClient.K8sClient().CoreV1().Namespaces().Delete(namespace.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted namespace")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted namespace")
 
 	return nil
 }

--- a/service/controller/resource/namespace/delete.go
+++ b/service/controller/resource/namespace/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting namespace")
 	err = r.k8sClient.K8sClient().CoreV1().Namespaces().Delete(namespace.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted namespace")
 
 	return nil
 }

--- a/service/controller/resource/prometheus/create.go
+++ b/service/controller/resource/prometheus/create.go
@@ -13,12 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating prometheus")
 	_, err = r.prometheusClient.MonitoringV1().Prometheuses(prometheus.GetNamespace()).Create(prometheus)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created prometheus")
 
 	return nil
 }

--- a/service/controller/resource/prometheus/create.go
+++ b/service/controller/resource/prometheus/create.go
@@ -13,14 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating prometheus")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating prometheus")
 	_, err = r.prometheusClient.MonitoringV1().Prometheuses(prometheus.GetNamespace()).Create(prometheus)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created prometheus")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created prometheus")
 
 	return nil
 }

--- a/service/controller/resource/prometheus/delete.go
+++ b/service/controller/resource/prometheus/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting prometheus")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting prometheus")
 	err = r.prometheusClient.MonitoringV1().Prometheuses(prometheus.GetNamespace()).Delete(prometheus.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted prometheus")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted prometheus")
 
 	return nil
 }

--- a/service/controller/resource/prometheus/delete.go
+++ b/service/controller/resource/prometheus/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting prometheus")
 	err = r.prometheusClient.MonitoringV1().Prometheuses(prometheus.GetNamespace()).Delete(prometheus.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted prometheus")
 
 	return nil
 }

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -1,4 +1,4 @@
-package controller
+package resource
 
 import (
 	promclient "github.com/coreos/prometheus-operator/pkg/client/versioned"
@@ -19,7 +19,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/servicemonitor"
 )
 
-type resourcesConfig struct {
+type Config struct {
 	K8sClient        k8sclient.Interface
 	Logger           micrologger.Logger
 	PrometheusClient promclient.Interface
@@ -27,7 +27,7 @@ type resourcesConfig struct {
 	BaseDomain string
 }
 
-func newResources(config resourcesConfig) ([]resource.Interface, error) {
+func New(config Config) ([]resource.Interface, error) {
 	var err error
 
 	var namespaceResource resource.Interface

--- a/service/controller/resource/service/create.go
+++ b/service/controller/resource/service/create.go
@@ -13,12 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating service")
 	_, err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Create(service)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "created service")
 
 	return nil
 }

--- a/service/controller/resource/service/create.go
+++ b/service/controller/resource/service/create.go
@@ -13,14 +13,14 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating service")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating service")
 	_, err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Create(service)
 	if apierrors.IsAlreadyExists(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "created service")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created service")
 
 	return nil
 }

--- a/service/controller/resource/service/delete.go
+++ b/service/controller/resource/service/delete.go
@@ -14,14 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting service")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting service")
 	err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Delete(service.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
-	r.logger.LogCtx(ctx, "deleted service")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted service")
 
 	return nil
 }

--- a/service/controller/resource/service/delete.go
+++ b/service/controller/resource/service/delete.go
@@ -14,12 +14,14 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting service")
 	err = r.k8sClient.K8sClient().CoreV1().Services(service.GetNamespace()).Delete(service.GetName(), &metav1.DeleteOptions{})
 	if apierrors.IsNotFound(err) {
 		// fall through
 	} else if err != nil {
 		return microerror.Mask(err)
 	}
+	r.logger.LogCtx(ctx, "deleted service")
 
 	return nil
 }

--- a/service/controller/resource/servicemonitor/create.go
+++ b/service/controller/resource/servicemonitor/create.go
@@ -13,7 +13,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "creating servicemonitor")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "creating servicemonitor")
 	for _, serviceMonitor := range serviceMonitors {
 		_, err = r.prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.GetNamespace()).Create(serviceMonitor)
 		if apierrors.IsAlreadyExists(err) {
@@ -22,7 +22,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
-	r.logger.LogCtx(ctx, "created servicemonitor")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "created servicemonitor")
 
 	return nil
 }

--- a/service/controller/resource/servicemonitor/create.go
+++ b/service/controller/resource/servicemonitor/create.go
@@ -13,6 +13,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "creating servicemonitor")
 	for _, serviceMonitor := range serviceMonitors {
 		_, err = r.prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.GetNamespace()).Create(serviceMonitor)
 		if apierrors.IsAlreadyExists(err) {
@@ -21,6 +22,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
+	r.logger.LogCtx(ctx, "created servicemonitor")
 
 	return nil
 }

--- a/service/controller/resource/servicemonitor/delete.go
+++ b/service/controller/resource/servicemonitor/delete.go
@@ -14,7 +14,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	r.logger.LogCtx(ctx, "deleting servicemonitor")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleting servicemonitor")
 	for _, serviceMonitor := range serviceMonitors {
 		err := r.prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.GetNamespace()).Delete(serviceMonitor.GetName(), &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -23,7 +23,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
-	r.logger.LogCtx(ctx, "deleted servicemonitor")
+	r.logger.LogCtx(ctx, "level", "debug", "message", "deleted servicemonitor")
 
 	return nil
 }

--- a/service/controller/resource/servicemonitor/delete.go
+++ b/service/controller/resource/servicemonitor/delete.go
@@ -14,6 +14,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
+	r.logger.LogCtx(ctx, "deleting servicemonitor")
 	for _, serviceMonitor := range serviceMonitors {
 		err := r.prometheusClient.MonitoringV1().ServiceMonitors(serviceMonitor.GetNamespace()).Delete(serviceMonitor.GetName(), &metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
@@ -22,6 +23,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 	}
+	r.logger.LogCtx(ctx, "deleted servicemonitor")
 
 	return nil
 }

--- a/service/service.go
+++ b/service/service.go
@@ -164,7 +164,7 @@ func New(config Config) (*Service, error) {
 func (s *Service) Boot(ctx context.Context) {
 	s.bootOnce.Do(func() {
 
-		//go s.awsconfigController.Boot(ctx)
+		go s.awsconfigController.Boot(ctx)
 		go s.clusterapiController.Boot(ctx)
 	})
 }

--- a/service/service.go
+++ b/service/service.go
@@ -16,8 +16,8 @@ import (
 	"github.com/spf13/viper"
 	"k8s.io/client-go/rest"
 
-	infrastructurev1alpha2 "github.com/giantswarm/apiextensions/pkg/apis/infrastructure/v1alpha2"
-	apiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
+	"github.com/giantswarm/apiextensions/pkg/apis/provider/v1alpha1"
+	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
 	"github.com/giantswarm/prometheus-meta-operator/flag"
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
@@ -86,8 +86,8 @@ func New(config Config) (*Service, error) {
 
 			RestConfig: restConfig,
 			SchemeBuilder: k8sclient.SchemeBuilder{
-				apiv1alpha2.AddToScheme,
-				infrastructurev1alpha2.AddToScheme,
+				v1alpha1.AddToScheme,
+				v1alpha2.AddToScheme,
 			},
 		}
 

--- a/service/service.go
+++ b/service/service.go
@@ -164,7 +164,7 @@ func New(config Config) (*Service, error) {
 func (s *Service) Boot(ctx context.Context) {
 	s.bootOnce.Do(func() {
 
-		go s.awsconfigController.Boot(ctx)
+		//go s.awsconfigController.Boot(ctx)
 		go s.clusterapiController.Boot(ctx)
 	})
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10898


* change: move controller.NewController to controller/clusterapi.NewController
* change: move controller.newResources to resources.New
* add: awsconfigController
* change: from v1beta1.Deployment to v1.Deployment
* rbac: move from `extensions/v1beta1.deployment` to `apps/v1.deployment`
* rbac: add awsconfigs.provider.giantswarm.io (watch, get, list, update, patch)
* logs: add log message to every resources



Tested on ginger

4 TCs
```
$ gsctl list clusters
ID      ORGANIZATION   NAME                              RELEASE   CREATED
gds6i   giantswarm     theo-monitoring2                  11.0.1    2020 Jun 02, 13:55 UTC
jcqj9   giantswarm     vaclav-test-ha-master-id          12.0.1    2020 Jun 02, 07:23 UTC
t0d0x   giantswarm     stevo - nginx - liveness probes   11.3.0    2020 May 28, 21:33 UTC
vp0bb   giantswarm     theo-monitoring                   9.0.5     2020 Jun 02, 10:23 UTC
```
3 TC using clusterapi, 1 TC using awsconfig
```
$ k get cluster.cluster.x-k8s.io,awsconfig -A
NAMESPACE   NAME                             PHASE
default     cluster.cluster.x-k8s.io/5dp5h
default     cluster.cluster.x-k8s.io/gds6i
default     cluster.cluster.x-k8s.io/jcqj9
default     cluster.cluster.x-k8s.io/t0d0x

NAMESPACE   NAME                                     AGE
default     awsconfig.provider.giantswarm.io/vp0bb   3h44m
```

4 Prometheus CRs created
```
$ k get prometheus -A
NAMESPACE          NAME    VERSION   REPLICAS   AGE
gds6i-prometheus   gds6i             2          10m
jcqj9-prometheus   jcqj9             2          6h42m
t0d0x-prometheus   t0d0x             2          4d16h
vp0bb-prometheus   vp0bb             2          19m
```