### PR TITLE
Fix nginx ingress target port

### DIFF
--- a/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
+++ b/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
@@ -34,7 +34,7 @@ func NginxIngressController(cluster metav1.Object) *promv1.ServiceMonitor {
 					RelabelConfigs: []*promv1.RelabelConfig{
 						&promv1.RelabelConfig{
 							Regex:        ".*",
-							Replacement:  fmt.Sprintf("master.%d:443", key.ClusterID(cluster)),
+							Replacement:  fmt.Sprintf("master.%s:443", key.ClusterID(cluster)),
 							SourceLabels: []string{"__address__"},
 							TargetLabel:  "__address__",
 						},

--- a/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
+++ b/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
@@ -29,7 +29,7 @@ func NginxIngressController(cluster metav1.Object) *promv1.ServiceMonitor {
 			},
 			Endpoints: []promv1.Endpoint{
 				promv1.Endpoint{
-					Port:   "http",
+					Port:   "10254",
 					Scheme: "http",
 				},
 			},


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/10905

In ordre for the nginx-ingress-controller target to work I had to apply the same relabeling logic than the one we have in g8s-prometheus: https://github.com/giantswarm/prometheus-config-controller/blob/0c80a5177c523a75068e9a2c44766bb548013c74/service/controller/v1/prometheus/scrapeconfig.go#L749-L752

This is because it is not possible to reach TC components from the CP. When prometheus finds the nginx-ingress-controller pods via the TC k8s api, it grabs the ip and trys to reach nginx pod using its ip which is not possible in our setup. In order to reach nginx we have to go via the TC api proxy.

Also note that nginx exposes metrics on port `10254`.

Successfully tested on godmsack
![image](https://user-images.githubusercontent.com/6536819/85602259-7df37400-b64f-11ea-9cfe-383a1c2bfe09.png)
![image](https://user-images.githubusercontent.com/6536819/85603146-5b158f80-b650-11ea-92d6-2f3c0fa9d622.png)
