### PR TITLE
ci: do not wait for aliyun

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,9 +51,6 @@ workflows:
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
           chart: "prometheus-meta-operator"
-          requires:
-            - push-to-quay
-            - push-to-aliyun
           filters:
             tags:
               only: /^v.*/
@@ -66,6 +63,8 @@ workflows:
           app_collection_repo: "aws-app-collection"
           unique: "true"
           requires:
+            - push-to-quay
+            - push-to-aliyun
             - app-catalog
           filters:
             branches:
@@ -81,6 +80,8 @@ workflows:
           app_collection_repo: "azure-app-collection"
           unique: "true"
           requires:
+            - push-to-quay
+            - push-to-aliyun
             - app-catalog
           filters:
             branches:
@@ -96,6 +97,8 @@ workflows:
           app_collection_repo: "kvm-app-collection"
           unique: "true"
           requires:
+            - push-to-quay
+            - push-to-aliyun
             - app-catalog
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,8 @@ workflows:
             - build
             - test
           filters:
+            branches:
+              ignore: /.*/
             tags:
               only: /^v.*/
 


### PR DESCRIPTION
This makes us spend wait too much time waiting for CI, so let's run as many job as possible in parallel (quay, aliyun, app-catalog) and only wait/require the ones we need during releases. 