### PR TITLE
move project root logic into unnitest.ProjectRoot

### DIFF
--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -188,3 +188,14 @@ func inputValue(inputFile string) (pkgruntime.Object, error) {
 
 	return input, nil
 }
+
+// ProjectRoot returns absolute path to prometheus-meta-operator root directory.
+// This comes in handy when you need to access files in this repository from a test.
+func ProjectRoot() string {
+	_, filename, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("cannot get current filename")
+	}
+
+	return path.Join(path.Dir(filename), "../..")
+}

--- a/service/controller/resource/alert/rule_test.go
+++ b/service/controller/resource/alert/rule_test.go
@@ -3,7 +3,6 @@ package alert
 import (
 	"path"
 	"reflect"
-	"runtime"
 	"testing"
 
 	"github.com/giantswarm/micrologger"
@@ -11,6 +10,8 @@ import (
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/pkg/unittest"
 )
 
 var (
@@ -25,12 +26,7 @@ var (
 )
 
 func TestGetRules(t *testing.T) {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		t.Fatal("cannot get current filename")
-	}
-
-	path := path.Join(path.Dir(filename), "../../../..", ruleFilesPath)
+	path := path.Join(unittest.ProjectRoot(), ruleFilesPath)
 
 	logger, err := micrologger.New(micrologger.Config{})
 	if err != nil {

--- a/service/controller/resource/scrapeconfigs/resource_test.go
+++ b/service/controller/resource/scrapeconfigs/resource_test.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"path"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/giantswarm/prometheus-meta-operator/pkg/unittest"
@@ -15,12 +14,7 @@ var update = flag.Bool("update", false, "update the ouput file")
 func TestAWSScrapeconfigs(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			t.Fatal("cannot get current filename")
-		}
-
-		path := path.Join(path.Dir(filename), "../../../..", templatePath)
+		path := path.Join(unittest.ProjectRoot(), templatePath)
 
 		config := Config{
 			TemplatePath: path,
@@ -59,12 +53,7 @@ func TestAWSScrapeconfigs(t *testing.T) {
 func TestAzureScrapeconfigs(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			t.Fatal("cannot get current filename")
-		}
-
-		path := path.Join(path.Dir(filename), "../../../..", templatePath)
+		path := path.Join(unittest.ProjectRoot(), templatePath)
 
 		config := Config{
 			TemplatePath: path,
@@ -103,12 +92,7 @@ func TestAzureScrapeconfigs(t *testing.T) {
 func TestKVMScrapeconfigs(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
-		_, filename, _, ok := runtime.Caller(0)
-		if !ok {
-			t.Fatal("cannot get current filename")
-		}
-
-		path := path.Join(path.Dir(filename), "../../../..", templatePath)
+		path := path.Join(unittest.ProjectRoot(), templatePath)
 
 		config := Config{
 			TemplatePath: path,


### PR DESCRIPTION
Hello there was this little patch abandonned somewhere on my disk.
I think it's worth having this, it helps with writting unit tests.