### PR TITLE
Installation info

### DIFF
--- a/flag/service/etcd/etcd.go
+++ b/flag/service/etcd/etcd.go
@@ -2,7 +2,4 @@ package etcd
 
 type Etcd struct {
 	Host string
-	CA   string
-	Crt  string
-	Key  string
 }

--- a/flag/service/etcd/etcd.go
+++ b/flag/service/etcd/etcd.go
@@ -1,0 +1,8 @@
+package etcd
+
+type Etcd struct {
+	Host string
+	CA   string
+	Crt  string
+	Key  string
+}

--- a/flag/service/installation/installation.go
+++ b/flag/service/installation/installation.go
@@ -1,0 +1,5 @@
+package installation
+
+type Installation struct {
+	Name string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -3,13 +3,19 @@ package service
 import (
 	"github.com/giantswarm/operatorkit/v2/pkg/flag/service/kubernetes"
 
+	"github.com/giantswarm/prometheus-meta-operator/flag/service/etcd"
+	"github.com/giantswarm/prometheus-meta-operator/flag/service/installation"
 	"github.com/giantswarm/prometheus-meta-operator/flag/service/prometheus"
 	"github.com/giantswarm/prometheus-meta-operator/flag/service/provider"
+	"github.com/giantswarm/prometheus-meta-operator/flag/service/vault"
 )
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
-	Kubernetes kubernetes.Kubernetes
-	Prometheus prometheus.Prometheus
-	Provider   provider.Provider
+	Kubernetes   kubernetes.Kubernetes
+	Prometheus   prometheus.Prometheus
+	Provider     provider.Provider
+	Installation installation.Installation
+	Etcd         etcd.Etcd
+	Vault        vault.Vault
 }

--- a/flag/service/vault/vault.go
+++ b/flag/service/vault/vault.go
@@ -1,5 +1,5 @@
 package vault
 
 type Vault struct {
-	Address string
+	Host string
 }

--- a/flag/service/vault/vault.go
+++ b/flag/service/vault/vault.go
@@ -1,0 +1,6 @@
+package vault
+
+type Vault struct {
+	Host    string
+	Address string
+}

--- a/flag/service/vault/vault.go
+++ b/flag/service/vault/vault.go
@@ -1,6 +1,5 @@
 package vault
 
 type Vault struct {
-	Host    string
 	Address string
 }

--- a/helm/prometheus-meta-operator/ci/default-values.yaml
+++ b/helm/prometheus-meta-operator/ci/default-values.yaml
@@ -4,7 +4,6 @@ Installation:
     Auth:
       Vault:
         Address: ""
-        Host: ""
     Name: ""
     Monitoring:
       Prometheus:

--- a/helm/prometheus-meta-operator/ci/default-values.yaml
+++ b/helm/prometheus-meta-operator/ci/default-values.yaml
@@ -1,12 +1,22 @@
 ---
 Installation:
   V1:
+    Auth:
+      Vault:
+        Address: ""
+        Host: ""
+    Name: ""
     Monitoring:
       Prometheus:
         Host: ""
         Storage:
           Enabled: true
           CreatePVC: true
+        HostEtcd: ""
+        EtcdClientCertificates:
+          Ca: ""
+          Crt: ""
+          Key: ""
     Provider:
       Kind: ""
     Registry:

--- a/helm/prometheus-meta-operator/ci/default-values.yaml
+++ b/helm/prometheus-meta-operator/ci/default-values.yaml
@@ -12,6 +12,10 @@ Installation:
           Enabled: true
           CreatePVC: true
         HostEtcd: ""
+        EtcdClientCertificates:
+          Ca: ""
+          Crt: ""
+          Key: ""
     Provider:
       Kind: ""
     Registry:

--- a/helm/prometheus-meta-operator/ci/default-values.yaml
+++ b/helm/prometheus-meta-operator/ci/default-values.yaml
@@ -12,10 +12,6 @@ Installation:
           Enabled: true
           CreatePVC: true
         HostEtcd: ""
-        EtcdClientCertificates:
-          Ca: ""
-          Crt: ""
-          Key: ""
     Provider:
       Kind: ""
     Registry:

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -32,7 +32,6 @@ data:
         name: {{ .Values.Installation.V1.Name }}
       vault:
         address: {{ .Values.Installation.V1.Auth.Vault.Address }}
-        host: {{ .Values.Installation.V1.Auth.Vault.Host }}
       etcd:
         host:  {{ .Values.Installation.V1.Monitoring.Prometheus.HostEtcd }}
         ca:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Ca }}

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -28,3 +28,13 @@ data:
           size: 20Gi
       provider:
         kind: {{ .Values.Installation.V1.Provider.Kind }}
+      installation:
+        name: {{ .Values.Installation.V1.Name }}
+      vault:
+        address: {{ .Values.Installation.V1.Auth.Vault.Address }}
+        host: {{ .Values.Installation.V1.Auth.Vault.Host }}
+      etcd:
+        host:  {{ .Values.Installation.V1.Monitoring.Prometheus.HostEtcd }}
+        ca:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Ca }}
+        crt:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Crt }}
+        key:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Key }}

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -31,9 +31,6 @@ data:
       installation:
         name: {{ .Values.Installation.V1.Name }}
       vault:
-        address: {{ .Values.Installation.V1.Auth.Vault.Address }}
+        host: {{ .Values.Installation.V1.Auth.Vault.Host }}
       etcd:
         host:  {{ .Values.Installation.V1.Monitoring.Prometheus.HostEtcd }}
-        ca:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Ca }}
-        crt:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Crt }}
-        key:  {{ .Values.Installation.V1.Monitoring.Prometheus.EtcdClientCertificates.Key }}

--- a/main.go
+++ b/main.go
@@ -113,6 +113,13 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().Bool(f.Service.Prometheus.Storage.CreatePVC, false, "Should the operator create a PVC for storage.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Storage.Size, "20Gi", "Storage sze for prometheus.")
 	daemonCommand.PersistentFlags().String(f.Service.Provider.Kind, "", "Provider of the installation. One of aws, azure, kvm.")
+	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Name of the installation.")
+	daemonCommand.PersistentFlags().String(f.Service.Vault.Host, "", "Address used to connect to Vault.")
+	daemonCommand.PersistentFlags().String(f.Service.Vault.Address, "", "Host used to connect to Vault.")
+	daemonCommand.PersistentFlags().String(f.Service.Etcd.Host, "", "Host used to connect to Etcd.")
+	daemonCommand.PersistentFlags().String(f.Service.Etcd.CA, "", "Certificate authority file path to use to authenticate with Etcd.")
+	daemonCommand.PersistentFlags().String(f.Service.Etcd.Crt, "", "Certificate file path to use to authenticate with Etcd.")
+	daemonCommand.PersistentFlags().String(f.Service.Etcd.Key, "", "Key file path to use to authenticate with Etcd.")
 
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -114,11 +114,8 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Storage.Size, "20Gi", "Storage sze for prometheus.")
 	daemonCommand.PersistentFlags().String(f.Service.Provider.Kind, "", "Provider of the installation. One of aws, azure, kvm.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Name of the installation.")
-	daemonCommand.PersistentFlags().String(f.Service.Vault.Address, "", "Host used to connect to Vault.")
+	daemonCommand.PersistentFlags().String(f.Service.Vault.Host, "", "Host used to connect to Vault.")
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.Host, "", "Host used to connect to Etcd.")
-	daemonCommand.PersistentFlags().String(f.Service.Etcd.CA, "", "Certificate authority file path to use to authenticate with Etcd.")
-	daemonCommand.PersistentFlags().String(f.Service.Etcd.Crt, "", "Certificate file path to use to authenticate with Etcd.")
-	daemonCommand.PersistentFlags().String(f.Service.Etcd.Key, "", "Key file path to use to authenticate with Etcd.")
 
 	err = newCommand.CobraCommand().Execute()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -114,7 +114,6 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Storage.Size, "20Gi", "Storage sze for prometheus.")
 	daemonCommand.PersistentFlags().String(f.Service.Provider.Kind, "", "Provider of the installation. One of aws, azure, kvm.")
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Name, "", "Name of the installation.")
-	daemonCommand.PersistentFlags().String(f.Service.Vault.Host, "", "Address used to connect to Vault.")
 	daemonCommand.PersistentFlags().String(f.Service.Vault.Address, "", "Host used to connect to Vault.")
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.Host, "", "Host used to connect to Etcd.")
 	daemonCommand.PersistentFlags().String(f.Service.Etcd.CA, "", "Certificate authority file path to use to authenticate with Etcd.")


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/11723

Add installation info:
- installation name
- etcd host and certificates path
- vault address

Tested on `gauss`

```yaml
apiVersion: v1
data:
  config.yml: |
    server:
      enable:
        debug:
          server: true
      listen:
        address: 'http://0.0.0.0:8000'
    service:
      kubernetes:
        address: ''
        inCluster: true
        tls:
          caFile: ''
          crtFile: ''
          keyFile: ''
      prometheus:
        baseDomain: prometheus.g8s.gauss.eu-west-1.aws.gigantic.io
        storage:
          createPVC: true
          size: 20Gi
      provider:
        kind: aws
      installation:
        name: gauss
      vault:
        host: vault.gauss.eu-west-1.aws.gigantic.io
      etcd:
        host:  etcd.gauss.eu-west-1.aws.gigantic.io:2379
        ca:  /etc/kubernetes/ssl/etcd/client-ca.pem
        crt:  /etc/kubernetes/ssl/etcd/client-crt.pem
        key:  /etc/kubernetes/ssl/etcd/client-key.pem
kind: ConfigMap
metadata:
  annotations:
    meta.helm.sh/release-name: prometheus-meta-operator-unique
    meta.helm.sh/release-namespace: monitoring
  creationTimestamp: "2020-07-30T11:10:28Z"
  labels:
    app: prometheus-meta-operator
    app.giantswarm.io/branch: etcd
    app.giantswarm.io/commit: 59c27bf08b45ef55c5b23034814bd47659719852
    app.kubernetes.io/instance: prometheus-meta-operator-unique
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: prometheus-meta-operator
    app.kubernetes.io/version: 1.1.1-dev
    helm.sh/chart: prometheus-meta-operator-1.1.0-59c27bf08b45ef55c5b23034814bd476
  name: prometheus-meta-operator-unique
  namespace: monitoring
  resourceVersion: "12642400"
  selfLink: /api/v1/namespaces/monitoring/configmaps/prometheus-meta-operator-unique
  uid: 4af6d579-ade6-4183-8484-b1f3cb4524ec
```