### PR TITLE
Ignore slack in alertmanagernotificationsfailing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the biscuit alerts to PMO:
   - `ControlPlaneCertificateWillExpireInLessThanTwoWeeks`
 - Add topologySpreadConstraint to evenly spread prometheus pods
+- Ignore Slack in `AlertManagerNotificationsFailing` alert.
 
 ### Removed
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager.rules.yml
@@ -15,7 +15,7 @@ spec:
       annotations:
         description: '{{`AlertManager {{ $labels.integration }} notifications are failing.`}}'
         opsrecipe: alert-manager-notifications-failing/
-      expr: rate(alertmanager_notifications_failed_total{cluster_id!~"axolotl|giraffe|argali"}[5m]) > 0
+      expr: rate(alertmanager_notifications_failed_total{cluster_id!~"argali|axolotl|giraffe", integration!="slack"}[5m]) > 0
       for: 10m
       labels:
         area: empowerment
@@ -26,7 +26,7 @@ spec:
       annotations:
         description: '{{`AlertManager {{ $labels.integration }} notifications are failing.`}}'
         opsrecipe: alert-manager-notifications-failing/
-      expr: rate(alertmanager_notifications_failed_total{cluster_id=~"argali|axolotl|giraffe"}[5m]) > 0
+      expr: rate(alertmanager_notifications_failed_total{cluster_id=~"argali|axolotl|giraffe", integration!="slack"}[5m]) > 0
       for: 120m
       labels:
         area: empowerment


### PR DESCRIPTION
Adding https://github.com/giantswarm/g8s-prometheus/commit/81361e3adda538584e0d7564c4ef6cb31e6ba879 before removing the atlas alerts from g8s-prometheus