### PR TITLE
Revert "Remote write to cortex (#190)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,15 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- Add support to remote write to Cortex
-- Added recording rules
-- Add node affinity to prefer not scheduling on master nodes
-
 ### Fixed
 
 - Fix kube-state-metrics scraping port on Control Planes.
+
+### Added
+
+- Added recording rules
+- Add node affinity to prefer not scheduling on master nodes
 
 ## [1.8.0] - 2020-10-21
 

--- a/files/templates/rules/alerts/prometheus-meta-operator.yml
+++ b/files/templates/rules/alerts/prometheus-meta-operator.yml
@@ -33,7 +33,7 @@ spec:
           or up{installation=""}
           or up{cluster_id=""}
           or up{provider!~"aws|azure|kvm"}
-          or up{instance!~"(\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+)|vault.*|bastion.*"}
+          or up{instance!~"(\\d+\\.\\d+\\.\\d+\\.\\d+:\\d+)||vault.*||bastion.*"}
         for: "10m"
         labels:
           area: "empowerment"

--- a/service/controller/control-plane/resource.go
+++ b/service/controller/control-plane/resource.go
@@ -155,7 +155,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			StorageSize:       config.StorageSize,
 			RetentionDuration: config.RetentionDuration,
 			RetentionSize:     config.RetentionSize,
-			RemoteWriteURL:    config.RemoteWriteURL,
 		}
 
 		prometheusResource, err = prometheus.New(c)

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -37,7 +37,6 @@ type Config struct {
 	StorageSize       string
 	RetentionDuration string
 	RetentionSize     string
-	RemoteWriteURL    string
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -159,33 +158,6 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 			RoutePrefix: fmt.Sprintf("/%s", key.ClusterID(cluster)),
 			PodMetadata: &promv1.EmbeddedObjectMetadata{
 				Labels: labels,
-			},
-			RemoteWrite: []promv1.RemoteWriteSpec{
-				promv1.RemoteWriteSpec{
-					URL: config.RemoteWriteURL,
-					BasicAuth: &promv1.BasicAuth{
-						Username: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: key.RemoteWriteSecretName(),
-							},
-							Key: key.RemoteWriteUsernameKey(),
-						},
-						Password: v1.SecretKeySelector{
-							LocalObjectReference: v1.LocalObjectReference{
-								Name: key.RemoteWriteSecretName(),
-							},
-							Key: key.RemoteWritePasswordKey(),
-						},
-					},
-					Name: key.ClusterID(cluster),
-					WriteRelabelConfigs: []promv1.RelabelConfig{
-						promv1.RelabelConfig{
-							SourceLabels: []string{"__name__"},
-							Regex:        "(^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)",
-							Action:       "keep",
-						},
-					},
-				},
 			},
 			Replicas: &replicas,
 			Resources: corev1.ResourceRequirements{

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: bob
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: alice
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: foo
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: bar
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: kubernetes
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: baz
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -144,7 +144,6 @@ func New(config Config) ([]resource.Interface, error) {
 			StorageSize:       config.StorageSize,
 			RetentionDuration: config.RetentionDuration,
 			RetentionSize:     config.RetentionSize,
-			RemoteWriteURL:    config.RemoteWriteURL,
 		}
 
 		prometheusResource, err = prometheus.New(c)


### PR DESCRIPTION
This reverts commit a7cab74b4f8154b7a71693d7ac758acc039c54a3.

Writing to cortex is not ready to be released yet, it has to be disabled
in g8s-prometheus first, but we want to make sure other fixes and
features are 100% first.
