### PR TITLE
Fixes labels for gatekeeper alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed incorrect label in GatekeeperDown alert.
+
 ## [1.17.0] - 2021-02-02
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/up.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/up.rules.yml
@@ -40,7 +40,7 @@ spec:
             instance: {{ $labels.instance }}
           }`}}
         opsrecipe: gatekeeper-down/
-      expr: absent(up{app_name="gatekeeper-app"}) or up{app_name="gatekeeper-app"} == 0
+      expr: absent(up{app="gatekeeper-app"}) or up{app="gatekeeper-app"} == 0
       for: 10m
       labels:
         area: kaas


### PR DESCRIPTION
The older setup had the metric labelled with `app_name="gatekeeper-app"`, while the newer on has `app="gatekeeper-app"`. This aligns the alert with the new labelling schema.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR (N/A)
- [x] Updated changelog in `CHANGELOG.md`
