### PR TITLE
set heartbeat client log level to fatal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set heartbeat client log level to fatal to avoid polluting our logs.
+
 ## [1.9.0] - 2020-11-11
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0
 	github.com/prometheus/common v0.14.0
 	github.com/prometheus/prometheus v2.21.0+incompatible
+	github.com/sirupsen/logrus v1.6.0
 	github.com/spf13/viper v1.6.2
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20201016220609-9e8e0b390897 // indirect

--- a/service/controller/resource/heartbeat/resource.go
+++ b/service/controller/resource/heartbeat/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opsgenie/opsgenie-go-sdk-v2/client"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/heartbeat"
 	"github.com/opsgenie/opsgenie-go-sdk-v2/og"
+	"github.com/sirupsen/logrus"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
@@ -49,6 +50,7 @@ func New(config Config) (*Resource, error) {
 		ApiKey:         config.OpsgenieKey,
 		OpsGenieAPIURL: client.API_URL,
 		RetryCount:     1,
+		LogLevel:       logrus.FatalLevel,
 	}
 	client, err := heartbeat.NewClient(c)
 	if err != nil {


### PR DESCRIPTION
heartbeat client logs error messages. Let's remove that because we do take care of those already and this is polluting our logs.
We cannot pass it a logger because it uses a totally different logger (logrus vs micrologger).

```
D 11/12 11:28:59 /apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/c0vce heartbeat checking if heartbeat exists | prometheus-meta-operator/service/controller/resource/heartbeat/create.go:16 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=27 | version=53241904
ERRO[2020-11-12T11:29:00.137839877Z] Error occurred with Status code: 404, Message: Heartbeat not found, Took: 0.008000, RequestId: 5e3a44f6-cf20-4005-b3b5-17fe8897b972
D 11/12 11:29:00 /apis/cluster.x-k8s.io/v1alpha2/namespaces/default/clusters/c0vce heartbeat heartbeat does not exist | prometheus-meta-operator/service/controller/resource/heartbeat/create.go:20 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=27 | version=53241904
```