### PR TITLE
Make writing to Cortex optional and disable it

### DIFF
--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -28,6 +28,8 @@ data:
         {{- range .Values.Installation.V1.Monitoring.Prometheus.Bastions }}
         - {{ . }}
         {{- end }}
+        # remoteWrite:
+        #   url: https://prometheus-us-central1.grafana.net/api/prom/push
         retention:
           duration: 2w
           size: 90GB

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -28,8 +28,6 @@ data:
         {{- range .Values.Installation.V1.Monitoring.Prometheus.Bastions }}
         - {{ . }}
         {{- end }}
-        remoteWrite:
-          url: https://prometheus-us-central1.grafana.net/api/prom/push
         retention:
           duration: 2w
           size: 90GB

--- a/service/controller/resource/prometheus/resource_test.go
+++ b/service/controller/resource/prometheus/resource_test.go
@@ -27,6 +27,7 @@ func TestPrometheus(t *testing.T) {
 		StorageSize:       "50Gi",
 		RetentionDuration: "2w",
 		RetentionSize:     "45Gi",
+		RemoteWriteURL:    "http://grafana/api/prom/push",
 	}
 
 	c := unittest.Config{

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: bob
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: bob
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: alice
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: alice
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: foo
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: foo
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: bar
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: bar
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: kubernetes
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: kubernetes
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -47,21 +47,6 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  remoteWrite:
-  - basicAuth:
-      password:
-        key: password
-        name: remote-write
-      username:
-        key: username
-        name: remote-write
-    name: baz
-    url: ""
-    writeRelabelConfigs:
-    - action: keep
-      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
-      sourceLabels:
-      - __name__
   replicas: 1
   resources:
     requests:

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -47,6 +47,21 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  remoteWrite:
+  - basicAuth:
+      password:
+        key: password
+        name: remote-write
+      username:
+        key: username
+        name: remote-write
+    name: baz
+    url: http://grafana/api/prom/push
+    writeRelabelConfigs:
+    - action: keep
+      regex: (^aggregation:.+|prometheus_tsdb_head_series|^slo_.+)
+      sourceLabels:
+      - __name__
   replicas: 1
   resources:
     requests:


### PR DESCRIPTION
Writing to cortex is not ready to be released yet, it has to be disabled
in g8s-prometheus first, but we want to make sure other fixes and
features are 100% first.
