### PR TITLE
more scrape config improvements

### DIFF
--- a/files/templates/_apiserver.yaml
+++ b/files/templates/_apiserver.yaml
@@ -1,0 +1,10 @@
+{{- define "_apiserver" -}}
+{{- if ne .ClusterType "control_plane" }}
+    api_server: https://{{ .APIServerURL }}
+    tls_config:
+      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
+      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
+      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
+      insecure_skip_verify: false
+{{- end -}}
+{{- end -}}

--- a/files/templates/_tlsconfig.yaml
+++ b/files/templates/_tlsconfig.yaml
@@ -1,0 +1,14 @@
+{{- define "_tlsconfig" -}}
+{{- if ne .ClusterType "control_plane" -}}
+tls_config:
+  ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
+  cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
+  key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
+  insecure_skip_verify: false
+{{- else -}}
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+{{- end -}}
+{{- end -}}

--- a/files/templates/_tlsconfig_skip.yaml
+++ b/files/templates/_tlsconfig_skip.yaml
@@ -1,0 +1,14 @@
+{{- define "_tlsconfig_skip" -}}
+{{- if ne .ClusterType "control_plane" -}}
+tls_config:
+  ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
+  cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
+  key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
+  insecure_skip_verify: true
+{{- else -}}
+bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+tls_config:
+  ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+  insecure_skip_verify: true
+{{- end -}}
+{{- end -}}

--- a/files/templates/additional-scrape-configs.template.yaml
+++ b/files/templates/additional-scrape-configs.template.yaml
@@ -12,17 +12,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: false
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig" . | indent 2 }}
+
   relabel_configs:
   - target_label: __address__
     replacement: {{ .APIServerURL }}:443

--- a/files/templates/additional-scrape-configs.template.yaml
+++ b/files/templates/additional-scrape-configs.template.yaml
@@ -5,14 +5,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: node
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig" . | indent 2 }}
 
   relabel_configs:
@@ -44,14 +37,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: node
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig" . | indent 2 }}
 
   relabel_configs:
@@ -83,14 +69,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: pod
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig" . | indent 2 }}
 
   relabel_configs:
@@ -120,14 +99,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: pod
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig" . | indent 2 }}
 
   relabel_configs:
@@ -199,14 +171,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: node
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -224,14 +189,7 @@
     namespaces:
       names:
       - kube-system
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -265,14 +223,7 @@
     namespaces:
       names:
       - kube-system
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -306,14 +257,7 @@
     namespaces:
       names:
       - kube-system
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -345,14 +289,7 @@
     namespaces:
       names:
       - kube-system
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -383,14 +320,7 @@
     namespaces:
       names:
       - giantswarm
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -431,14 +361,7 @@
 {{ else }}
       - kube-system
 {{ end }}
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -477,14 +400,7 @@
 {{ else }}
       - kube-system
 {{ end }}
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -523,14 +439,7 @@
 {{ else }}
       - kube-system
 {{ end }}
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -572,14 +481,7 @@
 {{ else }}
       - kube-system
 {{ end }}
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:
@@ -610,14 +512,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: endpoints
-{{ if ne .ClusterType "control_plane" }}
-    api_server: https://{{ .APIServerURL }}
-    tls_config:
-      ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-      cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-      key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-      insecure_skip_verify: false
-{{- end }}
+{{ include "_apiserver" . }}
 {{ include "_tlsconfig_skip" . | indent 2 }}
 
   relabel_configs:

--- a/files/templates/additional-scrape-configs.template.yaml
+++ b/files/templates/additional-scrape-configs.template.yaml
@@ -51,17 +51,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: false
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -98,17 +90,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: false
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     replacement: ${1}:9091
@@ -143,17 +127,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: false
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig" . | indent 2 }}
+
   relabel_configs:
   - target_label: __address__
     replacement: {{ .APIServerURL }}:443
@@ -230,17 +206,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - target_label: app
     replacement: kubelet
@@ -263,17 +231,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     replacement: $1:10252
@@ -312,17 +272,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     replacement: $1:10251
@@ -361,17 +313,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     replacement: $1:10249
@@ -408,17 +352,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -454,17 +390,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -510,17 +438,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -564,17 +484,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -618,17 +530,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__meta_kubernetes_service_label_app]
     regex: node-exporter
@@ -675,17 +579,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
@@ -721,17 +617,9 @@
       cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
       key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
       insecure_skip_verify: false
-  tls_config:
-    ca_file: /etc/prometheus/secrets/{{ .SecretName }}/ca
-    cert_file: /etc/prometheus/secrets/{{ .SecretName }}/crt
-    key_file: /etc/prometheus/secrets/{{ .SecretName }}/key
-    insecure_skip_verify: true
-{{ else }}
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-{{ end }}
+{{- end }}
+{{ include "_tlsconfig_skip" . | indent 2 }}
+
   relabel_configs:
   - source_labels: [__meta_kubernetes_pod_ip, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
     regex: (.*);(.*)


### PR DESCRIPTION
Towards: giantswarm/giantswarm#13443

* move target tlsconfig to separate template
* move api server config to separate template

Removed another 270 lines from additional-scrape-config.