### PR TITLE
upgrade to large circleci docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,7 @@ workflows:
       - architect/go-build:
           name: build
           binary: prometheus-meta-operator
+          resource_class: large
           filters:
             tags:
               only: /^v.*/


### PR DESCRIPTION
I keep seeing failures in CI

![image](https://user-images.githubusercontent.com/6536819/99557097-967b7680-29c2-11eb-9892-700c6b688741.png)


Let's upgrade CI machine from medium (2cpu 4GB) to large (4 cpu 8GB)

