### PR TITLE
prefer scheduling prometheus on non master nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support to remote write to Cortex
 - Added recording rules
+- Add node affinity to prefer not scheduling on master nodes
 
 ### Fixed
 

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -228,6 +228,26 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 				FSGroup:      &fsGroup,
 			},
 			Storage: &storage,
+			Affinity: &v1.Affinity{
+				NodeAffinity: &v1.NodeAffinity{
+					PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+						v1.PreferredSchedulingTerm{
+							Weight: 60,
+							Preference: v1.NodeSelectorTerm{
+								MatchExpressions: []v1.NodeSelectorRequirement{
+									v1.NodeSelectorRequirement{
+										Key:      "role",
+										Operator: v1.NodeSelectorOpNotIn,
+										Values: []string{
+											"master",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
 		},
 	}
 

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     host: https://master.bob
     tlsConfig:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     host: https://master.alice
     tlsConfig:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     host: https://master.foo
     tlsConfig:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     host: https://master.bar
     tlsConfig:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     host: https://

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -13,6 +13,16 @@ spec:
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs
+  affinity:
+    nodeAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - preference:
+          matchExpressions:
+          - key: role
+            operator: NotIn
+            values:
+            - master
+        weight: 60
   apiserverConfig:
     host: https://master.baz
     tlsConfig:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14076

New prometheus eat less memory but still they might kill master node. And this was observed multiple times already.

To prevent this, this PR adds soft node affinity which would prefer not scheduling on master but not prevent it.