### PR TITLE
fix wrong path in alert resource

### DIFF
--- a/service/controller/resource/alert/resource.go
+++ b/service/controller/resource/alert/resource.go
@@ -20,7 +20,7 @@ import (
 const (
 	Name = "alert"
 
-	ruleFilesDirectory = "/opt/prometheus/meta-operator"
+	ruleFilesDirectory = "/opt/prometheus-meta-operator"
 	ruleFilesPath      = "files/templates/rules/**/*.yml"
 )
 


### PR DESCRIPTION
fixes following error: unknown: html/template: pattern matches no files: `/opt/prometheus/meta-operator/files/templates/rules/**/*.yml`