### PR TITLE
Bump memory limit for Prometheus containers to 1G

### DIFF
--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -79,7 +79,7 @@ func toPrometheus(v interface{}) (metav1.Object, error) {
 					// cpu: 100m
 					corev1.ResourceCPU: *resource.NewMilliQuantity(100, resource.DecimalSI),
 					// memory: 100Mi
-					corev1.ResourceMemory: *resource.NewQuantity(200*1024*1024, resource.BinarySI),
+					corev1.ResourceMemory: *resource.NewQuantity(1*1024*1024*1024, resource.BinarySI),
 				},
 				Requests: corev1.ResourceList{
 					// cpu: 100m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12251.

Memory requirements for Prometheus container depend on a couple of
factors which contribute to the fact that 200M was too low for some
installations causing Prometheus to get OOM killed as it hit the limit
shortly after startup. This in turn caused crash looping, which in turn
increased storage requirements for the WAL files.