### PR TITLE
Drop highest cardinality nginx metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reduced number of metrics ingested from nginx-ingress-controller in order to
+  reduce memory requirements of Prometheus.
+
 ## [1.11.0] - 2020-12-01
 
 ### Added

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -559,6 +559,11 @@
     action: replace
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 [[ if eq .ClusterType "control_plane" ]]
 # app-operator
 - job_name: [[ .ClusterID ]]-prometheus/app-operator-[[ .ClusterID ]]/0

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -1156,4 +1156,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1156,4 +1156,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1156,4 +1156,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1156,4 +1156,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -978,6 +978,11 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1156,4 +1156,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -1094,4 +1094,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1094,4 +1094,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1094,4 +1094,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1094,4 +1094,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -923,6 +923,11 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -1094,4 +1094,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -1035,4 +1035,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -1035,4 +1035,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -1035,4 +1035,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -1035,4 +1035,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -923,6 +923,11 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -1035,4 +1035,9 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
 


### PR DESCRIPTION
Reduced number of metrics ingested from nginx-ingress-controller in order to
reduce memory requirements of Prometheus.

Closes: https://github.com/giantswarm/giantswarm/issues/14660
