### PR TITLE
Reenable cortex remote write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Reenable `Remote Write` to Cortex
+
 ## [1.15.0] - 2021-01-22
 
 ### Changed
@@ -114,13 +118,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add support to remote write to Cortex
+- Add support for `Remote Write` to Cortex
 - Added recording rules
 - Add node affinity to prefer not scheduling on master nodes
 - Added `pipeline` tag to _Hearbeat_ alert to be able to see if it affects
   a stable or testing installation at first glance
-- Added initial support for `remote_write` that will eventually be used for
-  writing to Cortex
 
 ### Changed
 

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -28,8 +28,8 @@ data:
         {{- range .Values.Installation.V1.Monitoring.Prometheus.Bastions }}
         - {{ . }}
         {{- end }}
-        # remoteWrite:
-        #   url: https://prometheus-us-central1.grafana.net/api/prom/push
+        remoteWrite:
+          url: https://prometheus-us-central1.grafana.net/api/prom/push
         retention:
           duration: 2w
           size: 90GB


### PR DESCRIPTION
Signed-off-by: QuentinBisson <quentin@giantswarm.io>

I upgraded the recording rules from g8s-prometheus.

I did not see any that we could  but a second pair of eyes could be useful