### PR TITLE
improve unit test error handling

### DIFF
--- a/pkg/unittest/input/case-1-awsconfig.golden
+++ b/pkg/unittest/input/case-1-awsconfig.golden
@@ -1,0 +1,4 @@
+apiVersion: provider.giantswarm.io/v1alpha1
+kind: AWSConfig
+metadata:
+  name: alice

--- a/pkg/unittest/input/case-2-azureconfig.golden
+++ b/pkg/unittest/input/case-2-azureconfig.golden
@@ -1,0 +1,4 @@
+apiVersion: provider.giantswarm.io/v1alpha1
+kind: AzureConfig
+metadata:
+  name: foo

--- a/pkg/unittest/input/case-3-kvmconfig.golden
+++ b/pkg/unittest/input/case-3-kvmconfig.golden
@@ -1,0 +1,4 @@
+apiVersion: provider.giantswarm.io/v1alpha1
+kind: KVMConfig
+metadata:
+  name: bar

--- a/pkg/unittest/input/case-4-control-plane.golden
+++ b/pkg/unittest/input/case-4-control-plane.golden
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: kubernetes

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -93,7 +93,11 @@ func NewRunner(config Config) (*Runner, error) {
 // Run execute all the test using testing/T.Run function.
 func (r *Runner) Run() error {
 	for r.Next() {
-		value := r.Value()
+		value, err := r.Value()
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
 		r.T.Run(value.Name, func(t *testing.T) {
 			namespace, err := r.TestFunc(value.Input)
 			if err != nil {
@@ -129,26 +133,26 @@ func (r *Runner) Next() bool {
 }
 
 // Value returns the current test case values.
-func (r *Runner) Value() Value {
+func (r *Runner) Value() (*Value, error) {
 	input, err := r.inputValue()
 	if err != nil {
 		r.err = microerror.Mask(err)
-		return Value{}
+		return nil, microerror.Mask(err)
 	}
 
 	output, err := r.outputValue()
 	if err != nil {
 		r.err = microerror.Mask(err)
-		return Value{}
+		return nil, microerror.Mask(err)
 	}
 
-	v := Value{
+	v := &Value{
 		Name:   r.files[r.current].Name(),
 		Input:  input,
 		Output: output,
 	}
 
-	return v
+	return v, nil
 }
 
 // inputValue decode the input file as a kubernetes object and returns it.

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/cluster-api/api/v1alpha2"
+	"sigs.k8s.io/cluster-api/api/v1alpha3"
 )
 
 type Config struct {
@@ -173,6 +174,10 @@ func (r *Runner) inputValue() (pkgruntime.Object, error) {
 		return nil, microerror.Mask(err)
 	}
 	err = v1alpha2.AddToScheme(s)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	err = v1alpha3.AddToScheme(s)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/namespace/test/case-1-awsconfig.golden
+++ b/service/controller/resource/namespace/test/case-1-awsconfig.golden
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: alice-prometheus
+spec: {}
+status: {}

--- a/service/controller/resource/namespace/test/case-2-azureconfig.golden
+++ b/service/controller/resource/namespace/test/case-2-azureconfig.golden
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: foo-prometheus
+spec: {}
+status: {}

--- a/service/controller/resource/namespace/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/namespace/test/case-3-kvmconfig.golden
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: bar-prometheus
+spec: {}
+status: {}

--- a/service/controller/resource/namespace/test/case-4-control-plane.golden
+++ b/service/controller/resource/namespace/test/case-4-control-plane.golden
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  creationTimestamp: null
+  name: kubernetes-prometheus
+spec: {}
+status: {}

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -11,7 +11,7 @@ import (
 func ToCluster(obj interface{}) (metav1.Object, error) {
 	clusterMetaObject, ok := obj.(metav1.Object)
 	if !ok {
-		return nil, microerror.Maskf(wrongTypeError, "'%T' does not implements '%T'", obj, clusterMetaObject)
+		return nil, microerror.Maskf(wrongTypeError, "'%T' does not implements 'metav1.Object'", obj)
 	}
 
 	return clusterMetaObject, nil


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/12981

Fix an issue where test would fail with a misleading error when a file is missing.

```
$ go test -v ./service/controller/resource/namespace
=== RUN   TestNamespace
=== RUN   TestNamespace/case-0-cluster-api.golden
=== RUN   TestNamespace/#00
    unittest.go:100: TestFunc: wrong type error: '<nil>' does not implements '<nil>'
=== CONT  TestNamespace
    resource_test.go:28: open /home/theo/src/github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace/test/case-1-awsconfig.golden: no such file or directory
--- FAIL: TestNamespace (0.00s)
    --- PASS: TestNamespace/case-0-cluster-api.golden (0.00s)
    --- FAIL: TestNamespace/#00 (0.00s)
FAIL
FAIL    github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace    0.023s
FAIL
```