### PR TITLE
Rename controller names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename controller name and finalizers
+
 ## [1.0.0] - 2020-08-20
 
 ### Added

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
 
+	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
 )
 
@@ -45,7 +46,7 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		c := controller.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-			Name:      "clusterapi-controller",
+			Name:      project.Name() + "-cluster-api-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1alpha2.Cluster)
 			},

--- a/service/controller/legacy/controller.go
+++ b/service/controller/legacy/controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/operatorkit/v2/pkg/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
 )
 
@@ -73,7 +74,7 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		c := controller.Config{
 			K8sClient:            config.K8sClient,
 			Logger:               config.Logger,
-			Name:                 "legacy-controller",
+			Name:                 project.Name() + "-legacy-controller",
 			NewRuntimeObjectFunc: runtimeFunc,
 			Resources:            resources,
 		}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/12550

I followed the practice defined https://github.com/giantswarm/aws-operator/blob/02d8199912361284bffde9d6d034998baa6fe5ba/service/controller/control_plane.go#L115