### PR TITLE
Don't copy TLS certs to per-cluster namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- (internal) Rely on `Ingress` for OAuth2 proxy to configure TLS for Prometheus
+  domain, as it also configures management of the certificates, instead of
+  creating copies which could break access in case they became out of date.
+
 ### Fixed
 
 - Fix incorrect prometheus memory usage recording rule

--- a/service/controller/control-plane/resource.go
+++ b/service/controller/control-plane/resource.go
@@ -11,7 +11,6 @@ import (
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/alertmanagerconfig"
-	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/certificates"
 	etcdcertificates "github.com/giantswarm/prometheus-meta-operator/service/controller/resource/etcd-certificates"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeat"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting"
@@ -26,7 +25,6 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/volumeresizehack"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/wrapper/monitoringdisabledresource"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 type resourcesConfig struct {
@@ -68,23 +66,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 
 		namespaceResource, err = namespace.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var tlsCertificatesResource resource.Interface
-	{
-		c := certificates.Config{
-			Name:                "tls-certificates",
-			K8sClient:           config.K8sClient,
-			Logger:              config.Logger,
-			SourceNameFunc:      key.SecretTLSCertificates,
-			SourceNamespaceFunc: key.NamespaceMonitoring,
-			TargetNameFunc:      key.SecretTLSCertificates,
-		}
-
-		tlsCertificatesResource, err = certificates.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -293,7 +274,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 
 	resources := []resource.Interface{
 		namespaceResource,
-		tlsCertificatesResource,
 		etcdCertificatesResource,
 		rbacResource,
 		alertmanagerConfig,

--- a/service/controller/control-plane/resource.go
+++ b/service/controller/control-plane/resource.go
@@ -22,6 +22,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/remotewriteconfig"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/servicemonitor"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/tlscleanup"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/volumeresizehack"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/wrapper/monitoringdisabledresource"
@@ -66,6 +67,19 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 
 		namespaceResource, err = namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var tlsCleanupResource resource.Interface
+	{
+		c := tlscleanup.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		tlsCleanupResource, err = tlscleanup.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -274,6 +288,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 
 	resources := []resource.Interface{
 		namespaceResource,
+		tlsCleanupResource,
 		etcdCertificatesResource,
 		rbacResource,
 		alertmanagerConfig,

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -96,7 +96,7 @@ func toIngress(v interface{}, config Config) (metav1.Object, error) {
 	// added to the proxy for the base domain here.
 	//
 	// The common server configuration like TLS is configured in the `Ingress`
-	// installed by PMO chart itself. We want to avoid duplicating thr TLS
+	// installed by PMO chart itself. We want to avoid duplicating the TLS
 	// configuration here as only one certificate can be used for a given
 	// domain, and if multiple `Ingress` resources specify that  configuration
 	// the Ingress Controller just picks a random one (first one it finds), and

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -98,14 +98,15 @@ func toIngress(v interface{}, config Config) (metav1.Object, error) {
 	// The common server configuration like TLS is configured in the `Ingress`
 	// installed by PMO chart itself. We want to avoid duplicating the TLS
 	// configuration here as only one certificate can be used for a given
-	// domain, and if multiple `Ingress` resources specify that  configuration
-	// the Ingress Controller just picks a random one (first one it finds), and
-	// if that certificate happened to become out of date, it would break HTTPS
-	// access to that domain.
+	// domain, and if multiple `Ingress` resources specify that configuration
+	// the Ingress Controller just picks a random one (first one it finds). And
+	// if it picks up a copied certificate, and that copy happens to become out
+	// of date at some point, it would break HTTPS access to that domain.
 	//
 	// So we want TLS configuration to be controlled only by the `Ingress`
 	// resource that also defines the source of the certificates (i.e. the
-	// Let's Encrypt annotation or the static source for the installation).
+	// Let's Encrypt annotation or the static source for the installation)
+	// so we know as soon as it's updated IC will be using it.
 	ingress := &extensionsv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: extensionsv1beta1.SchemeGroupVersion.Version,

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -92,6 +92,9 @@ func toIngress(v interface{}, config Config) (metav1.Object, error) {
 		return nil, microerror.Mask(err)
 	}
 
+	// Note we only configure an ingress path that will add a location/HTTP
+	// path to the proxy for the base domain. The common server configuration
+	// like TLS is configured in Ingress installed by PMO chart itself.
 	ingress := &extensionsv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: extensionsv1beta1.SchemeGroupVersion.Version,

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -92,9 +92,20 @@ func toIngress(v interface{}, config Config) (metav1.Object, error) {
 		return nil, microerror.Mask(err)
 	}
 
-	// Note we only configure an ingress path that will add a location/HTTP
-	// path to the proxy for the base domain. The common server configuration
-	// like TLS is configured in Ingress installed by PMO chart itself.
+	// Note we only configure a path that will cause a location/HTTP path to be
+	// added to the proxy for the base domain here.
+	//
+	// The common server configuration like TLS is configured in the `Ingress`
+	// installed by PMO chart itself. We want to avoid duplicating thr TLS
+	// configuration here as only one certificate can be used for a given
+	// domain, and if multiple `Ingress` resources specify that  configuration
+	// the Ingress Controller just picks a random one (first one it finds), and
+	// if that certificate happened to become out of date, it would break HTTPS
+	// access to that domain.
+	//
+	// So we want TLS configuration to be controlled only by the `Ingress`
+	// resource that also defines the source of the certificates (i.e. the
+	// Let's Encrypt annotation or the static source for the installation).
 	ingress := &extensionsv1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: extensionsv1beta1.SchemeGroupVersion.Version,

--- a/service/controller/resource/ingress/resource.go
+++ b/service/controller/resource/ingress/resource.go
@@ -99,12 +99,6 @@ func toIngress(v interface{}, config Config) (metav1.Object, error) {
 		},
 		ObjectMeta: objectMeta,
 		Spec: extensionsv1beta1.IngressSpec{
-			TLS: []extensionsv1beta1.IngressTLS{
-				{
-					Hosts:      []string{config.BaseDomain},
-					SecretName: key.SecretTLSCertificates(cluster),
-				},
-			},
 			Rules: []extensionsv1beta1.IngressRule{
 				{
 					Host: config.BaseDomain,

--- a/service/controller/resource/ingress/test/case-0-cluster-api.golden
+++ b/service/controller/resource/ingress/test/case-0-cluster-api.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /bob
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/ingress/test/case-1-awsconfig.golden
+++ b/service/controller/resource/ingress/test/case-1-awsconfig.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /alice
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/ingress/test/case-2-azureconfig.golden
+++ b/service/controller/resource/ingress/test/case-2-azureconfig.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /foo
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/ingress/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/ingress/test/case-3-kvmconfig.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /bar
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/ingress/test/case-4-control-plane.golden
+++ b/service/controller/resource/ingress/test/case-4-control-plane.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /kubernetes
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/ingress/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/ingress/test/case-5-cluster-api-v1alpha3.golden
@@ -21,9 +21,5 @@ spec:
           serviceName: prometheus-operated
           servicePort: 9090
         path: /baz
-  tls:
-  - hosts:
-    - https://prometheus
-    secretName: prometheus-tls
 status:
   loadBalancer: {}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -21,6 +21,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/remotewriteconfig"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/servicemonitor"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/tlscleanup"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/volumeresizehack"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/wrapper/monitoringdisabledresource"
@@ -83,6 +84,19 @@ func New(config Config) ([]resource.Interface, error) {
 		}
 
 		apiCertificatesResource, err = certificates.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var tlsCleanupResource resource.Interface
+	{
+		c := tlscleanup.Config{
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+		}
+
+		tlsCleanupResource, err = tlscleanup.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -265,6 +279,7 @@ func New(config Config) ([]resource.Interface, error) {
 	resources := []resource.Interface{
 		namespaceResource,
 		apiCertificatesResource,
+		tlsCleanupResource,
 		alertmanagerConfig,
 		serviceMonitorResource,
 		scrapeConfigResource,

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -88,23 +88,6 @@ func New(config Config) ([]resource.Interface, error) {
 		}
 	}
 
-	var tlsCertificatesResource resource.Interface
-	{
-		c := certificates.Config{
-			Name:                "tls-certificates",
-			K8sClient:           config.K8sClient,
-			Logger:              config.Logger,
-			SourceNameFunc:      key.SecretTLSCertificates,
-			SourceNamespaceFunc: key.NamespaceMonitoring,
-			TargetNameFunc:      key.SecretTLSCertificates,
-		}
-
-		tlsCertificatesResource, err = certificates.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var alertmanagerConfig resource.Interface
 	{
 		c := alertmanagerconfig.Config{
@@ -282,7 +265,6 @@ func New(config Config) ([]resource.Interface, error) {
 	resources := []resource.Interface{
 		namespaceResource,
 		apiCertificatesResource,
-		tlsCertificatesResource,
 		alertmanagerConfig,
 		serviceMonitorResource,
 		scrapeConfigResource,

--- a/service/controller/resource/tlscleanup/create.go
+++ b/service/controller/resource/tlscleanup/create.go
@@ -1,0 +1,16 @@
+package tlscleanup
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	err := r.EnsureDeleted(ctx, obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	return nil
+}

--- a/service/controller/resource/tlscleanup/delete.go
+++ b/service/controller/resource/tlscleanup/delete.go
@@ -1,0 +1,26 @@
+package tlscleanup
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	object, err := r.getObjectMeta(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "deleting")
+	c := r.k8sClient.K8sClient().CoreV1().Secrets(object.GetNamespace())
+	err = c.Delete(ctx, object.GetName(), metav1.DeleteOptions{})
+	if !apierrors.IsNotFound(err) && err != nil {
+		return microerror.Mask(err)
+	}
+	r.logger.Debugf(ctx, "deleted")
+
+	return nil
+}

--- a/service/controller/resource/tlscleanup/error.go
+++ b/service/controller/resource/tlscleanup/error.go
@@ -1,0 +1,12 @@
+package tlscleanup
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/tlscleanup/resource.go
+++ b/service/controller/resource/tlscleanup/resource.go
@@ -1,0 +1,57 @@
+// tlscleanup provides a resource that cleans up unnecessary TLS certificates
+// from the shard namespace. These were created by earlier versions but are now
+// unused so we ensure to remove them to not leave them dangling.
+//
+// TODO: this resource can be removed after a couple of releases
+// TODO: when removing, check and remove `key.SecretTLSCertificates` function
+package tlscleanup
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+type Config struct {
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.K8sClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	return &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+	}, nil
+}
+
+func (r *Resource) Name() string {
+	return "tlscleanup"
+}
+
+func (r *Resource) getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return metav1.ObjectMeta{}, microerror.Mask(err)
+	}
+
+	return metav1.ObjectMeta{
+		Name:      key.SecretTLSCertificates(cluster),
+		Namespace: key.Namespace(cluster),
+	}, nil
+}

--- a/service/controller/resource/tlscleanup/resource.go
+++ b/service/controller/resource/tlscleanup/resource.go
@@ -2,7 +2,7 @@
 // from the shard namespace. These were created by earlier versions but are now
 // unused so we ensure to remove them to not leave them dangling.
 //
-// TODO: this resource can be removed after a couple of releases
+// TODO: this resource can be removed in next release.
 // TODO: when removing, check and remove `key.SecretTLSCertificates` function
 package tlscleanup
 


### PR DESCRIPTION
This is unnecessary as it's enough for a single `Ingress` resource to
specify TLS configuration for a host, and in specific circumstances it
can in fact cause problems like an orphaned `Ingress` resource can
prevent an ingress-controller from picking up updated certificates.

This change removes copying of TLS certificates and duplicating TLS
configuration from `Ingress` resources, instead relying on the global
Prometheus `Ingress` (currently maintained in _g8s-prometheus_) being
the source-of-truth for the TLS configuration.

Closes: https://github.com/giantswarm/giantswarm/issues/14951