### PR TITLE
set prometheus-meta-operator replicas to 0

### DIFF
--- a/helm/prometheus-meta-operator/templates/deployment.yaml
+++ b/helm/prometheus-meta-operator/templates/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11702

Given that we encoutered capacity issues on CPs, this PR set `prometheus-meta-operator` replicas to 0 so nothing is deployed and we do not run into troubles.