### PR TITLE
rename control plane & tenant cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use giantswarm/prometheus image
+- Renamed control plane and tenant cluster respectively to management cluster and
+  workload cluster. Renamed some alerts:
+  - ControlPlaneCertificateWillExpireInLessThanTwoWeeks > ManagementClusterCertificateWillExpireInLessThanTwoWeeks
+  - ControlPlaneDaemonSetNotSatisfiedAtlas > ManagementClusterDaemonSetNotSatisfiedAtlas
+  - ControlPlaneDaemonSetNotSatisfiedChinaAtlas > ManagementClusterDaemonSetNotSatisfiedChinaAtlas
+  - PrometheusCantCommunicateWithTenantAPI > PrometheusCantCommunicateWithKubernetesAPI
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Renamed control plane and tenant cluster respectively to management cluster and
+  workload cluster. Renamed some alerts:
+  - ControlPlaneCertificateWillExpireInLessThanTwoWeeks > ManagementClusterCertificateWillExpireInLessThanTwoWeeks
+  - ControlPlaneDaemonSetNotSatisfiedAtlas > ManagementClusterDaemonSetNotSatisfiedAtlas
+  - ControlPlaneDaemonSetNotSatisfiedChinaAtlas > ManagementClusterDaemonSetNotSatisfiedChinaAtlas
+  - PrometheusCantCommunicateWithTenantAPI > PrometheusCantCommunicateWithKubernetesAPI
+
 ## [1.16.1] - 2021-01-28
 
 ### Fixed
@@ -34,12 +43,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use giantswarm/prometheus image
-- Renamed control plane and tenant cluster respectively to management cluster and
-  workload cluster. Renamed some alerts:
-  - ControlPlaneCertificateWillExpireInLessThanTwoWeeks > ManagementClusterCertificateWillExpireInLessThanTwoWeeks
-  - ControlPlaneDaemonSetNotSatisfiedAtlas > ManagementClusterDaemonSetNotSatisfiedAtlas
-  - ControlPlaneDaemonSetNotSatisfiedChinaAtlas > ManagementClusterDaemonSetNotSatisfiedChinaAtlas
-  - PrometheusCantCommunicateWithTenantAPI > PrometheusCantCommunicateWithKubernetesAPI
 
 ### Fixed
 

--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -4,8 +4,8 @@ When possible on customers installations, we decided to use dynamic provisioning
 
 As some installations do not support dynamic provisioning (some on-prem installations), we decided to ask customers to provision volumes in the following pattern:
 
-- 1 Volume for the control plane.
-- 1 Volume per tenant cluster managed by the control plane.
+- 1 Volume for the management cluster.
+- 1 Volume per workload cluster managed by the management cluster.
 - 1 extra volume that we can use in case a new cluster is created.
 
 ## Retention

--- a/files/templates/scrapeconfigs/_apiserver.yaml
+++ b/files/templates/scrapeconfigs/_apiserver.yaml
@@ -1,5 +1,5 @@
 [[- define "_apiserver" -]]
-[[- if ne .ClusterType "control_plane" ]]
+[[- if ne .ClusterType "management_cluster" ]]
     api_server: https://[[ .APIServerURL ]]
     tls_config:
       ca_file: /etc/prometheus/secrets/[[ .SecretName ]]/ca

--- a/files/templates/scrapeconfigs/_tlsconfig.yaml
+++ b/files/templates/scrapeconfigs/_tlsconfig.yaml
@@ -1,5 +1,5 @@
 [[- define "_tlsconfig" -]]
-[[- if ne .ClusterType "control_plane" -]]
+[[- if ne .ClusterType "management_cluster" -]]
 tls_config:
   ca_file: /etc/prometheus/secrets/[[ .SecretName ]]/ca
   cert_file: /etc/prometheus/secrets/[[ .SecretName ]]/crt

--- a/files/templates/scrapeconfigs/_tlsconfig_skip.yaml
+++ b/files/templates/scrapeconfigs/_tlsconfig_skip.yaml
@@ -1,5 +1,5 @@
 [[- define "_tlsconfig_skip" -]]
-[[- if ne .ClusterType "control_plane" -]]
+[[- if ne .ClusterType "management_cluster" -]]
 tls_config:
   ca_file: /etc/prometheus/secrets/[[ .SecretName ]]/ca
   cert_file: /etc/prometheus/secrets/[[ .SecretName ]]/crt

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: [[ .ClusterID ]]-prometheus/kubernetes-apiserver-[[ .ClusterID ]]/0
   honor_labels: true
   scheme: https
@@ -18,7 +17,7 @@
     action: drop
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
-[[ if ne .ClusterType "control_plane" ]]
+[[ if ne .ClusterType "management_cluster" ]]
 [[ if or (eq .Provider "aws") (eq .Provider "azure") ]]
 - job_name: [[ .ClusterID ]]-prometheus/cluster-autoscaler-[[ .ClusterID ]]/0
   honor_labels: true
@@ -101,7 +100,7 @@
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
-[[- if eq .ClusterType "control_plane" ]]
+[[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring)
     action: keep
@@ -166,7 +165,7 @@
   scheme: https
   kubernetes_sd_configs:
   - role: node
-[[ if ne .ClusterType "control_plane" ]]
+[[ if ne .ClusterType "management_cluster" ]]
     api_server: https://[[ .APIServerURL ]]
     tls_config:
       ca_file: /etc/prometheus/secrets/[[ .SecretName ]]/ca
@@ -228,7 +227,7 @@
   - source_labels: [__address__]
     replacement: $1:10252
     target_label: instance
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (k8s-controller-manager.*)
     action: keep
@@ -262,7 +261,7 @@
   - source_labels: [__address__]
     replacement: $1:10251
     target_label: instance
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (k8s-scheduler.*)
     action: keep
@@ -350,7 +349,7 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
   - source_labels: [__meta_kubernetes_service_name]
     regex: chart-operator-unique
     action: keep
@@ -377,7 +376,7 @@
   - role: endpoints
     namespaces:
       names:
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
       - monitoring
 [[ else ]]
       - kube-system
@@ -395,7 +394,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (net-exporter.*)
     target_label: __metrics_path__
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
     replacement: /api/v1/namespaces/monitoring/pods/${1}:8000/proxy/metrics
 [[ else ]]
     replacement: /api/v1/namespaces/kube-system/pods/${1}:8000/proxy/metrics
@@ -412,7 +411,7 @@
   - role: endpoints
     namespaces:
       names:
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
       - monitoring
 [[ else ]]
       - kube-system
@@ -430,7 +429,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
     replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
 [[ else ]]
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
@@ -447,7 +446,7 @@
   - role: endpoints
     namespaces:
       names:
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
       - monitoring
 [[ else ]]
       - kube-system
@@ -485,7 +484,7 @@
   - role: endpoints
     namespaces:
       names:
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
       - monitoring
 [[ else ]]
       - kube-system
@@ -503,7 +502,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (kube-state-metrics.*)
     target_label: __metrics_path__
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
     replacement: /api/v1/namespaces/monitoring/pods/${1}:10301/proxy/metrics
 [[ else ]]
     replacement: /api/v1/namespaces/kube-system/pods/${1}:10301/proxy/metrics
@@ -564,7 +563,7 @@
   - source_labels: [__name__]
     regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
     action: drop
-[[ if eq .ClusterType "control_plane" ]]
+[[ if eq .ClusterType "management_cluster" ]]
 # app-operator
 - job_name: [[ .ClusterID ]]-prometheus/app-operator-[[ .ClusterID ]]/0
   honor_labels: true

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager.rules.yml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: alertmanager.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/certificate.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/certificate.rules.yml
@@ -4,17 +4,17 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: certificate.rules
 spec:
   groups:
   - name: certificate
     rules:
-    - alert: ControlPlaneCertificateWillExpireInLessThanTwoWeeks
+    - alert: ManagementClusterCertificateWillExpireInLessThanTwoWeeks
       annotations:
         description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
         opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="control_plane", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
@@ -4,30 +4,30 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: daemonset.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:
   groups:
   - name: daemonset
     rules:
-    - alert: ControlPlaneDaemonSetNotSatisfiedAtlas
+    - alert: ManagementClusterDaemonSetNotSatisfiedAtlas
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="control_plane", cluster_id!="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
+      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id!="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
       for: 30m
       labels:
         area: kaas
         severity: notify
         team: atlas
-        topic: controlplane
-    - alert: ControlPlaneDaemonSetNotSatisfiedChinaAtlas
+        topic: managementcluster
+    - alert: ManagementClusterDaemonSetNotSatisfiedChinaAtlas
       annotations:
         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="control_plane", cluster_id="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
+      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
       for: 3h
       labels:
         area: kaas
         severity: notify
         team: atlas
-        topic: controlplane
+        topic: managementcluster

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="control_plane", deployment=~"alertmanager.*|prometheus|prometheus-meta-operator.*|promxy.*", cluster_id!~"axolotl|giraffe|argali"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|prometheus|prometheus-meta-operator.*|promxy.*", cluster_id!~"axolotl|giraffe|argali"} > 0
       for: 30m
       labels:
         area: kaas
@@ -23,12 +23,12 @@ spec:
         cancel_if_cluster_status_updating: "true"
         severity: page
         team: atlas
-        topic: controlplane
+        topic: managementcluster
     - alert: DeploymentNotSatisfiedChinaAtlas
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="control_plane", deployment=~"alertmanager.*|prometheus|prometheus-meta-operator.*|promxy.*", cluster_id=~"axolotl|giraffe|argali"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"alertmanager.*|prometheus|prometheus-meta-operator.*|promxy.*", cluster_id=~"axolotl|giraffe|argali"} > 0
       for: 30m
       labels:
         area: kaas
@@ -37,4 +37,4 @@ spec:
         cancel_if_cluster_status_updating: "true"
         severity: page
         team: atlas
-        topic: controlplane
+        topic: managementcluster

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/fluentbit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/fluentbit.rules.yml
@@ -4,7 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: fluentbit.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.rules.yml
@@ -112,7 +112,7 @@ spec:
     - alert: InhibitionKVMClusterHasNoRunningCPNodes
       annotations:
         description: '{{`KVM Cluster {{ $labels.cluster_id }} has nodes down.`}}'
-      expr: label_replace(up{app=~"master|worker", cluster_type="control_plane"} == 0, "cluster_id", "$1", "namespace", "(.*)")
+      expr: label_replace(up{app=~"master|worker", cluster_type="management_cluster"} == 0, "cluster_id", "$1", "namespace", "(.*)")
       labels:
         area: kaas
         nodes_down: "true"

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -24,7 +24,7 @@ spec:
     rules:
       - alert: "InvalidLabellingSchema"
         expr: |
-          up{cluster_type!~"control_plane|tenant_cluster"}
+          up{cluster_type!~"management_cluster|workload_cluster"}
           or up{app=""}
           or up{installation=""}
           or up{cluster_id=""}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -4,16 +4,16 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: prometheus.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:
   groups:
   - name: prometheus
     rules:
-    - alert: PrometheusCantCommunicateWithTenantAPI
+    - alert: PrometheusCantCommunicateWithKubernetesAPI
       annotations:
-        description: '{{`Prometheus can''t communicate with tenant cluster Kubernetes API.`}}'
+        description: '{{`Prometheus can''t communicate with Kubernetes API.`}}'
         opsrecipe: prometheus-cant-communicate/
       expr: rate(prometheus_sd_kubernetes_http_request_total{app!="promxy-app-unique", status_code="<error>"}[15m]) > 2
       for: 15m

--- a/helm/prometheus-meta-operator/templates/recording-rules/helm-operations.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/helm-operations.rules.yml
@@ -3,7 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_cluster"
   name: helm-operations
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:

--- a/helm/prometheus-meta-operator/templates/recording-rules/service-levels.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/service-levels.rules.yml
@@ -3,7 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "control_plane"
+    cluster_type: "management_clustemanagement_cluster"
   name: service-level
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:

--- a/helm/prometheus-meta-operator/templates/recording-rules/service-levels.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/service-levels.rules.yml
@@ -3,7 +3,7 @@ kind: PrometheusRule
 metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "management_clustemanagement_cluster"
+    cluster_type: "management_cluster"
   name: service-level
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Opsgenie.Key, "", "Opsgenie Key used for API authentication.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Address, "", "Address to access Prometheus UI.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.BaseDomain, "", "Base domain to create Prometheus Ingress resources under.")
-	daemonCommand.PersistentFlags().StringSlice(f.Service.Prometheus.Bastions, make([]string, 0), "Address of the control plane bastions.")
+	daemonCommand.PersistentFlags().StringSlice(f.Service.Prometheus.Bastions, make([]string, 0), "Address of the bastions.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Prometheus.Storage.CreatePVC, false, "Should the operator create a PVC for storage.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Storage.Size, "100Gi", "Storage size for prometheus.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Version, "v2.24.0", "Prometheus container image version.")

--- a/service/controller/managementcluster/controller.go
+++ b/service/controller/managementcluster/controller.go
@@ -1,4 +1,4 @@
-package controlplane
+package managementcluster
 
 import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
@@ -73,7 +73,7 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		c := controller.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
-			Name:      project.Name() + "-control-plane-controller",
+			Name:      project.Name() + "-management-cluster-controller",
 			NewRuntimeObjectFunc: func() runtime.Object {
 				return new(v1.Service)
 			},

--- a/service/controller/managementcluster/error.go
+++ b/service/controller/managementcluster/error.go
@@ -1,4 +1,4 @@
-package controlplane
+package managementcluster
 
 import (
 	"github.com/giantswarm/microerror"

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -16,6 +16,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeat"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/heartbeatrouting"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/ingress"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/legacyfinalizer"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/namespace"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/prometheus"
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/promxy"
@@ -68,6 +69,19 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 
 		namespaceResource, err = namespace.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var legacyfinalizerResource resource.Interface
+	{
+		c := legacyfinalizer.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		legacyfinalizerResource, err = legacyfinalizer.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -293,6 +307,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 
 	resources := []resource.Interface{
 		namespaceResource,
+		legacyfinalizerResource,
 		tlsCertificatesResource,
 		etcdCertificatesResource,
 		rbacResource,

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -294,7 +294,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 
 	resources := []resource.Interface{
 		namespaceResource,
-		legacyfinalizerResource,
 		tlsCertificatesResource,
 		etcdCertificatesResource,
 		rbacResource,

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -74,19 +74,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 	}
 
-	var legacyfinalizerResource resource.Interface
-	{
-		c := legacyfinalizer.Config{
-			CtrlClient: config.K8sClient.CtrlClient(),
-			Logger:     config.Logger,
-		}
-
-		legacyfinalizerResource, err = legacyfinalizer.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var tlsCertificatesResource resource.Interface
 	{
 		c := certificates.Config{
@@ -360,6 +347,21 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			return nil, microerror.Mask(err)
 		}
 	}
+
+	var legacyfinalizerResource resource.Interface
+	{
+		c := legacyfinalizer.Config{
+			CtrlClient: config.K8sClient.CtrlClient(),
+			Logger:     config.Logger,
+		}
+
+		legacyfinalizerResource, err = legacyfinalizer.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	resources = append([]resource.Interface{legacyfinalizerResource}, resources...)
 
 	return resources, nil
 }

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -1,4 +1,4 @@
-package controlplane
+package managementcluster
 
 import (
 	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
@@ -330,7 +330,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	}
 
 	{
-		resources, err = ControlPlaneWrap(resources, config)
+		resources, err = Wrap(resources, config)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}

--- a/service/controller/managementcluster/wrapper.go
+++ b/service/controller/managementcluster/wrapper.go
@@ -1,4 +1,4 @@
-package controlplane
+package managementcluster
 
 import (
 	"context"
@@ -18,8 +18,8 @@ type cpResource struct {
 	installation string
 }
 
-// ControlPlaneWrap wrap resource and replace the input object with a Service which is named after the installation.
-func ControlPlaneWrap(resources []resource.Interface, config resourcesConfig) ([]resource.Interface, error) {
+// Wrap wrap resource and replace the input object with a Service which is named after the installation.
+func Wrap(resources []resource.Interface, config resourcesConfig) ([]resource.Interface, error) {
 	var wrapped []resource.Interface
 
 	for _, r := range resources {

--- a/service/controller/resource/certificates/doc.go
+++ b/service/controller/resource/certificates/doc.go
@@ -1,5 +1,5 @@
 package certificates
 
 // The Kubernetes Secrets we currently use for prometheus (e.g: $CLUSTER_ID-prometheus) are held in the default namespace.
-// We want to run the tenant cluster Prometheus servers in a per-tenant cluster namespace ($CLUSTER_ID-prometheus). prometheus-operator does not support referencing a secret in a different namespace.
-// So, we need to copy the secret default/$CLUSTER_ID-prometheus to the tenant cluster prometheus namespace - e.g: $CLUSTER_ID-prometheus/cluster-certificates
+// We want to run the Prometheus servers in a per-cluster namespace ($CLUSTER_ID-prometheus). prometheus-operator does not support referencing a secret in a different namespace.
+// So, we need to copy the secret default/$CLUSTER_ID-prometheus to the cluster prometheus namespace - e.g: $CLUSTER_ID-prometheus/cluster-certificates

--- a/service/controller/resource/legacyfinalizer/create.go
+++ b/service/controller/resource/legacyfinalizer/create.go
@@ -5,8 +5,9 @@ import (
 	"strings"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 // EnsureCreated ensures that reconciled AzureConfig CR gets orphaned finalizer

--- a/service/controller/resource/legacyfinalizer/create.go
+++ b/service/controller/resource/legacyfinalizer/create.go
@@ -1,0 +1,56 @@
+package legacyfinalizer
+
+import (
+	"context"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EnsureCreated ensures that reconciled AzureConfig CR gets orphaned finalizer
+// deleted.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToClusterMR(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "ensuring resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
+
+	{
+		// Refresh the CR object.
+		err := r.ctrlClient.Get(ctx, client.ObjectKey{Name: cr.GetName(), Namespace: cr.GetNamespace()}, cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var exists bool
+	finalizers := cr.GetFinalizers()
+	for i, v := range finalizers {
+		if strings.TrimSpace(v) == legacyFinalizer {
+			exists = true
+
+			// Drop it.
+			cr.SetFinalizers(append(finalizers[:i], finalizers[i+1:]...))
+			break
+		}
+	}
+
+	if exists {
+		r.logger.Debugf(ctx, "deleting legacy finalizer from resource")
+
+		err := r.ctrlClient.Update(ctx, cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.Debugf(ctx, "deleted legacy finalizer from resource")
+	}
+
+	r.logger.Debugf(ctx, "ensured resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
+
+	return nil
+}

--- a/service/controller/resource/legacyfinalizer/delete.go
+++ b/service/controller/resource/legacyfinalizer/delete.go
@@ -1,0 +1,8 @@
+package legacyfinalizer
+
+import "context"
+
+// EnsureDeleted is no-op.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}

--- a/service/controller/resource/legacyfinalizer/error.go
+++ b/service/controller/resource/legacyfinalizer/error.go
@@ -1,0 +1,14 @@
+package legacyfinalizer
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}

--- a/service/controller/resource/legacyfinalizer/resource.go
+++ b/service/controller/resource/legacyfinalizer/resource.go
@@ -1,14 +1,9 @@
 package legacyfinalizer
 
 import (
-	"context"
-	"strings"
-
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
 const (
@@ -43,58 +38,6 @@ func New(config Config) (*Resource, error) {
 	}
 
 	return r, nil
-}
-
-// EnsureCreated ensures that reconciled AzureConfig CR gets orphaned finalizer
-// deleted.
-func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	cr, err := key.ToClusterMR(obj)
-	if err != nil {
-		return microerror.Mask(err)
-	}
-
-	r.logger.Debugf(ctx, "ensuring resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
-
-	{
-		// Refresh the CR object.
-		err := r.ctrlClient.Get(ctx, client.ObjectKey{Name: cr.GetName(), Namespace: cr.GetNamespace()}, cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-	}
-
-	var exists bool
-	finalizers := cr.GetFinalizers()
-	for i, v := range finalizers {
-		if strings.TrimSpace(v) == legacyFinalizer {
-			exists = true
-
-			// Drop it.
-			cr.SetFinalizers(append(finalizers[:i], finalizers[i+1:]...))
-			break
-		}
-	}
-
-	if exists {
-		r.logger.Debugf(ctx, "deleting legacy finalizer from resource")
-
-		err := r.ctrlClient.Update(ctx, cr)
-		if err != nil {
-			return microerror.Mask(err)
-		}
-
-		r.logger.Debugf(ctx, "deleted legacy finalizer from resource")
-		return nil
-	}
-
-	r.logger.Debugf(ctx, "ensured resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
-
-	return nil
-}
-
-// EnsureDeleted is no-op.
-func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	return nil
 }
 
 // Name returns the resource name.

--- a/service/controller/resource/legacyfinalizer/resource.go
+++ b/service/controller/resource/legacyfinalizer/resource.go
@@ -1,0 +1,103 @@
+package legacyfinalizer
+
+import (
+	"context"
+	"strings"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+const (
+	Name = "finalizer"
+
+	// Finalizer of old operator's controller.
+	legacyFinalizer = "operatorkit.giantswarm.io/prometheus-meta-operator-control-plane-controller"
+)
+
+type Config struct {
+	CtrlClient client.Client
+	Logger     micrologger.Logger
+}
+
+// Resource does garbage collection on the AzureConfig CR finalizers.
+type Resource struct {
+	ctrlClient client.Client
+	logger     micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	if config.CtrlClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.CtrlClient must not be empty", config)
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	r := &Resource{
+		ctrlClient: config.CtrlClient,
+		logger:     config.Logger,
+	}
+
+	return r, nil
+}
+
+// EnsureCreated ensures that reconciled AzureConfig CR gets orphaned finalizer
+// deleted.
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	cr, err := key.ToClusterMR(obj)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "ensuring resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
+
+	{
+		// Refresh the CR object.
+		err := r.ctrlClient.Get(ctx, client.ObjectKey{Name: cr.GetName(), Namespace: cr.GetNamespace()}, cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+	}
+
+	var exists bool
+	finalizers := cr.GetFinalizers()
+	for i, v := range finalizers {
+		if strings.TrimSpace(v) == legacyFinalizer {
+			exists = true
+
+			// Drop it.
+			cr.SetFinalizers(append(finalizers[:i], finalizers[i+1:]...))
+			break
+		}
+	}
+
+	if exists {
+		r.logger.Debugf(ctx, "deleting legacy finalizer from resource")
+
+		err := r.ctrlClient.Update(ctx, cr)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		r.logger.Debugf(ctx, "deleted legacy finalizer from resource")
+		return nil
+	}
+
+	r.logger.Debugf(ctx, "ensured resource doesn't have orphaned prometheus-meta-operator-control-plane-controller finalizer present")
+
+	return nil
+}
+
+// EnsureDeleted is no-op.
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	return nil
+}
+
+// Name returns the resource name.
+func (r *Resource) Name() string {
+	return Name
+}

--- a/service/controller/resource/legacyfinalizer/resource.go
+++ b/service/controller/resource/legacyfinalizer/resource.go
@@ -18,7 +18,11 @@ type Config struct {
 	Logger     micrologger.Logger
 }
 
-// Resource does garbage collection on the AzureConfig CR finalizers.
+// Resource does garbage collection of the CR finalizers.
+// Since the control-plane-controller got renamed to management-cluster-controller
+// finalizers in place need to be updated. This resource achieve this by deleting
+// the old finalizer; new finalizer will be added by operatorkit.
+// TODO: remove this resource in next release.
 type Resource struct {
 	ctrlClient client.Client
 	logger     micrologger.Logger

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -275,7 +275,7 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 	}
 
 	if !key.IsInCluster(cluster) {
-		// Tenant cluster
+		// Workload cluster
 		prometheus.Spec.APIServerConfig = &promv1.APIServerConfig{
 			Host: fmt.Sprintf("https://%s", key.APIUrl(cluster)),
 			TLSConfig: &promv1.TLSConfig{
@@ -294,17 +294,17 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 				metav1.LabelSelectorRequirement{
 					Key:      "cluster_type",
 					Operator: metav1.LabelSelectorOpNotIn,
-					Values:   []string{"control_plane"},
+					Values:   []string{"management_cluster"},
 				},
 			},
 		}
 	} else {
-		// Control plane
+		// Management cluster
 		prometheus.Spec.APIServerConfig = &promv1.APIServerConfig{
 			Host:            fmt.Sprintf("https://%s", key.APIUrl(cluster)),
-			BearerTokenFile: key.ControlPlaneBearerToken(),
+			BearerTokenFile: key.BearerTokenPath(),
 			TLSConfig: &promv1.TLSConfig{
-				CAFile: key.ControlPlaneCAFile(),
+				CAFile: key.CAFilePath(),
 				SafeTLSConfig: promv1.SafeTLSConfig{
 					InsecureSkipVerify: true,
 				},

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: bob
-    cluster_type: tenant_cluster
+    cluster_type: workload_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
@@ -82,7 +82,7 @@ spec:
     - key: cluster_type
       operator: NotIn
       values:
-      - control_plane
+      - management_cluster
   rules:
     alert: {}
   secrets:

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: alice
-    cluster_type: tenant_cluster
+    cluster_type: workload_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
@@ -82,7 +82,7 @@ spec:
     - key: cluster_type
       operator: NotIn
       values:
-      - control_plane
+      - management_cluster
   rules:
     alert: {}
   secrets:

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: foo
-    cluster_type: tenant_cluster
+    cluster_type: workload_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
@@ -82,7 +82,7 @@ spec:
     - key: cluster_type
       operator: NotIn
       values:
-      - control_plane
+      - management_cluster
   rules:
     alert: {}
   secrets:

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: bar
-    cluster_type: tenant_cluster
+    cluster_type: workload_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
@@ -82,7 +82,7 @@ spec:
     - key: cluster_type
       operator: NotIn
       values:
-      - control_plane
+      - management_cluster
   rules:
     alert: {}
   secrets:

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: kubernetes
-    cluster_type: control_plane
+    cluster_type: management_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -33,7 +33,7 @@ spec:
   arbitraryFSAccessThroughSMs: {}
   externalLabels:
     cluster_id: baz
-    cluster_type: tenant_cluster
+    cluster_type: workload_cluster
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
@@ -82,7 +82,7 @@ spec:
     - key: cluster_type
       operator: NotIn
       values:
-      - control_plane
+      - management_cluster
   rules:
     alert: {}
   secrets:

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bob-prometheus/kubernetes-apiserver-bob/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -91,7 +90,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -142,7 +141,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -197,7 +196,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -276,7 +275,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -338,7 +337,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -386,7 +385,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -429,7 +428,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -499,7 +498,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -569,7 +568,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -637,7 +636,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -704,7 +703,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -773,7 +772,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -844,7 +843,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -915,7 +914,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -991,7 +990,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1062,7 +1061,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1149,7 +1148,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: alice-prometheus/kubernetes-apiserver-alice/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -91,7 +90,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -142,7 +141,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -197,7 +196,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -276,7 +275,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -338,7 +337,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -386,7 +385,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -429,7 +428,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -499,7 +498,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -569,7 +568,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -637,7 +636,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -704,7 +703,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -773,7 +772,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -844,7 +843,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -915,7 +914,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -991,7 +990,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1062,7 +1061,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1149,7 +1148,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: foo-prometheus/kubernetes-apiserver-foo/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -91,7 +90,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -142,7 +141,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -197,7 +196,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -276,7 +275,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -338,7 +337,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -386,7 +385,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -429,7 +428,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -499,7 +498,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -569,7 +568,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -637,7 +636,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -704,7 +703,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -773,7 +772,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -844,7 +843,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -915,7 +914,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -991,7 +990,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1062,7 +1061,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1149,7 +1148,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bar-prometheus/kubernetes-apiserver-bar/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -91,7 +90,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -142,7 +141,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -197,7 +196,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -276,7 +275,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -338,7 +337,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -386,7 +385,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -429,7 +428,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -499,7 +498,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -569,7 +568,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -637,7 +636,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -704,7 +703,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -773,7 +772,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -844,7 +843,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -915,7 +914,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -991,7 +990,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1062,7 +1061,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1149,7 +1148,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
   honor_labels: true
   scheme: https
@@ -24,7 +23,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -67,7 +66,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -115,7 +114,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -187,7 +186,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -242,7 +241,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -285,7 +284,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -321,7 +320,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -384,7 +383,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -447,7 +446,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -508,7 +507,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -568,7 +567,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -630,7 +629,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -694,7 +693,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -758,7 +757,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -827,7 +826,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -891,7 +890,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -971,7 +970,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1043,7 +1042,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1109,7 +1108,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1243,7 +1242,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1309,7 +1308,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1377,7 +1376,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1445,7 +1444,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1513,7 +1512,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1581,7 +1580,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1647,7 +1646,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1715,7 +1714,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1783,7 +1782,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1849,7 +1848,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1915,7 +1914,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1981,7 +1980,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2046,7 +2045,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2111,7 +2110,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2176,7 +2175,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2241,7 +2240,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2306,7 +2305,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2371,7 +2370,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2436,7 +2435,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2504,7 +2503,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2532,7 +2531,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2588,7 +2587,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2629,7 +2628,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -2660,7 +2659,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: baz-prometheus/kubernetes-apiserver-baz/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -91,7 +90,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -142,7 +141,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -197,7 +196,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -276,7 +275,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -338,7 +337,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -386,7 +385,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -429,7 +428,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -499,7 +498,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -569,7 +568,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -637,7 +636,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -704,7 +703,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -773,7 +772,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -844,7 +843,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -915,7 +914,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -991,7 +990,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1062,7 +1061,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1149,7 +1148,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws
@@ -1177,7 +1176,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: aws

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bob-prometheus/kubernetes-apiserver-bob/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -91,7 +90,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -142,7 +141,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -197,7 +196,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -276,7 +275,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -324,7 +323,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -367,7 +366,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -437,7 +436,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -507,7 +506,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -642,7 +641,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -711,7 +710,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -782,7 +781,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -853,7 +852,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -929,7 +928,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1000,7 +999,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1087,7 +1086,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1115,7 +1114,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: alice-prometheus/kubernetes-apiserver-alice/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -91,7 +90,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -142,7 +141,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -197,7 +196,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -276,7 +275,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -324,7 +323,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -367,7 +366,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -437,7 +436,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -507,7 +506,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -642,7 +641,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -711,7 +710,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -782,7 +781,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -853,7 +852,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -929,7 +928,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1000,7 +999,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1087,7 +1086,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1115,7 +1114,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: foo-prometheus/kubernetes-apiserver-foo/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -91,7 +90,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -142,7 +141,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -197,7 +196,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -276,7 +275,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -324,7 +323,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -367,7 +366,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -437,7 +436,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -507,7 +506,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -642,7 +641,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -711,7 +710,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -782,7 +781,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -853,7 +852,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -929,7 +928,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1000,7 +999,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1087,7 +1086,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1115,7 +1114,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bar-prometheus/kubernetes-apiserver-bar/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -91,7 +90,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -142,7 +141,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -197,7 +196,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -276,7 +275,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -324,7 +323,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -367,7 +366,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -437,7 +436,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -507,7 +506,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -642,7 +641,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -711,7 +710,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -782,7 +781,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -853,7 +852,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -929,7 +928,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1000,7 +999,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1087,7 +1086,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1115,7 +1114,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
   honor_labels: true
   scheme: https
@@ -24,7 +23,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -67,7 +66,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -115,7 +114,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -187,7 +186,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -230,7 +229,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -266,7 +265,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -329,7 +328,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -392,7 +391,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -453,7 +452,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -513,7 +512,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -639,7 +638,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -703,7 +702,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -772,7 +771,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -836,7 +835,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -916,7 +915,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -988,7 +987,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1054,7 +1053,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1122,7 +1121,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1188,7 +1187,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1254,7 +1253,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1322,7 +1321,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1390,7 +1389,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1458,7 +1457,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1526,7 +1525,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1592,7 +1591,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1660,7 +1659,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1728,7 +1727,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1794,7 +1793,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1860,7 +1859,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1926,7 +1925,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1991,7 +1990,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2056,7 +2055,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2121,7 +2120,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2186,7 +2185,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2251,7 +2250,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2316,7 +2315,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2381,7 +2380,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2450,7 +2449,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2501,7 +2500,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2528,7 +2527,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2584,7 +2583,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2625,7 +2624,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -2656,7 +2655,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: baz-prometheus/kubernetes-apiserver-baz/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -91,7 +90,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -142,7 +141,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -197,7 +196,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -276,7 +275,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -324,7 +323,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -367,7 +366,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -437,7 +436,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -507,7 +506,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -575,7 +574,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -642,7 +641,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -711,7 +710,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -782,7 +781,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -853,7 +852,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -929,7 +928,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1000,7 +999,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1087,7 +1086,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure
@@ -1115,7 +1114,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: azure

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bob-prometheus/kubernetes-apiserver-bob/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -83,7 +82,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -138,7 +137,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -217,7 +216,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -265,7 +264,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -308,7 +307,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -378,7 +377,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -448,7 +447,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -516,7 +515,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -583,7 +582,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -652,7 +651,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -723,7 +722,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -794,7 +793,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -870,7 +869,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -941,7 +940,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1028,7 +1027,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1056,7 +1055,7 @@
     replacement: bob
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: alice-prometheus/kubernetes-apiserver-alice/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -83,7 +82,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -138,7 +137,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -217,7 +216,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -265,7 +264,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -308,7 +307,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -378,7 +377,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -448,7 +447,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -516,7 +515,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -583,7 +582,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -652,7 +651,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -723,7 +722,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -794,7 +793,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -870,7 +869,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -941,7 +940,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1028,7 +1027,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1056,7 +1055,7 @@
     replacement: alice
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: foo-prometheus/kubernetes-apiserver-foo/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -83,7 +82,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -138,7 +137,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -217,7 +216,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -265,7 +264,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -308,7 +307,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -378,7 +377,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -448,7 +447,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -516,7 +515,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -583,7 +582,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -652,7 +651,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -723,7 +722,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -794,7 +793,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -870,7 +869,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -941,7 +940,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1028,7 +1027,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1056,7 +1055,7 @@
     replacement: foo
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: bar-prometheus/kubernetes-apiserver-bar/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -83,7 +82,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -138,7 +137,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -217,7 +216,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -265,7 +264,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -308,7 +307,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -378,7 +377,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -448,7 +447,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -516,7 +515,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -583,7 +582,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -652,7 +651,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -723,7 +722,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -794,7 +793,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -870,7 +869,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -941,7 +940,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1028,7 +1027,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1056,7 +1055,7 @@
     replacement: bar
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
   honor_labels: true
   scheme: https
@@ -24,7 +23,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -67,7 +66,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -115,7 +114,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -187,7 +186,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -230,7 +229,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -266,7 +265,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -329,7 +328,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -392,7 +391,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -453,7 +452,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -513,7 +512,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -575,7 +574,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -639,7 +638,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -703,7 +702,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -772,7 +771,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -836,7 +835,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -916,7 +915,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -988,7 +987,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1054,7 +1053,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1122,7 +1121,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1188,7 +1187,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1254,7 +1253,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1322,7 +1321,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1390,7 +1389,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1458,7 +1457,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1526,7 +1525,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1592,7 +1591,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1660,7 +1659,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1728,7 +1727,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1794,7 +1793,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1860,7 +1859,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1926,7 +1925,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1991,7 +1990,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2056,7 +2055,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2121,7 +2120,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2186,7 +2185,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2251,7 +2250,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2316,7 +2315,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2381,7 +2380,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2451,7 +2450,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2502,7 +2501,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2553,7 +2552,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2604,7 +2603,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2630,7 +2629,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2686,7 +2685,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2727,7 +2726,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -2758,7 +2757,7 @@
     replacement: kubernetes
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: control_plane
+    replacement: management_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -1,4 +1,3 @@
-# Additional scrape configuration for the tenant clusters components
 - job_name: baz-prometheus/kubernetes-apiserver-baz/0
   honor_labels: true
   scheme: https
@@ -31,7 +30,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -83,7 +82,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -138,7 +137,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -217,7 +216,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -265,7 +264,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -308,7 +307,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -378,7 +377,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -448,7 +447,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -516,7 +515,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -583,7 +582,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -652,7 +651,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -723,7 +722,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -794,7 +793,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -870,7 +869,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -941,7 +940,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1028,7 +1027,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm
@@ -1056,7 +1055,7 @@
     replacement: baz
   # Add cluster_type label.
   - target_label: cluster_type
-    replacement: tenant_cluster
+    replacement: workload_cluster
   # Add provider label.
   - target_label: provider
     replacement: kvm

--- a/service/controller/resource/servicemonitor/resource.go
+++ b/service/controller/resource/servicemonitor/resource.go
@@ -61,7 +61,7 @@ func toServiceMonitors(cluster metav1.Object, provider string, installation stri
 		service.NginxIngressController(cluster, provider, installation),
 	}
 
-	if (provider == "aws" || provider == "azure") && key.ClusterType(cluster) == "tenant_cluster" {
+	if (provider == "aws" || provider == "azure") && key.ClusterType(cluster) == "workload_cluster" {
 		serviceMonitors = append(serviceMonitors, service.ClusterAutoscaler(cluster, provider, installation))
 	}
 

--- a/service/controller/resource/servicemonitor/service/apiserver.go
+++ b/service/controller/resource/servicemonitor/service/apiserver.go
@@ -79,12 +79,12 @@ func APIServer(cluster metav1.Object, provider string, installation string) *pro
 		}
 	} else {
 		serviceMonitor.Spec.Endpoints[0].TLSConfig = &promv1.TLSConfig{
-			CAFile: key.ControlPlaneCAFile(),
+			CAFile: key.CAFilePath(),
 			SafeTLSConfig: promv1.SafeTLSConfig{
 				InsecureSkipVerify: true,
 			},
 		}
-		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.ControlPlaneBearerToken()
+		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.BearerTokenPath()
 	}
 
 	return serviceMonitor

--- a/service/controller/resource/servicemonitor/service/cluster_autoscaler.go
+++ b/service/controller/resource/servicemonitor/service/cluster_autoscaler.go
@@ -94,12 +94,12 @@ func ClusterAutoscaler(cluster metav1.Object, provider string, installation stri
 		}
 	} else {
 		serviceMonitor.Spec.Endpoints[0].TLSConfig = &promv1.TLSConfig{
-			CAFile: key.ControlPlaneCAFile(),
+			CAFile: key.CAFilePath(),
 			SafeTLSConfig: promv1.SafeTLSConfig{
 				InsecureSkipVerify: true,
 			},
 		}
-		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.ControlPlaneBearerToken()
+		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.BearerTokenPath()
 	}
 
 	return serviceMonitor

--- a/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
+++ b/service/controller/resource/servicemonitor/service/nginx-ingress-controller.go
@@ -11,7 +11,7 @@ import (
 
 func NginxIngressController(cluster metav1.Object, provider string, installation string) *promv1.ServiceMonitor {
 	var labelSelectors map[string]string
-	if key.ClusterType(cluster) == "control_plane" {
+	if key.ClusterType(cluster) == "management_cluster" {
 		labelSelectors = map[string]string{
 			"k8s-app": "nginx-ingress-controller",
 		}
@@ -103,12 +103,12 @@ func NginxIngressController(cluster metav1.Object, provider string, installation
 		}
 	} else {
 		serviceMonitor.Spec.Endpoints[0].TLSConfig = &promv1.TLSConfig{
-			CAFile: key.ControlPlaneCAFile(),
+			CAFile: key.CAFilePath(),
 			SafeTLSConfig: promv1.SafeTLSConfig{
 				InsecureSkipVerify: true,
 			},
 		}
-		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.ControlPlaneBearerToken()
+		serviceMonitor.Spec.Endpoints[0].BearerTokenFile = key.BearerTokenPath()
 	}
 
 	return serviceMonitor

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -153,17 +153,17 @@ func IsInCluster(obj interface{}) bool {
 
 func ClusterType(obj interface{}) string {
 	if IsInCluster(obj) {
-		return "control_plane"
+		return "management_cluster"
 	}
 
-	return "tenant_cluster"
+	return "workload_cluster"
 }
 
-func ControlPlaneBearerToken() string {
+func BearerTokenPath() string {
 	return "/var/run/secrets/kubernetes.io/serviceaccount/token"
 }
 
-func ControlPlaneCAFile() string {
+func CAFilePath() string {
 	return "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
 }
 

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 )
@@ -17,6 +18,20 @@ func ToCluster(obj interface{}) (metav1.Object, error) {
 	clusterMetaObject, ok := obj.(metav1.Object)
 	if !ok {
 		return nil, microerror.Maskf(wrongTypeError, "'%T' does not implements 'metav1.Object'", obj)
+	}
+
+	return clusterMetaObject, nil
+}
+
+type MetaRuner interface {
+	metav1.Object
+	runtime.Object
+}
+
+func ToClusterMR(obj interface{}) (MetaRuner, error) {
+	clusterMetaObject, ok := obj.(MetaRuner)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "'%T' does not implements 'MetaRuner'", obj)
 	}
 
 	return clusterMetaObject, nil


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15028

- renamed some alerts
- move controller/control-plane > controller/managementcluster
- removed control plane or tenant cluster notation in some places