### PR TITLE
add heartbeatrouting/route sub resource

### DIFF
--- a/service/controller/resource/heartbeatrouting/route/error.go
+++ b/service/controller/resource/heartbeatrouting/route/error.go
@@ -1,0 +1,14 @@
+package route
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var emptyRouteError = &microerror.Error{
+	Kind: "emptyRouteError",
+}
+
+// IsEmptyRouteError asserts emptyRouteError.
+func IsEmptyRouteError(err error) bool {
+	return microerror.Cause(err) == emptyRouteError
+}

--- a/service/controller/resource/heartbeatrouting/route/route.go
+++ b/service/controller/resource/heartbeatrouting/route/route.go
@@ -1,0 +1,96 @@
+package route
+
+import (
+	"reflect"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/common/model"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+func toRoute(cluster metav1.Object, installation string) (config.Route, error) {
+	one, err := model.ParseDuration("1s")
+	if err != nil {
+		return config.Route{}, microerror.Mask(err)
+	}
+
+	fifteen, err := model.ParseDuration("15s")
+	if err != nil {
+		return config.Route{}, microerror.Mask(err)
+	}
+
+	r := config.Route{
+		Receiver: key.HeartbeatReceiverName(cluster, installation),
+		Match: map[string]string{
+			key.ClusterIDKey():    key.ClusterID(cluster),
+			key.InstallationKey(): installation,
+			key.TypeKey():         key.Heartbeat(),
+		},
+		Continue:       false,
+		GroupInterval:  &one,
+		GroupWait:      &one,
+		RepeatInterval: &fifteen,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensure route exist in cfg.Route and is up to date. Returns true when changes have been made to cfg.
+// Return untouched cfg and false when no changes are made.
+func EnsureCreated(cfg config.Config, cluster metav1.Object, installation string) (config.Config, bool, error) {
+	desired, err := toRoute(cluster, installation)
+	if err != nil {
+		return cfg, false, microerror.Mask(err)
+	}
+
+	current, _ := getRoute(&cfg, desired)
+
+	if current != nil {
+		if !reflect.DeepEqual(*current, desired) {
+			*current = desired
+			return cfg, true, nil
+		}
+	} else {
+		if cfg.Route == nil {
+			return cfg, false, microerror.Mask(emptyRouteError)
+		}
+		cfg.Route.Routes = append(cfg.Route.Routes, &desired)
+		return cfg, true, nil
+	}
+
+	return cfg, false, nil
+}
+
+// EnsureDeleted ensure route is removed from cfg.Receivers. Returns true when changes have been made to cfg.
+// Return untouched cfg and false when no changes are made.
+func EnsureDeleted(cfg config.Config, cluster metav1.Object, installation string) (config.Config, bool, error) {
+	desired, err := toRoute(cluster, installation)
+	if err != nil {
+		return cfg, false, microerror.Mask(err)
+	}
+
+	current, index := getRoute(&cfg, desired)
+
+	if current != nil {
+		cfg.Route.Routes = append(cfg.Route.Routes[:index], cfg.Route.Routes[index+1:]...)
+		return cfg, true, nil
+	}
+
+	return cfg, false, nil
+}
+
+func getRoute(cfg *config.Config, route config.Route) (*config.Route, int) {
+	if cfg.Route != nil {
+		for index, r := range cfg.Route.Routes {
+			if r.Receiver == route.Receiver {
+				return r, index
+			}
+		}
+	}
+
+	return nil, -1
+}

--- a/service/controller/resource/heartbeatrouting/route/route_test.go
+++ b/service/controller/resource/heartbeatrouting/route/route_test.go
@@ -1,0 +1,295 @@
+package route
+
+import (
+	"testing"
+
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/common/model"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	cluster = &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "cluster-namespace",
+		},
+	}
+
+	installation = "installation"
+)
+
+func TestEnsureCreated(t *testing.T) {
+	var one, _ = model.ParseDuration("1s")
+	var fifteen, _ = model.ParseDuration("15s")
+
+	testCases := []struct {
+		name           string
+		cfg            config.Config
+		expectedUpdate bool
+		errorMatcher   func(error) bool
+		len            int
+	}{
+		{
+			name: "no update",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+							Match: map[string]string{
+								"cluster_id":   "cluster",
+								"installation": "installation",
+								"type":         "heartbeat",
+							},
+							Continue:       false,
+							GroupInterval:  &one,
+							GroupWait:      &one,
+							RepeatInterval: &fifteen,
+						},
+					},
+				},
+			},
+			expectedUpdate: false,
+			len:            1,
+		},
+		{
+			name: "update",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+							Match: map[string]string{
+								"cluster_id":   "cluster",
+								"installation": "installation",
+								"type":         "wrong",
+							},
+							Continue:       false,
+							GroupInterval:  &one,
+							GroupWait:      &one,
+							RepeatInterval: &fifteen,
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            1,
+		},
+		{
+			name: "add",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "not me",
+							Match: map[string]string{
+								"cluster":      "cluster",
+								"installation": "installation",
+								"type":         "heartbeat",
+							},
+							Continue:       false,
+							GroupInterval:  &one,
+							GroupWait:      &one,
+							RepeatInterval: &fifteen,
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "add from 0",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes:   []*config.Route{},
+				},
+			},
+			expectedUpdate: true,
+			len:            1,
+		},
+		{
+			name: "empty route",
+			cfg: config.Config{
+				Route: nil,
+			},
+			errorMatcher: IsEmptyRouteError,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, updated, err := EnsureCreated(tc.cfg, cluster, installation)
+			switch {
+			case err == nil && tc.errorMatcher == nil:
+				// correct; carry on
+			case err != nil && tc.errorMatcher == nil:
+				t.Fatalf("error == %#v, want nil", err)
+			case err == nil && tc.errorMatcher != nil:
+				t.Fatalf("error == nil, want non-nil")
+			case !tc.errorMatcher(err):
+				t.Fatalf("error == %#v, want matching", err)
+				return
+			}
+
+			if err == nil {
+				if updated != tc.expectedUpdate {
+					t.Fatalf("updated %t, expected %t\n", updated, tc.expectedUpdate)
+				}
+
+				if len(c.Route.Routes) != tc.len {
+					t.Fatalf("len(c.Route.Routes) %d, expected %d\n", len(c.Route.Routes), tc.len)
+				}
+			}
+		})
+	}
+}
+
+func TestEnsureDeleted(t *testing.T) {
+	testCases := []struct {
+		name           string
+		cfg            config.Config
+		expectedUpdate bool
+		errorMatcher   func(error) bool
+		len            int
+	}{
+		{
+			name: "no update",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "one",
+						},
+						&config.Route{
+							Receiver: "two",
+						},
+					},
+				},
+			},
+			expectedUpdate: false,
+			len:            2,
+		},
+		{
+			name: "no update (empty)",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes:   []*config.Route{},
+				},
+			},
+			expectedUpdate: false,
+			len:            0,
+		},
+		{
+			name: "remove first",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+						},
+						&config.Route{
+							Receiver: "one",
+						},
+						&config.Route{
+							Receiver: "two",
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove middle",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "one",
+						},
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+						},
+						&config.Route{
+							Receiver: "two",
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove last",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "one",
+						},
+						&config.Route{
+							Receiver: "two",
+						},
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            2,
+		},
+		{
+			name: "remove (empty)",
+			cfg: config.Config{
+				Route: &config.Route{
+					Receiver: "root",
+					Routes: []*config.Route{
+						&config.Route{
+							Receiver: "heartbeat_installation_cluster",
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            0,
+		},
+		{
+			name: "empty route",
+			cfg: config.Config{
+				Route: nil,
+			},
+			expectedUpdate: false,
+			len:            0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			c, updated, err := EnsureDeleted(tc.cfg, cluster, installation)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if updated != tc.expectedUpdate {
+				t.Fatalf("updated %t, expected %t\n", updated, tc.expectedUpdate)
+			}
+
+			if c.Route != nil && len(c.Route.Routes) != tc.len {
+				t.Fatalf("len(c.Route.Routes) %d, expected %d\n", len(c.Route.Routes), tc.len)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13302
Needs: https://github.com/giantswarm/prometheus-meta-operator/pull/177

This PR add the `heartbeatrouting/route` resource in charge of managin the alertmanager route for hearteat. Which basically map a heartbeat alert to its receiver/opsgenie endpoint.
