### PR TITLE
generic: fix invalid resource version error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Removed service resource as this is no longer needed (it was used for cortex frontend)
 
+### Fixed
+
+- Fix an error during alert update: metadata.resourceVersion: Invalid value
+
 ## [0.1.1] - 2020-05-27
 
 ### Added

--- a/service/controller/resource/generic/create.go
+++ b/service/controller/resource/generic/create.go
@@ -18,7 +18,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	c := r.clientFunc(desired.GetNamespace())
 	current, err := c.Get(desired.GetName(), metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
-		_, err = c.Create(desired)
+		current, err = c.Create(desired)
 	}
 	if err != nil {
 		return microerror.Mask(err)


### PR DESCRIPTION
Fixes the following error

```
W 06/24 09:03:08 /apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/h4d6v alert retrying due to error | operatorkit/resource/wrapper/retryresource/basic_resource.go:59 | controller=clusterapi-controller | event=update | loop=37 | stack=map[annotation:prometheusrules.monitoring.coreos.com "example-rules" is invalid: metadata.resourceVersion: Invalid value: 0x0: must be specified for an update kind:unknown stack:[map[file:/root/project/service/controller/resource/generic/create.go line:31] map[file:/go/pkg/mod/github.com/giantswarm/operatorkit@v1.0.0/resource/wrapper/retryresource/basic_resource.go line:52]]] | version=80098004
```