### PR TITLE
unittest: remove print, add comments

### DIFF
--- a/pkg/unittest/error.go
+++ b/pkg/unittest/error.go
@@ -1,0 +1,14 @@
+package unittest
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var executionError = &microerror.Error{
+	Kind: "executionError",
+}
+
+// IsExecution asserts executionError.
+func IsExecution(err error) bool {
+	return microerror.Cause(err) == executionError
+}

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -2,7 +2,6 @@ package unittest
 
 import (
 	"bytes"
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -64,7 +63,10 @@ type Value struct {
 // NewRunner creates a new Runner given a Config.
 func NewRunner(config Config) (*Runner, error) {
 	_, filename, _, ok := runtime.Caller(0)
-	fmt.Println(path.Dir(filename), ok)
+	if !ok {
+		return nil, microerror.Mask(executionError)
+	}
+
 	inputDir, err := filepath.Abs(filepath.Join(path.Dir(filename), "input"))
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -26,6 +26,20 @@ type Config struct {
 	TestFunc  func(interface{}) (metav1.Object, error)
 }
 
+// Runner is used to run unit test for a specific resource.
+// It does so by running TestFunc with different input and compare the result
+// with expected outputs.
+//
+// TestFunc is a function which takes the observed kubernetes object as input
+// (e.g. AWSConfig) and returns another kubernetes object (e.g. Service).
+//
+// OututDir holds yaml files, representing the yaml version of the object
+// returned by TestFunc.
+// Files are mapped 1 to 1 from input to output directory.
+// e.g. when a file called `foo` is placed in the input directory, a
+// corresponding file named `foo` must be placed in the output directory.
+//
+// Input directory is harcoded as the input directory in this package.
 type Runner struct {
 	OutputDir string
 	T         *testing.T
@@ -37,12 +51,17 @@ type Runner struct {
 	err      error
 }
 
+// Value represent a test case.
+// Name is the name of the test case.
+// Input is the input kubernetes object.
+// Output is the expected output.
 type Value struct {
 	Name   string
 	Input  pkgruntime.Object
 	Output []byte
 }
 
+// NewRunner creates a new Runner given a Config.
 func NewRunner(config Config) (*Runner, error) {
 	_, filename, _, ok := runtime.Caller(0)
 	fmt.Println(path.Dir(filename), ok)
@@ -69,6 +88,7 @@ func NewRunner(config Config) (*Runner, error) {
 	return r, nil
 }
 
+// Run execute all the test using testing/T.Run function.
 func (r *Runner) Run() error {
 	for r.Next() {
 		value := r.Value()
@@ -95,6 +115,8 @@ func (r *Runner) Run() error {
 	return nil
 }
 
+// Next return true when there is more test cases to run.
+// There is 1 test case per input file.
 func (r *Runner) Next() bool {
 	if r.err != nil {
 		return false
@@ -104,6 +126,7 @@ func (r *Runner) Next() bool {
 	return len(r.files) > r.current
 }
 
+// Value returns the current test case values.
 func (r *Runner) Value() Value {
 	input, err := r.inputValue()
 	if err != nil {
@@ -126,13 +149,17 @@ func (r *Runner) Value() Value {
 	return v
 }
 
+// inputValue decode the input file as a kubernetes object and returns it.
 func (r *Runner) inputValue() (pkgruntime.Object, error) {
+	// Read the file.
 	inputFile := filepath.Join(r.inputDir, r.files[r.current].Name())
 	inputData, err := ioutil.ReadFile(inputFile)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
+	// Create a decoder capable of decoding kubernetes objects but also
+	// Giant Swarm objects.
 	scheme := pkgruntime.NewScheme()
 	err = v1alpha2.AddToScheme(scheme)
 	if err != nil {
@@ -144,6 +171,8 @@ func (r *Runner) inputValue() (pkgruntime.Object, error) {
 	}
 	codecs := serializer.NewCodecFactory(scheme)
 	deserializer := codecs.UniversalDeserializer()
+
+	// Do the acutal decoding.
 	input, err := pkgruntime.Decode(deserializer, inputData)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -152,6 +181,7 @@ func (r *Runner) inputValue() (pkgruntime.Object, error) {
 	return input, nil
 }
 
+// outputValue return the expected output by reading the output file.
 func (r *Runner) outputValue() ([]byte, error) {
 	outputFile := filepath.Join(r.OutputDir, r.files[r.current].Name())
 	output, err := ioutil.ReadFile(outputFile)

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -32,7 +32,7 @@ type Config struct {
 // TestFunc is a function which takes the observed kubernetes object as input
 // (e.g. AWSConfig) and returns another kubernetes object (e.g. Service).
 //
-// OututDir holds yaml files, representing the yaml version of the object
+// OutputDir holds yaml files, representing the yaml version of the object
 // returned by TestFunc.
 // Files are mapped 1 to 1 from input to output directory.
 // e.g. when a file called `foo` is placed in the input directory, a

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -50,7 +50,7 @@ type Runner struct {
 	err      error
 }
 
-// Value represent a test case.
+// Value represents a test case.
 // Name is the name of the test case.
 // Input is the input kubernetes object.
 // Output is the expected output.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12981

* Remove some debug printing
* Add comments to explain how uniitest.Runner works