### PR TITLE
re-order resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add alertmanager config
 
+### Fixed
+
+- Fix a bug where promxy configmap keep growing and lead to OutOfMemory issues.
+- Fix an issue where prometheus fails to be created due to resource order.
+
 ## [1.6.0] - 2020-10-12
 
 ### Changed

--- a/service/controller/control-plane/resource.go
+++ b/service/controller/control-plane/resource.go
@@ -224,11 +224,11 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		etcdCertificatesResource,
 		rbacResource,
 		alertmanagerConfig,
-		prometheusResource,
-		volumeResizeHack,
 		serviceMonitorResource,
 		alertResource,
 		scrapeConfigResource,
+		prometheusResource,
+		volumeResizeHack,
 		ingressResource,
 		promxyResource,
 	}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -211,11 +211,11 @@ func New(config Config) ([]resource.Interface, error) {
 		apiCertificatesResource,
 		tlsCertificatesResource,
 		alertmanagerConfig,
-		prometheusResource,
-		volumeResizeHack,
 		serviceMonitorResource,
 		alertResource,
 		scrapeConfigResource,
+		prometheusResource,
+		volumeResizeHack,
 		ingressResource,
 		promxyResource,
 	}


### PR DESCRIPTION
This PR fixes an issue with the order of resources.

volumeresize fails because it does not find the statefulset, prometheus-operator fails to create statefulset because additional scrape configs is not present.

prometheus-meta-operator logs
```
D 10/14 09:30:12 /apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/ykc2i volumeresizehack checking if pvc need to be re-created | prometheus-meta-operator/service/controller/resource/volumeresizehack/create.go:23 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=14 | version=38155263
E 10/14 09:30:12 /apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/ykc2i failed to reconcile | operatorkit/v2/pkg/controller/controller.go:305 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=14 | version=38155263
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/controller/controller.go:485
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/controller/controller.go:509
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/controller/controller.go:591
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/resource/wrapper/metricsresource/basic_resource.go:43
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/resource/wrapper/retryresource/basic_resource.go:64
        /go/pkg/mod/github.com/giantswarm/backoff@v0.2.0/retry.go:23
        /go/pkg/mod/github.com/giantswarm/operatorkit/v2@v2.0.0/pkg/resource/wrapper/retryresource/basic_resource.go:52
        /root/project/service/controller/resource/volumeresizehack/create.go:31
        unknown: statefulsets.apps "prometheus-ykc2i" not found
```

prometheus-operator logs
```
level=info ts=2020-10-14T09:28:00.442915486Z caller=operator.go:1094 component=prometheusoperator msg="sync prometheus" key=ykc2i-prometheus/ykc2i
E1014 09:28:00.449337       1 operator.go:994] Sync "ykc2i-prometheus/ykc2i" failed: creating config failed: loading additional scrape configs from Secret failed: secret additional-scrape-configs could not be found
```