### PR TITLE
Add ingress resource

### DIFF
--- a/service/controller/resource/ingress/client.go
+++ b/service/controller/resource/ingress/client.go
@@ -1,0 +1,25 @@
+package ingress
+
+import (
+	"golang.org/x/net/context"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clientextv1beta1 "k8s.io/client-go/kubernetes/typed/extensions/v1beta1"
+)
+
+type wrappedClient struct {
+	client clientextv1beta1.IngressInterface
+}
+
+func (c wrappedClient) Create(ctx context.Context, object metav1.Object, options metav1.CreateOptions) (metav1.Object, error) {
+	return c.client.Create(ctx, object.(*v1beta1.Ingress), options)
+}
+func (c wrappedClient) Update(ctx context.Context, object metav1.Object, options metav1.UpdateOptions) (metav1.Object, error) {
+	return c.client.Update(ctx, object.(*v1beta1.Ingress), options)
+}
+func (c wrappedClient) Get(ctx context.Context, name string, options metav1.GetOptions) (metav1.Object, error) {
+	return c.client.Get(ctx, name, options)
+}
+func (c wrappedClient) Delete(ctx context.Context, name string, options *metav1.DeleteOptions) error {
+	return c.client.Delete(ctx, name, *options)
+}

--- a/service/controller/resource/ingress/error.go
+++ b/service/controller/resource/ingress/error.go
@@ -1,0 +1,23 @@
+package ingress
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/generic"
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
+	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -40,7 +41,10 @@ func New(config Config) (*generic.Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
 	}
 
-	clientFunc := func(namespace string) generic.Interface {}
+	clientFunc := func(namespace string) generic.Interface {
+		c := config.K8sClient.K8sClient().ExtensionsV1beta1().Ingresses(namespace)
+		return wrappedClient{client: c}
+	}
 
 	c := generic.Config{
 		ClientFunc:       clientFunc,
@@ -71,12 +75,12 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 }
 
 func toIngress(v interface{}) (metav1.Object, error) {
-	return TODO, nil
+	return &v1beta1.Ingress{}, nil
 }
 
 func hasChanged(current, desired metav1.Object) bool {
-	c := current.(*TODO)
-	d := desired.(*TODO)
+	c := current.(*v1beta1.Ingress)
+	d := desired.(*v1beta1.Ingress)
 
 	return !reflect.DeepEqual(c.Spec, d.Spec)
 }

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -1,0 +1,82 @@
+package ingress
+
+import (
+	"reflect"
+
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/generic"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	Name = "ingress"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+
+	BaseDomain string
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+
+	baseDomain string
+}
+
+func New(config Config) (*generic.Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.BaseDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.BaseDomain must not be empty", config)
+	}
+
+	clientFunc := func(namespace string) generic.Interface {}
+
+	c := generic.Config{
+		ClientFunc:       clientFunc,
+		Logger:           config.Logger,
+		Name:             Name,
+		GetObjectMeta:    getObjectMeta,
+		GetDesiredObject: toIngress,
+		HasChangedFunc:   hasChanged,
+	}
+	r, err := generic.New(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}
+
+func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return metav1.ObjectMeta{}, err
+	}
+
+	return metav1.ObjectMeta{
+		Name:      cluster.GetName(),
+		Namespace: key.Namespace(cluster),
+	}, nil
+}
+
+func toIngress(v interface{}) (metav1.Object, error) {
+	return TODO, nil
+}
+
+func hasChanged(current, desired metav1.Object) bool {
+	c := current.(*TODO)
+	d := desired.(*TODO)
+
+	return !reflect.DeepEqual(c.Spec, d.Spec)
+}

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -23,13 +23,6 @@ type Config struct {
 	BaseDomain string
 }
 
-type Resource struct {
-	k8sClient k8sclient.Interface
-	logger    micrologger.Logger
-
-	baseDomain string
-}
-
 func New(config Config) (*generic.Resource, error) {
 	if config.K8sClient == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -7,11 +7,12 @@ import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/generic"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/generic"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -1,6 +1,7 @@
 package ingress
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
@@ -10,6 +11,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 const (
@@ -40,12 +42,14 @@ func New(config Config) (*generic.Resource, error) {
 	}
 
 	c := generic.Config{
-		ClientFunc:       clientFunc,
-		Logger:           config.Logger,
-		Name:             Name,
-		GetObjectMeta:    getObjectMeta,
-		GetDesiredObject: toIngress,
-		HasChangedFunc:   hasChanged,
+		ClientFunc:    clientFunc,
+		Logger:        config.Logger,
+		Name:          Name,
+		GetObjectMeta: getObjectMeta,
+		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
+			return toIngress(v, config.BaseDomain)
+		},
+		HasChangedFunc: hasChanged,
 	}
 	r, err := generic.New(c)
 	if err != nil {
@@ -64,11 +68,61 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	return metav1.ObjectMeta{
 		Name:      cluster.GetName(),
 		Namespace: key.Namespace(cluster),
+		Labels: map[string]string{
+			"app": "prometheus",
+		},
+		Annotations: map[string]string{
+			"kubernetes.io/ingress.class":                        "nginx",
+			"kubernetes.io/tls-acme":                             "true",
+			"nginx.ingress.kubernetes.io/auth-signin":            "https://$host/oauth2/start?rd=$escaped_request_uri",
+			"nginx.ingress.kubernetes.io/auth-url":               "https://$host/oauth2/auth",
+			"nginx.ingress.kubernetes.io/whitelist-source-range": "185.102.95.187/32,95.179.153.65/32",
+		},
 	}, nil
 }
 
-func toIngress(v interface{}) (metav1.Object, error) {
-	return &v1beta1.Ingress{}, nil
+func toIngress(v interface{}, baseDomain string) (metav1.Object, error) {
+	objectMeta, err := getObjectMeta(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	path := fmt.Sprintf("/%s", cluster.GetName())
+
+	return &v1beta1.Ingress{
+		ObjectMeta: objectMeta,
+		Spec: v1beta1.IngressSpec{
+			TLS: []v1beta1.IngressTLS{
+				{
+					Hosts:      []string{baseDomain},
+					SecretName: "monitoring-prometheus", // TODO: is this new?
+				},
+			},
+			Rules: []v1beta1.IngressRule{
+				{
+					Host: baseDomain,
+					IngressRuleValue: v1beta1.IngressRuleValue{
+						HTTP: &v1beta1.HTTPIngressRuleValue{
+							Paths: []v1beta1.HTTPIngressPath{
+								{
+									Backend: v1beta1.IngressBackend{
+										ServiceName: "prometheus-operated",
+										ServicePort: intstr.FromInt(9090),
+									},
+									Path: path,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}, nil
 }
 
 func hasChanged(current, desired metav1.Object) bool {


### PR DESCRIPTION

This provides access to the Prometheus pods via a corresponding HTTP
path on ingress proxy so as to avoid the need to access it via port
forwarding.

Closes giantswarm/giantswarm#13366