### PR TITLE
fix promxy config marshaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix promxy config marshaling
+- Fix promxy config not being updated
+
 ## [1.5.0] - 2020-10-07
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/spf13/viper v1.6.2
 	golang.org/x/crypto v0.0.0-20200930160638-afb6bcd081ae // indirect
 	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	gopkg.in/yaml.v2 v2.3.0
 	k8s.io/api v0.18.8
 	k8s.io/apiextensions-apiserver v0.18.5
 	k8s.io/apimachinery v0.18.8

--- a/service/controller/resource/promxy/create.go
+++ b/service/controller/resource/promxy/create.go
@@ -31,7 +31,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	if !config.Promxy.contains(serverGroup) {
+	if !config.Promxy.contains(serverGroup) || config.Promxy.needsUpdate(serverGroup) {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "promxy configmap needs to be updated")
 		r.logger.LogCtx(ctx, "level", "debug", "message", "adding server group")
 		config.Promxy.add(serverGroup)

--- a/service/controller/resource/promxy/resource.go
+++ b/service/controller/resource/promxy/resource.go
@@ -6,7 +6,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/ghodss/yaml"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -14,6 +13,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/discovery/kubernetes"
 	"github.com/prometheus/prometheus/pkg/relabel"
+	"gopkg.in/yaml.v2"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/service/controller/resource/promxy/types.go
+++ b/service/controller/resource/promxy/types.go
@@ -2,6 +2,7 @@ package promxy
 
 import (
 	"fmt"
+	"reflect"
 	"time"
 
 	config_util "github.com/prometheus/common/config"
@@ -34,6 +35,15 @@ func (p *PromxyConfig) contains(group *ServerGroup) bool {
 	for _, val := range p.ServerGroups {
 		if val.PathPrefix == group.PathPrefix {
 			return true
+		}
+	}
+	return false
+}
+
+func (p *PromxyConfig) needsUpdate(group *ServerGroup) bool {
+	for _, val := range p.ServerGroups {
+		if val.PathPrefix == group.PathPrefix {
+			return !reflect.DeepEqual(val, group)
 		}
 	}
 	return false


### PR DESCRIPTION
tested on ginger

```yaml
global:
  scrape_interval: 1m
  scrape_timeout: 10s
  evaluation_interval: 5s
  external_labels:
    source: promxy
remote_write:
- url: http://localhost:8083/receive
  remote_timeout: 30s
  queue_config:
    capacity: 500
    max_shards: 1000
    min_shards: 1
    max_samples_per_send: 100
    batch_send_deadline: 5s
    min_backoff: 30ms
    max_backoff: 100ms
promxy:
  server_groups:
  - remote_read: true
    remote_read_path: api/v1/read
    http_client:
      dial_timeout: 200ms
    scheme: http
    labels:
      cluster_id: ginger
      installation: ginger
      provider: aws
    relabel_configs:
    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_managed_by, __meta_kubernetes_pod_label_app_kubernetes_io_name, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
      separator: ;
      regex: prometheus-meta-operator;prometheus;ginger
      replacement: $1
      action: keep
    kubernetes_sd_configs:
    - api_server: https://172.31.0.1:443
      role: pod
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      tls_config:
        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecure_skip_verify: true
      namespaces:
        names:
        - ginger-prometheus
    path_prefix: /ginger
  - remote_read: true
    remote_read_path: api/v1/read
    http_client:
      dial_timeout: 200ms
    scheme: http
    labels:
      cluster_id: ginger
      installation: ginger
      provider: aws
    relabel_configs:
    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_managed_by, __meta_kubernetes_pod_label_app_kubernetes_io_name, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
      separator: ;
      regex: prometheus-meta-operator;prometheus;ginger
      replacement: $1
      action: keep
    kubernetes_sd_configs:
    - api_server: https://172.31.0.1:443
      role: pod
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      tls_config:
        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecure_skip_verify: true
      namespaces:
        names:
        - ginger-prometheus
    path_prefix: /ginger
  - remote_read: true
    remote_read_path: api/v1/read
    http_client:
      dial_timeout: 200ms
    scheme: http
    labels:
      cluster_id: p0t7g
      installation: ginger
      provider: aws
    relabel_configs:
    - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_managed_by, __meta_kubernetes_pod_label_app_kubernetes_io_name, __meta_kubernetes_pod_label_app_kubernetes_io_instance]
      separator: ;
      regex: prometheus-meta-operator;prometheus;p0t7g
      action: keep
    kubernetes_sd_configs:
    - api_server: https://172.31.0.1:443
      role: pod
      bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
      tls_config:
        ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
        insecure_skip_verify: true
      namespaces:
        names:
        - p0t7g-prometheus
    path_prefix: /p0t7g
```