### PR TITLE
fix panic: redefined service.prometheus.basedomain

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,6 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.CrtFile, "", "Certificate file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Kubernetes.TLS.KeyFile, "", "Key file path to use to authenticate with Kubernetes.")
 	daemonCommand.PersistentFlags().String(f.Service.Opsgenie.Key, "", "Opsgenie Key used for API authentication.")
-	daemonCommand.PersistentFlags().String(f.Service.Prometheus.BaseDomain, "", "Base domain to create Prometheus Ingress resources under.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Address, "", "Address to access Prometheus UI.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.BaseDomain, "", "Base domain to create Prometheus Ingress resources under.")
 	daemonCommand.PersistentFlags().StringSlice(f.Service.Prometheus.Bastions, make([]string, 0), "Address of the control plane bastions.")


### PR DESCRIPTION
Fix panic error (probably due to bad merge)

This PR fixes the following startup error
```
panic: daemon flag redefined: service.prometheus.basedomain

goroutine 1 [running]:
github.com/spf13/pflag.(*FlagSet).AddFlag(0xc00020f500, 0xc000656500)
        /go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:848 +0x807
github.com/spf13/pflag.(*FlagSet).VarPF(0xc00020f500, 0x1d246a0, 0xc00058f7c0, 0xc000227160, 0x1d, 0x0, 0x0, 0x1aab43e, 0x39, 0xc00058f7c0)
        /go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:831 +0x10b
github.com/spf13/pflag.(*FlagSet).VarP(...)
        /go/pkg/mod/github.com/spf13/pflag@v1.0.5/flag.go:837
github.com/spf13/pflag.(*FlagSet).StringVarP(0xc00020f500, 0xc00058f7c0, 0xc000227160, 0x1d, 0x0, 0x0, 0x0, 0x0, 0x1aab43e, 0x39)
        /go/pkg/mod/github.com/spf13/pflag@v1.0.5/string.go:42 +0xad
github.com/spf13/pflag.(*FlagSet).String(...)
        /go/pkg/mod/github.com/spf13/pflag@v1.0.5/string.go:60
main.mainE(0x1d36760, 0xc0000b0000, 0x0, 0xc00009c058)
        /root/project/main.go:115 +0xaf1
main.main()
        /root/project/main.go:24 +0x3d
```