### PR TITLE
add heartbeatrouting resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add monitoring of control plane bastions
 - Add heartbeat alert to prometheus
 - Create heartbeat in opsgenie
+- Route heartbeat alerts to corresponding opsgenie heartbeat
 
 ## [1.7.0] - 2020-10-14
 

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f
 	github.com/opsgenie/opsgenie-go-sdk-v2 v1.2.1
 	github.com/pkg/errors v0.9.1
-	github.com/prometheus/alertmanager v0.21.0
 	github.com/prometheus/common v0.13.0
 	github.com/prometheus/prometheus v2.21.0+incompatible
 	github.com/spf13/viper v1.6.2

--- a/go.sum
+++ b/go.sum
@@ -1046,13 +1046,10 @@ github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7q
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.2.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
-github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
-github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
-github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.13.0 h1:vJlpe9wPgDRM1Z+7Wj3zUUjY1nr6/1jNKyl7llliccg=
 github.com/prometheus/common v0.13.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=

--- a/service/controller/control-plane/resource.go
+++ b/service/controller/control-plane/resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/certificates"
 	etcdcertificates "github.com/giantswarm/prometheus-meta-operator/service/controller/resource/etcd-certificates"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeat"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/ingress"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/prometheus"
@@ -240,6 +241,21 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var heartbeatRoutingResource resource.Interface
+	{
+		c := heartbeatrouting.Config{
+			Installation: config.Installation,
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			OpsgenieKey:  config.OpsgenieKey,
+		}
+
+		heartbeatRoutingResource, err = heartbeatrouting.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		namespaceResource,
 		tlsCertificatesResource,
@@ -254,6 +270,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		ingressResource,
 		promxyResource,
 		heartbeatResource,
+		heartbeatRoutingResource,
 	}
 
 	{

--- a/service/controller/resource/alert/rules/heartbeat.go
+++ b/service/controller/resource/alert/rules/heartbeat.go
@@ -22,7 +22,7 @@ func Heartbeat(obj metav1.Object, installation string) promv1.RuleGroup {
 					"team":                "atlas",
 				},
 				Annotations: map[string]string{
-					"description": "This alert is used to ensure the entire alerting pipeline is functionnal.",
+					"description": "This alert is used to ensure the entire alerting pipeline is functional.",
 				},
 			},
 		},

--- a/service/controller/resource/heartbeat/create.go
+++ b/service/controller/resource/heartbeat/create.go
@@ -68,8 +68,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "heartbeat is up to date")
 	}
 
-	// Trigger initial ping to ensure opsgenie alerts when an issue arise.
-	// This check if alertmanager is up and its config is up to date
+	// The initial ping to the heartbeat is there to move the heartbeat from inactive to active.
 	_, err = r.heartbeatClient.Ping(ctx, desired.Name)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/heartbeat/create.go
+++ b/service/controller/resource/heartbeat/create.go
@@ -68,5 +68,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "heartbeat is up to date")
 	}
 
+	// Trigger initial ping to ensure opsgenie alerts when an issue arise.
+	// This check if alertmanager is up and its config is up to date
+	_, err = r.heartbeatClient.Ping(ctx, desired.Name)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
 	return nil
 }

--- a/service/controller/resource/heartbeatrouting/create.go
+++ b/service/controller/resource/heartbeatrouting/create.go
@@ -1,0 +1,49 @@
+package heartbeatrouting
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting/receiver"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting/route"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "checking if alertmanager configmap needs to be updated")
+
+	cluster, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMap, cfg, err := r.readConfig(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cfg, receiverUpdated, err := receiver.EnsureCreated(cfg, cluster, r.installation, r.opsgenieKey)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cfg, routeUpdated, err := route.EnsureCreated(cfg, cluster, r.installation)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if receiverUpdated || routeUpdated {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap needs to be updated")
+		err = r.updateConfig(ctx, configMap, cfg)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap updated")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap does not need to be updated")
+	}
+
+	return nil
+}

--- a/service/controller/resource/heartbeatrouting/create.go
+++ b/service/controller/resource/heartbeatrouting/create.go
@@ -23,17 +23,19 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	cfg, receiverUpdated, err := receiver.EnsureCreated(cfg, cluster, r.installation, r.opsgenieKey)
+	cfg, receiverNeedsUpdate, err := receiver.EnsureCreated(cfg, cluster, r.installation, r.opsgenieKey)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	cfg, routeUpdated, err := route.EnsureCreated(cfg, cluster, r.installation)
+	cfg, routeNeedsUpdate, err := route.EnsureCreated(cfg, cluster, r.installation)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	if receiverUpdated || routeUpdated {
+	alertManagerConfigMapNeedsUpdate := receiverNeedsUpdate || routeNeedsUpdate
+
+	if alertManagerConfigMapNeedsUpdate {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap needs to be updated")
 		err = r.updateConfig(ctx, configMap, cfg)
 		if err != nil {

--- a/service/controller/resource/heartbeatrouting/delete.go
+++ b/service/controller/resource/heartbeatrouting/delete.go
@@ -23,17 +23,19 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	cfg, receiverUpdated, err := receiver.EnsureDeleted(cfg, cluster, r.installation, r.opsgenieKey)
+	cfg, receiverNeedsUpdate, err := receiver.EnsureDeleted(cfg, cluster, r.installation, r.opsgenieKey)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	cfg, routeUpdated, err := route.EnsureDeleted(cfg, cluster, r.installation)
+	cfg, routeNeedsUpdate, err := route.EnsureDeleted(cfg, cluster, r.installation)
 	if err != nil {
 		return microerror.Mask(err)
 	}
 
-	if receiverUpdated || routeUpdated {
+	alertManagerConfigMapNeedsUpdate := receiverNeedsUpdate || routeNeedsUpdate
+
+	if alertManagerConfigMapNeedsUpdate {
 		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap needs to be updated")
 		err = r.updateConfig(ctx, configMap, cfg)
 		if err != nil {

--- a/service/controller/resource/heartbeatrouting/delete.go
+++ b/service/controller/resource/heartbeatrouting/delete.go
@@ -1,0 +1,49 @@
+package heartbeatrouting
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting/receiver"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting/route"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	r.logger.LogCtx(ctx, "level", "debug", "message", "checking if alertmanager configmap needs to be updated")
+
+	cluster, err := key.ToCluster(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	configMap, cfg, err := r.readConfig(ctx)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cfg, receiverUpdated, err := receiver.EnsureDeleted(cfg, cluster, r.installation, r.opsgenieKey)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	cfg, routeUpdated, err := route.EnsureDeleted(cfg, cluster, r.installation)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	if receiverUpdated || routeUpdated {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap needs to be updated")
+		err = r.updateConfig(ctx, configMap, cfg)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap updated")
+	} else {
+		r.logger.LogCtx(ctx, "level", "debug", "message", "alertmanager configmap does not need to be updated")
+	}
+
+	return nil
+}

--- a/service/controller/resource/heartbeatrouting/error.go
+++ b/service/controller/resource/heartbeatrouting/error.go
@@ -1,0 +1,23 @@
+package heartbeatrouting
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+// IsWrongType asserts wrongTypeError.
+func IsWrongType(err error) bool {
+	return microerror.Cause(err) == wrongTypeError
+}

--- a/service/controller/resource/heartbeatrouting/helpers.go
+++ b/service/controller/resource/heartbeatrouting/helpers.go
@@ -1,0 +1,41 @@
+package heartbeatrouting
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertmanagerconfig "github.com/giantswarm/prometheus-meta-operator/pkg/alertmanager/config"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+func (r *Resource) readConfig(ctx context.Context) (*v1.ConfigMap, alertmanagerconfig.Config, error) {
+	configMap, err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(key.AlertmanagerConfigMapNamespace()).Get(ctx, key.AlertmanagerConfigMapName(), metav1.GetOptions{})
+	if err != nil {
+		return nil, alertmanagerconfig.Config{}, microerror.Mask(err)
+	}
+
+	content, ok := configMap.Data[key.AlertmanagerConfigMapKey()]
+	if !ok {
+		return nil, alertmanagerconfig.Config{}, microerror.Mask(invalidConfigError)
+	}
+
+	cfg, err := alertmanagerconfig.Load(content)
+	if err != nil {
+		return nil, alertmanagerconfig.Config{}, microerror.Mask(err)
+	}
+
+	return configMap, *cfg, nil
+}
+
+func (r *Resource) updateConfig(ctx context.Context, configMap *v1.ConfigMap, cfg alertmanagerconfig.Config) error {
+	configMap.Data[key.AlertmanagerConfigMapKey()] = cfg.String()
+	_, err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(key.AlertmanagerConfigMapNamespace()).Update(ctx, configMap, metav1.UpdateOptions{})
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -5,34 +5,34 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/prometheus/alertmanager/config"
-	commoncfg "github.com/prometheus/common/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/microerror"
 
+	alertmanagerconfig "github.com/giantswarm/prometheus-meta-operator/pkg/alertmanager/config"
+	promcommonconfig "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
-func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) (config.Receiver, error) {
+func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) (alertmanagerconfig.Receiver, error) {
 	u, err := url.Parse(fmt.Sprintf("https://api.opsgenie.com/v2/heartbeats/%s/ping", key.HeartbeatName(cluster, installation)))
 	if err != nil {
-		return config.Receiver{}, microerror.Mask(err)
+		return alertmanagerconfig.Receiver{}, microerror.Mask(err)
 	}
 
-	r := config.Receiver{
+	r := alertmanagerconfig.Receiver{
 		Name: key.HeartbeatReceiverName(cluster, installation),
-		WebhookConfigs: []*config.WebhookConfig{
-			&config.WebhookConfig{
-				URL: &config.URL{
+		WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+			&alertmanagerconfig.WebhookConfig{
+				URL: &alertmanagerconfig.URL{
 					URL: u,
 				},
-				HTTPConfig: &commoncfg.HTTPClientConfig{
-					BasicAuth: &commoncfg.BasicAuth{
-						Password: commoncfg.Secret(opsgenieKey),
+				HTTPConfig: &promcommonconfig.HTTPClientConfig{
+					BasicAuth: &promcommonconfig.BasicAuth{
+						Password: promcommonconfig.Secret(opsgenieKey),
 					},
 				},
-				NotifierConfig: config.NotifierConfig{
+				NotifierConfig: alertmanagerconfig.NotifierConfig{
 					VSendResolved: false,
 				},
 			},
@@ -44,7 +44,7 @@ func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) 
 
 // EnsureCreated ensure receiver exist in cfg.Receivers and is up to date. Returns true when changes have been made to cfg.
 // Return untouched cfg and false when no changes are made.
-func EnsureCreated(cfg config.Config, cluster metav1.Object, installation, opsgenieKey string) (config.Config, bool, error) {
+func EnsureCreated(cfg alertmanagerconfig.Config, cluster metav1.Object, installation, opsgenieKey string) (alertmanagerconfig.Config, bool, error) {
 	desired, err := toReceiver(cluster, installation, opsgenieKey)
 	if err != nil {
 		return cfg, false, microerror.Mask(err)
@@ -67,7 +67,7 @@ func EnsureCreated(cfg config.Config, cluster metav1.Object, installation, opsge
 
 // EnsureDeleted ensure receiver is removed from cfg.Receivers. Returns true when changes have been made to cfg.
 // Return untouched cfg and false when no changes are made.
-func EnsureDeleted(cfg config.Config, cluster metav1.Object, installation, opsgenieKey string) (config.Config, bool, error) {
+func EnsureDeleted(cfg alertmanagerconfig.Config, cluster metav1.Object, installation, opsgenieKey string) (alertmanagerconfig.Config, bool, error) {
 	desired, err := toReceiver(cluster, installation, opsgenieKey)
 	if err != nil {
 		return cfg, false, microerror.Mask(err)
@@ -83,7 +83,7 @@ func EnsureDeleted(cfg config.Config, cluster metav1.Object, installation, opsge
 	return cfg, false, nil
 }
 
-func getReceiver(cfg config.Config, receiver config.Receiver) (*config.Receiver, int) {
+func getReceiver(cfg alertmanagerconfig.Config, receiver alertmanagerconfig.Receiver) (*alertmanagerconfig.Receiver, int) {
 	for index, r := range cfg.Receivers {
 		if r.Name == receiver.Name {
 			return r, index

--- a/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
@@ -4,10 +4,11 @@ import (
 	"net/url"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
-	commoncfg "github.com/prometheus/common/config"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	alertmanagerconfig "github.com/giantswarm/prometheus-meta-operator/pkg/alertmanager/config"
+	promcommonconfig "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
 )
 
 var (
@@ -26,28 +27,28 @@ var (
 func TestEnsureReceiver(t *testing.T) {
 	testCases := []struct {
 		name           string
-		cfg            config.Config
+		cfg            alertmanagerconfig.Config
 		expectedUpdate bool
 		len            int
 		index          int
 	}{
 		{
 			name: "no update",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
-						WebhookConfigs: []*config.WebhookConfig{
-							&config.WebhookConfig{
-								URL: &config.URL{
+						WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+							&alertmanagerconfig.WebhookConfig{
+								URL: &alertmanagerconfig.URL{
 									URL: u,
 								},
-								HTTPConfig: &commoncfg.HTTPClientConfig{
-									BasicAuth: &commoncfg.BasicAuth{
+								HTTPConfig: &promcommonconfig.HTTPClientConfig{
+									BasicAuth: &promcommonconfig.BasicAuth{
 										Password: "secret-key",
 									},
 								},
-								NotifierConfig: config.NotifierConfig{
+								NotifierConfig: alertmanagerconfig.NotifierConfig{
 									VSendResolved: false,
 								},
 							},
@@ -61,21 +62,21 @@ func TestEnsureReceiver(t *testing.T) {
 		},
 		{
 			name: "update",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
-						WebhookConfigs: []*config.WebhookConfig{
-							&config.WebhookConfig{
-								URL: &config.URL{
+						WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+							&alertmanagerconfig.WebhookConfig{
+								URL: &alertmanagerconfig.URL{
 									URL: u,
 								},
-								HTTPConfig: &commoncfg.HTTPClientConfig{
-									BasicAuth: &commoncfg.BasicAuth{
+								HTTPConfig: &promcommonconfig.HTTPClientConfig{
+									BasicAuth: &promcommonconfig.BasicAuth{
 										Password: "wrong",
 									},
 								},
-								NotifierConfig: config.NotifierConfig{
+								NotifierConfig: alertmanagerconfig.NotifierConfig{
 									VSendResolved: false,
 								},
 							},
@@ -89,21 +90,21 @@ func TestEnsureReceiver(t *testing.T) {
 		},
 		{
 			name: "add",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "not me",
-						WebhookConfigs: []*config.WebhookConfig{
-							&config.WebhookConfig{
-								URL: &config.URL{
+						WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+							&alertmanagerconfig.WebhookConfig{
+								URL: &alertmanagerconfig.URL{
 									URL: u,
 								},
-								HTTPConfig: &commoncfg.HTTPClientConfig{
-									BasicAuth: &commoncfg.BasicAuth{
+								HTTPConfig: &promcommonconfig.HTTPClientConfig{
+									BasicAuth: &promcommonconfig.BasicAuth{
 										Password: "something",
 									},
 								},
-								NotifierConfig: config.NotifierConfig{
+								NotifierConfig: alertmanagerconfig.NotifierConfig{
 									VSendResolved: false,
 								},
 							},
@@ -117,8 +118,8 @@ func TestEnsureReceiver(t *testing.T) {
 		},
 		{
 			name: "add from 0",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{},
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{},
 			},
 			expectedUpdate: true,
 			len:            1,
@@ -147,18 +148,18 @@ func TestEnsureReceiver(t *testing.T) {
 func TestRemoveReceiver(t *testing.T) {
 	testCases := []struct {
 		name           string
-		cfg            config.Config
+		cfg            alertmanagerconfig.Config
 		expectedUpdate bool
 		len            int
 	}{
 		{
 			name: "no update",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "one",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "two",
 					},
 				},
@@ -168,23 +169,23 @@ func TestRemoveReceiver(t *testing.T) {
 		},
 		{
 			name: "no update (empty)",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{},
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{},
 			},
 			expectedUpdate: false,
 			len:            0,
 		},
 		{
 			name: "remove first",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "one",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "two",
 					},
 				},
@@ -194,15 +195,15 @@ func TestRemoveReceiver(t *testing.T) {
 		},
 		{
 			name: "remove middle",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "one",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "two",
 					},
 				},
@@ -212,15 +213,15 @@ func TestRemoveReceiver(t *testing.T) {
 		},
 		{
 			name: "remove last",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "one",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "two",
 					},
-					&config.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
 					},
 				},
@@ -230,9 +231,9 @@ func TestRemoveReceiver(t *testing.T) {
 		},
 		{
 			name: "remove (empty)",
-			cfg: config.Config{
-				Receivers: []*config.Receiver{
-					&config.Receiver{
+			cfg: alertmanagerconfig.Config{
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
 						Name: "heartbeat_installation_cluster",
 					},
 				},

--- a/service/controller/resource/heartbeatrouting/resource.go
+++ b/service/controller/resource/heartbeatrouting/resource.go
@@ -1,0 +1,51 @@
+package heartbeatrouting
+
+import (
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+)
+
+const Name = "heartbeatrouting"
+
+type Config struct {
+	Installation string
+	K8sClient    k8sclient.Interface
+	Logger       micrologger.Logger
+	OpsgenieKey  string
+}
+
+type Resource struct {
+	installation string
+	k8sClient    k8sclient.Interface
+	logger       micrologger.Logger
+	opsgenieKey  string
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Installation must not be empty", config)
+	}
+	if config.OpsgenieKey == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.OpsgenieKey must not be empty", config)
+	}
+
+	r := &Resource{
+		installation: config.Installation,
+		k8sClient:    config.K8sClient,
+		logger:       config.Logger,
+		opsgenieKey:  config.OpsgenieKey,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -13,6 +13,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/alertmanagerconfig"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/certificates"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeat"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/ingress"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/prometheus"
@@ -227,6 +228,21 @@ func New(config Config) ([]resource.Interface, error) {
 		}
 	}
 
+	var heartbeatRoutingResource resource.Interface
+	{
+		c := heartbeatrouting.Config{
+			Installation: config.Installation,
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			OpsgenieKey:  config.OpsgenieKey,
+		}
+
+		heartbeatRoutingResource, err = heartbeatrouting.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		namespaceResource,
 		apiCertificatesResource,
@@ -240,6 +256,7 @@ func New(config Config) ([]resource.Interface, error) {
 		ingressResource,
 		promxyResource,
 		heartbeatResource,
+		heartbeatRoutingResource,
 	}
 
 	{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13302
Needs: https://github.com/giantswarm/prometheus-meta-operator/pull/177 https://github.com/giantswarm/prometheus-meta-operator/pull/178 https://github.com/giantswarm/prometheus-meta-operator/pull/179

This PR adds `heartbeatrouting` resource in charge of configuring alertmanager to correctly route new heartbeats to their respective endpoints in opsgenie.