### PR TITLE
add heartbeatrouting/receiver sub resource

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.1
+	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/common v0.13.0
 	github.com/prometheus/prometheus v2.21.0+incompatible
 	github.com/spf13/viper v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1016,6 +1016,7 @@ github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prY
 github.com/prometheus-community/prom-label-proxy v0.1.1-0.20200616110844-0fbfa11fa8f3/go.mod h1:XdjyZg7LCbCC5FADHtpgNp6kQ0W9beXVGfmcvndMj5Y=
 github.com/prometheus/alertmanager v0.18.0/go.mod h1:WcxHBl40VSPuOaqWae6l6HpnEOVRIycEJ7i9iYkadEE=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
+github.com/prometheus/alertmanager v0.21.0 h1:qK51JcUR9l/unhawGA9F9B64OCYfcGewhPNprem/Acc=
 github.com/prometheus/alertmanager v0.21.0/go.mod h1:h7tJ81NA0VLWvWEayi1QltevFkLF3KxmC/malTcT8Go=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -1,0 +1,94 @@
+package receiver
+
+import (
+	"fmt"
+	"net/url"
+	"reflect"
+
+	"github.com/prometheus/alertmanager/config"
+	commoncfg "github.com/prometheus/common/config"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) (config.Receiver, error) {
+	u, err := url.Parse(fmt.Sprintf("https://api.opsgenie.com/v2/heartbeats/%s/ping", key.HeartbeatName(cluster, installation)))
+	if err != nil {
+		return config.Receiver{}, microerror.Mask(err)
+	}
+
+	r := config.Receiver{
+		Name: key.HeartbeatReceiverName(cluster, installation),
+		WebhookConfigs: []*config.WebhookConfig{
+			&config.WebhookConfig{
+				URL: &config.URL{
+					URL: u,
+				},
+				HTTPConfig: &commoncfg.HTTPClientConfig{
+					BasicAuth: &commoncfg.BasicAuth{
+						Password: commoncfg.Secret(opsgenieKey),
+					},
+				},
+				NotifierConfig: config.NotifierConfig{
+					VSendResolved: false,
+				},
+			},
+		},
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensure receiver exist in cfg.Receivers and is up to date. Returns true when changes have been made to cfg.
+// Return untouched cfg and false when no changes are made.
+func EnsureCreated(cfg config.Config, cluster metav1.Object, installation, opsgenieKey string) (config.Config, bool, error) {
+	desired, err := toReceiver(cluster, installation, opsgenieKey)
+	if err != nil {
+		return cfg, false, microerror.Mask(err)
+	}
+
+	current, _ := getReceiver(cfg, desired)
+
+	if current != nil {
+		if !reflect.DeepEqual(*current, desired) {
+			*current = desired
+			return cfg, true, nil
+		}
+	} else {
+		cfg.Receivers = append(cfg.Receivers, &desired)
+		return cfg, true, nil
+	}
+
+	return cfg, false, nil
+}
+
+// EnsureDeleted ensure receiver is removed from cfg.Receivers. Returns true when changes have been made to cfg.
+// Return untouched cfg and false when no changes are made.
+func EnsureDeleted(cfg config.Config, cluster metav1.Object, installation, opsgenieKey string) (config.Config, bool, error) {
+	desired, err := toReceiver(cluster, installation, opsgenieKey)
+	if err != nil {
+		return cfg, false, microerror.Mask(err)
+	}
+
+	current, index := getReceiver(cfg, desired)
+
+	if current != nil {
+		cfg.Receivers = append(cfg.Receivers[:index], cfg.Receivers[index+1:]...)
+		return cfg, true, nil
+	}
+
+	return cfg, false, nil
+}
+
+func getReceiver(cfg config.Config, receiver config.Receiver) (*config.Receiver, int) {
+	for index, r := range cfg.Receivers {
+		if r.Name == receiver.Name {
+			return r, index
+		}
+	}
+
+	return nil, -1
+}

--- a/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
@@ -1,0 +1,261 @@
+package receiver
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/prometheus/alertmanager/config"
+	commoncfg "github.com/prometheus/common/config"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	cluster = &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "cluster-namespace",
+		},
+	}
+
+	installation = "installation"
+	opsgenieKey  = "secret-key"
+	u, _         = url.Parse("https://api.opsgenie.com/v2/heartbeats/installation-cluster/ping")
+)
+
+func TestEnsureReceiver(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cfg            config.Config
+		expectedUpdate bool
+		len            int
+		index          int
+	}{
+		{
+			name: "no update",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+						WebhookConfigs: []*config.WebhookConfig{
+							&config.WebhookConfig{
+								URL: &config.URL{
+									URL: u,
+								},
+								HTTPConfig: &commoncfg.HTTPClientConfig{
+									BasicAuth: &commoncfg.BasicAuth{
+										Password: "secret-key",
+									},
+								},
+								NotifierConfig: config.NotifierConfig{
+									VSendResolved: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdate: false,
+			len:            1,
+			index:          0,
+		},
+		{
+			name: "update",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+						WebhookConfigs: []*config.WebhookConfig{
+							&config.WebhookConfig{
+								URL: &config.URL{
+									URL: u,
+								},
+								HTTPConfig: &commoncfg.HTTPClientConfig{
+									BasicAuth: &commoncfg.BasicAuth{
+										Password: "wrong",
+									},
+								},
+								NotifierConfig: config.NotifierConfig{
+									VSendResolved: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            1,
+			index:          0,
+		},
+		{
+			name: "add",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "not me",
+						WebhookConfigs: []*config.WebhookConfig{
+							&config.WebhookConfig{
+								URL: &config.URL{
+									URL: u,
+								},
+								HTTPConfig: &commoncfg.HTTPClientConfig{
+									BasicAuth: &commoncfg.BasicAuth{
+										Password: "something",
+									},
+								},
+								NotifierConfig: config.NotifierConfig{
+									VSendResolved: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+			index:          1,
+		},
+		{
+			name: "add from 0",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{},
+			},
+			expectedUpdate: true,
+			len:            1,
+			index:          0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, updated, err := EnsureCreated(tc.cfg, cluster, installation, opsgenieKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if updated != tc.expectedUpdate {
+				t.Fatalf("updated %t, expected %t\n", updated, tc.expectedUpdate)
+			}
+
+			if len(c.Receivers) != tc.len {
+				t.Fatalf("len(c.Receivers) %d, expected %d\n", len(c.Receivers), tc.len)
+			}
+		})
+	}
+}
+
+func TestRemoveReceiver(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cfg            config.Config
+		expectedUpdate bool
+		len            int
+	}{
+		{
+			name: "no update",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "one",
+					},
+					&config.Receiver{
+						Name: "two",
+					},
+				},
+			},
+			expectedUpdate: false,
+			len:            2,
+		},
+		{
+			name: "no update (empty)",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{},
+			},
+			expectedUpdate: false,
+			len:            0,
+		},
+		{
+			name: "remove first",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+					},
+					&config.Receiver{
+						Name: "one",
+					},
+					&config.Receiver{
+						Name: "two",
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove middle",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "one",
+					},
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+					},
+					&config.Receiver{
+						Name: "two",
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove last",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "one",
+					},
+					&config.Receiver{
+						Name: "two",
+					},
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove (empty)",
+			cfg: config.Config{
+				Receivers: []*config.Receiver{
+					&config.Receiver{
+						Name: "heartbeat_installation_cluster",
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, updated, err := EnsureDeleted(tc.cfg, cluster, installation, opsgenieKey)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if updated != tc.expectedUpdate {
+				t.Fatalf("updated %t, expected %t\n", updated, tc.expectedUpdate)
+			}
+
+			if len(c.Receivers) != tc.len {
+				t.Fatalf("len(c.Receivers) %d, expected %d\n", len(c.Receivers), tc.len)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13302
Needs: https://github.com/giantswarm/prometheus-meta-operator/pull/177

This PR add the `heartbeatrouting/receiver` resource in charge of managing the alertmanager receiver for hearteat. Which basically boils down to configuring a new opsgenie heartbeat endpoint in alertmanager.
