### PR TITLE
Replace `bundleVersion` with `version`

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,17 +1,12 @@
 package project
 
 var (
-	bundleVersion = "0.0.1"
-	description   = "The prometheus-meta-operator does something."
-	gitSHA        = "n/a"
-	name          = "prometheus-meta-operator"
-	source        = "https://github.com/giantswarm/prometheus-meta-operator"
-	version       = "1.9.1-dev"
+	description = "The prometheus-meta-operator does something."
+	gitSHA      = "n/a"
+	name        = "prometheus-meta-operator"
+	source      = "https://github.com/giantswarm/prometheus-meta-operator"
+	version     = "1.9.1-dev"
 )
-
-func BundleVersion() string {
-	return bundleVersion
-}
 
 func Description() string {
 	return description

--- a/pkg/project/version_bundle.go
+++ b/pkg/project/version_bundle.go
@@ -15,6 +15,6 @@ func NewVersionBundle() versionbundle.Bundle {
 		},
 		Components: []versionbundle.Component{},
 		Name:       "prometheus-meta-operator",
-		Version:    BundleVersion(),
+		Version:    Version(),
 	}
 }


### PR DESCRIPTION
Not sure how it got in here as it was replaced in all operators as part
of VOO refactoring.

Currently it's causing _prometheus-meta-operator_ to report incorrect
version of itself via `prometheus-meta-operator version` and via the
`giantswarm_build_info` metric (reports `version="0.0.1"`).

This fixes it by removing all references to `bundleVersion` with
`version` which is maintained in `project.go` via CI.