### PR TITLE
clean up promxy configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add alertmanager config
 
+### Fixed
+
+- Fix a bug where promxy configmap keep growing and lead to OutOfMemory issues.
+
 ## [1.6.0] - 2020-10-12
 
 ### Changed

--- a/service/controller/resource/promxy/types.go
+++ b/service/controller/resource/promxy/types.go
@@ -54,13 +54,15 @@ func (p *PromxyConfig) add(group *ServerGroup) {
 }
 
 func (p *PromxyConfig) remove(group *ServerGroup) {
-	var index int
-	for key, val := range p.ServerGroups {
-		if val.PathPrefix == group.PathPrefix {
-			index = key
+	var s []*ServerGroup
+
+	for _, val := range p.ServerGroups {
+		if val.PathPrefix != group.PathPrefix {
+			s = append(s, val)
 		}
 	}
-	p.ServerGroups = append(p.ServerGroups[:index], p.ServerGroups[index+1:]...)
+
+	p.ServerGroups = s
 }
 
 // ServerGroup is the configuration for a ServerGroup that promxy will talk to.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13486

This will actually clean up the promxy configmap so we don't have to do it manually.