### PR TITLE
Implement test for alert rules

### DIFF
--- a/service/controller/resource/alert/create.go
+++ b/service/controller/resource/alert/create.go
@@ -17,7 +17,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	rules, err := getRules(obj, r.installation)
+	rules, err := r.GetRules(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/alert/delete.go
+++ b/service/controller/resource/alert/delete.go
@@ -16,7 +16,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		return microerror.Mask(err)
 	}
 
-	rules, err := getRules(obj, r.installation)
+	rules, err := r.GetRules(obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/alert/resource.go
+++ b/service/controller/resource/alert/resource.go
@@ -99,7 +99,7 @@ func (r *Resource) GetRules(obj interface{}) ([]*promv1.PrometheusRule, error) {
 		if len(bytes.TrimSpace(file)) > 0 {
 			var rule promv1.PrometheusRule = promv1.PrometheusRule{}
 
-			if err = yaml.Unmarshal(file, &rule); err != nil {
+			if err = yaml.UnmarshalStrict(file, &rule); err != nil {
 				return nil, microerror.Mask(err)
 			}
 

--- a/service/controller/resource/alert/resource.go
+++ b/service/controller/resource/alert/resource.go
@@ -2,6 +2,7 @@ package alert
 
 import (
 	"bytes"
+	"path"
 	"reflect"
 
 	"github.com/giantswarm/microerror"
@@ -17,20 +18,24 @@ import (
 )
 
 const (
-	Name              = "alert"
-	rulesFileLocation = "/opt/prometheus-meta-operator/files/templates/rules/**/*.yml"
+	Name = "alert"
+
+	ruleFilesDirectory = "/opt/prometheus/meta-operator"
+	ruleFilesPath      = "files/templates/rules/**/*.yml"
 )
 
 type Config struct {
 	Installation     string
 	PrometheusClient promclient.Interface
 	Logger           micrologger.Logger
+	TemplatePath     string
 }
 
 type Resource struct {
 	prometheusClient promclient.Interface
 	logger           micrologger.Logger
 	installation     string
+	templatePath     string
 }
 
 func New(config Config) (*Resource, error) {
@@ -43,11 +48,15 @@ func New(config Config) (*Resource, error) {
 	if config.Installation == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Installation must not be empty", config)
 	}
+	if config.TemplatePath == "" {
+		config.TemplatePath = path.Join(ruleFilesDirectory, ruleFilesPath)
+	}
 
 	r := &Resource{
 		logger:           config.Logger,
 		prometheusClient: config.PrometheusClient,
 		installation:     config.Installation,
+		templatePath:     config.TemplatePath,
 	}
 
 	return r, nil
@@ -64,7 +73,7 @@ type TemplateData struct {
 	Namespace    string
 }
 
-func getRules(obj interface{}, installation string) ([]*promv1.PrometheusRule, error) {
+func (r *Resource) GetRules(obj interface{}) ([]*promv1.PrometheusRule, error) {
 	cluster, err := key.ToCluster(obj)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -72,12 +81,12 @@ func getRules(obj interface{}, installation string) ([]*promv1.PrometheusRule, e
 
 	var data TemplateData = TemplateData{
 		ClusterID:    key.ClusterID(cluster),
-		Installation: installation,
+		Installation: r.installation,
 		ManagedBy:    project.Name(),
 		Namespace:    key.Namespace(cluster),
 	}
 
-	template, err := template.RenderTemplate(data, rulesFileLocation)
+	template, err := template.RenderTemplate(data, r.templatePath)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/alert/rule_test.go
+++ b/service/controller/resource/alert/rule_test.go
@@ -1,0 +1,103 @@
+package alert
+
+import (
+	"path"
+	"reflect"
+	"runtime"
+	"testing"
+
+	"github.com/giantswarm/micrologger"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var (
+	cluster = &v1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster",
+			Namespace: "cluster-namespace",
+		},
+	}
+
+	installation = "installation"
+)
+
+func TestGetRules(t *testing.T) {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("cannot get current filename")
+	}
+
+	path := path.Join(path.Dir(filename), "../../../..", ruleFilesPath)
+
+	logger, err := micrologger.New(micrologger.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := Config{
+		Installation:     installation,
+		PrometheusClient: &promclient.Clientset{},
+		Logger:           logger,
+		TemplatePath:     path,
+	}
+
+	r, err := New(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rules, err := r.GetRules(cluster)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(rules) <= 0 {
+		t.Fatalf("no rules")
+	}
+
+	for _, r := range rules {
+		valid := validateRule(r)
+		if !valid {
+			t.Errorf("rule %#q is invalid\n", r.GetName())
+		}
+	}
+}
+
+// validateRule validate a promv1.PrometheusRule object.
+// This is to avoid adding invalid rule into the codebase.
+// Rule are as follow:
+// * object must not be empty
+// * .spec.groups > 0
+// * .spec.groups[].name != ""
+// * .spec.groups[].rules > 0
+// * .spec.groups[].rules.expr != ""
+// taken from: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#prometheusrule
+func validateRule(rule *promv1.PrometheusRule) bool {
+	if reflect.DeepEqual(rule, &promv1.PrometheusRule{}) {
+		return false
+	}
+
+	if len(rule.Spec.Groups) <= 0 {
+		return false
+	}
+
+	for _, g := range rule.Spec.Groups {
+		if g.Name == "" {
+			return false
+		}
+		if len(g.Rules) <= 0 {
+			return false
+		}
+
+		for _, r := range g.Rules {
+			if r.Expr.String() == "" {
+				return false
+			}
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/13092

Add test to identify invalid/wrongly formatted rules files.



#### Test run

Here is a test run with some invalid rules.

```diff
diff --git a/files/templates/rules/alerts/prometheus-meta-operator.yml b/files/templates/rules/alerts/prometheus-meta-operator.yml
index ccd1f5f..8658bc2 100644
--- a/files/templates/rules/alerts/prometheus-meta-operator.yml
+++ b/files/templates/rules/alerts/prometheus-meta-operator.yml
@@ -48,3 +48,21 @@ spec:
         annotations:
           description: Labelling schema is invalid.
 ---
+kind: bob
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: alice
+  namespace: {{ .Namespace }}
+  labels:
+    app.kubernetes.io/name: "prometheus"
+    app.kubernetes.io/managed-by: {{ .ManagedBy }}
+    app.kubernetes.io/instance: {{ .ClusterID }}
+spec:
+  groups:
+  - name: alice
+    rules:
+    - alert: "Heartbeat"
+      expr: ""
+---
```


```
$ go test ./service/controller/resource/alert
--- FAIL: TestGetRules (0.00s)
    rule_test.go:64: rule `` is invalid
    rule_test.go:64: rule `alice` is invalid
FAIL
FAIL	github.com/giantswarm/prometheus-meta-operator/service/controller/resource/alert	0.014s
FAIL
```