### PR TITLE
Add Pod priority class for Prometheus pods

### DIFF
--- a/helm/prometheus-meta-operator/templates/priority-class.yaml
+++ b/helm/prometheus-meta-operator/templates/priority-class.yaml
@@ -1,6 +1,6 @@
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: prometheus-important
+  name: prometheus
 value: 500000000
 description: "High-priority class for Prometheus service pods only."

--- a/helm/prometheus-meta-operator/templates/priority-class.yaml
+++ b/helm/prometheus-meta-operator/templates/priority-class.yaml
@@ -1,4 +1,4 @@
-apiVersion: scheduling.k8s.io/v1alpha1
+apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
   name: prometheus-important

--- a/helm/prometheus-meta-operator/templates/priority-class.yaml
+++ b/helm/prometheus-meta-operator/templates/priority-class.yaml
@@ -1,0 +1,6 @@
+apiVersion: scheduling.k8s.io/v1alpha1
+kind: PriorityClass
+metadata:
+  name: prometheus-important
+value: 500000000
+description: "High-priority class for Prometheus service pods only."

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -223,6 +223,7 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 					"name": key.NamespaceMonitoring(cluster),
 				},
 			},
+			PriorityClassName: "prometheus-important",
 		},
 	}
 

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -223,7 +223,7 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 					"name": key.NamespaceMonitoring(cluster),
 				},
 			},
-			PriorityClassName: "prometheus-important",
+			PriorityClassName: "prometheus",
 		},
 	}
 

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -46,7 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
-  priorityClassName: prometheus-important
+  priorityClassName: prometheus
   remoteWrite:
   - basicAuth:
       password:

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -46,6 +46,7 @@ spec:
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
       giantswarm.io/monitoring: "true"
+  priorityClassName: prometheus-important
   remoteWrite:
   - basicAuth:
       password:


### PR DESCRIPTION
This will allow scheduler to prioritise Prometheus over other apps and
allow it to re-schedule pods with less constraints to make nodes in
specific zone required by a Prometheus pod (by placement of its data
volume) available.

Closes: https://github.com/giantswarm/giantswarm/issues/14798