### PR TITLE
fix nginx-ingress-controller target

### DIFF
--- a/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
+++ b/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
@@ -21,7 +21,7 @@ func NginxIngressController(cluster metav1.Object) *promv1.ServiceMonitor {
 		Spec: promv1.ServiceMonitorSpec{
 			Selector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					"k8s-app": "nginx-ingress-controller",
+					"app.kubernetes.io/name": "nginx-ingress-controller",
 				},
 			},
 			NamespaceSelector: promv1.NamespaceSelector{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10905

The label selector to use is `app.kubernetes.io/name=nginx-ingress-controller`.

The previously used `k8s-app=nginx-ingress-controller` is only used on control planes.