### PR TITLE
Add celestial rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the celestial rules to PMO:
   - `AzureClusterAutoscalerIsRestartingFrequently`
   - `AzureClusterCreationFailed`
-  - `AzureClusterWithNoAPIServer`
   - `AzureDeploymentIsRunningForTooLong`
   - `AzureDeploymentStatusFailed`
   - `AzureManagementClusterDeploymentScaledDownToZero`
@@ -39,7 +38,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `EtcdWorkloadClusterDownAzure`
   - `LatestETCDBackup1DayOld`
   - `LatestETCDBackup2DaysOld`
-  - `ManagementClusterDaemonSetNotSatisfiedCelestial`
   - `ManagementClusterNotBackedUp24h`
   - `MasterNodeMissingCelestial`
   - `OperatorNotReconcilingCelestial`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
 - Added the celestial rules to PMO:
   - `AzureClusterAutoscalerIsRestartingFrequently`
   - `AzureClusterCreationFailed`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `WorkloadClusterEtcdNumberOfLeaderChangesTooHighAzure`
   - `WritesRateLimitAlmostReached`
   - `ETCDBackupJobFailedOrStuck` (renamed from `BackupJobFailedOrStuck`)
+- Added node `role` label to `kubelet` metrics as it's needed by `MasterNodeMissingCelestial` alert
 
 ## [1.18.0] - 2021-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `WorkloadClusterEtcdHasNoLeaderAzure`
   - `WorkloadClusterEtcdNumberOfLeaderChangesTooHighAzure`
   - `WritesRateLimitAlmostReached`
-
+  - `ETCDBackupJobFailedOrStuck` (renamed from `BackupJobFailedOrStuck`)
 
 ## [1.18.0] - 2021-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added the celestial rules to PMO:
+  - `AzureClusterAutoscalerIsRestartingFrequently`
+  - `AzureClusterCreationFailed`
+  - `AzureClusterWithNoAPIServer`
+  - `AzureDeploymentIsRunningForTooLong`
+  - `AzureDeploymentStatusFailed`
+  - `AzureManagementClusterDeploymentScaledDownToZero`
+  - `AzureManagementClusterMissingNodes`
+  - `AzureNetworkErrorRateTooHigh`
+  - `AzureServicePrincipalExpirationDateUnknown`
+  - `AzureServicePrincipalExpiresInOneMonth`
+  - `AzureServicePrincipalExpiresInOneWeek`
+  - `AzureVMSSRateLimit30MinutesAlmostReached`
+  - `AzureVMSSRateLimit30MinutesReached`
+  - `AzureVMSSRateLimit3MinutesAlmostReached`
+  - `AzureVMSSRateLimit3MinutesReached`
+  - `ClockOutOfSyncAzure`
+  - `ClusterAutoscalerAppFailedAzure`
+  - `ClusterAutoscalerAppNotInstalledAzure`
+  - `ClusterAutoscalerAppPendingInstallAzure`
+  - `ClusterAutoscalerAppPendingUpgradeAzure`
+  - `ClusterWithNoResourceGroup`
+  - `CollidingOperatorsCelestial`
+  - `CriticalPodMetricMissingAzure`
+  - `CriticalPodNotRunningAzure`
+  - `DNSCheckErrorRateTooHighAzure`
+  - `DNSErrorRateTooHighAzure`
+  - `DeploymentNotSatisfiedCelestial`
+  - `EtcdWorkloadClusterDownAzure`
+  - `LatestETCDBackup1DayOld`
+  - `LatestETCDBackup2DaysOld`
+  - `ManagementClusterDaemonSetNotSatisfiedCelestial`
+  - `ManagementClusterNotBackedUp24h`
+  - `MasterNodeMissingCelestial`
+  - `OperatorNotReconcilingCelestial`
+  - `OperatorkitCRNotDeletedCelestial`
+  - `OperatorkitErrorRateTooHighCelestial`
+  - `PodLimitAlmostReachedAzure`
+  - `PodStuckAzure`
+  - `ReadsRateLimitAlmostReached`
+  - `VPNConnectionProvisioningStateBad`
+  - `VPNConnectionStatusBad`
+  - `WorkloadClusterEtcdCommitDurationTooHighAzure`
+  - `WorkloadClusterEtcdDBSizeTooLargeAzure`
+  - `WorkloadClusterEtcdHasNoLeaderAzure`
+  - `WorkloadClusterEtcdNumberOfLeaderChangesTooHighAzure`
+  - `WritesRateLimitAlmostReached`
+
+
 ## [1.18.0] - 2021-02-08
 
 ### Removed 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `OperatorkitCRNotDeletedCelestial`
   - `OperatorkitErrorRateTooHighCelestial`
   - `PodLimitAlmostReachedAzure`
-  - `PodStuckAzure`
+  - `ManagementClusterPodStuckAzure` (renamed from `PodStuckAzure`)
   - `ReadsRateLimitAlmostReached`
   - `VPNConnectionProvisioningStateBad`
   - `VPNConnectionStatusBad`

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -214,6 +214,7 @@
   - source_labels: [__address__]
     target_label: instance
 [[ include "_labelingschema" . | indent 2 ]]
+[[ include "_node_role" . | indent 2 ]]
 # kube-controller-manager
 - job_name: [[ .ClusterID ]]-prometheus/kubernetes-controller-manager-[[ .ClusterID ]]/0
   honor_labels: true

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.all.rules.yml
@@ -1,0 +1,64 @@
+{{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: azure.all.rules
+spec:
+  groups:
+  - name: azure
+    rules:
+    - alert: CriticalPodNotRunningAzure
+      annotations:
+        description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: kubernetes
+    - alert: CriticalPodMetricMissingAzure
+      annotations:
+        description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_kube_state_metrics_down: "true"
+        severity: page
+        team: celestial
+        topic: kubernetes
+    - alert: PodLimitAlmostReachedAzure
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: kubernetes
+    - alert: MasterNodeMissingCelestial
+      annotations:
+        description: '{{`Master node is missing.`}}'
+        opsrecipe: master-node-missing/
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        master_node_down: "true"
+        severity: page
+        team: celestial
+        topic: kubernetes
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.all.rules.yml
@@ -46,6 +46,20 @@ spec:
         severity: notify
         team: celestial
         topic: kubernetes
+    # MasterNodeMissingCelestial in this file is Azure specific and thus
+    # assigned to Team Celestial. The alert is also defined for all the other
+    # providers with other team assignments.
+    #
+    #     kubernetes_build_info{app="kubernetes"} gives us a vector of all the
+    #     apiservers.
+    #
+    #     kubernetes_build_info{app="kubelet", role="master"} gives us a vector
+    #     of all master node kubelets.
+    #
+    #     `unless` results in a vector consisting of the apiservers for which
+    #     there are no master kubelets, which we can then alert on. See
+    #     https://prometheus.io/docs/prometheus/latest/querying/operators.
+    #
     - alert: MasterNodeMissingCelestial
       annotations:
         description: '{{`Master node is missing.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
@@ -5,7 +5,8 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: azure.rules
+    cluster_type: "management_cluster"
+  name: azure.management-cluster.rules
 spec:
   groups:
   - name: azure
@@ -38,7 +39,7 @@ spec:
     - alert: ClusterAutoscalerAppFailedAzure
       annotations:
         description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in failed state.`}}'
-      expr: label_replace(app_operator_app_info{status="FAILED",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status="FAILED",name=~"cluster-autoscaler.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 10m
       labels:
         area: managedservices
@@ -51,7 +52,7 @@ spec:
     - alert: ClusterAutoscalerAppPendingInstallAzure
       annotations:
         description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in pending install state.`}}'
-      expr: label_replace(app_operator_app_info{status="PENDING_INSTALL",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status="PENDING_INSTALL",name=~"cluster-autoscaler.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 30m
       labels:
         area: managedservices
@@ -64,7 +65,7 @@ spec:
     - alert: ClusterAutoscalerAppPendingUpgradeAzure
       annotations:
         description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in pending upgrade state.`}}'
-      expr: label_replace(app_operator_app_info{status="PENDING_UPGRADE",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status="PENDING_UPGRADE",name=~"cluster-autoscaler.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 30m
       labels:
         area: managedservices
@@ -77,7 +78,7 @@ spec:
     - alert: ClusterAutoscalerAppNotInstalledAzure
       annotations:
         description: '{{`App {{ $labels.name }} was not installed in {{ $labels.namespace }} namespace.`}}'
-      expr: label_replace(app_operator_app_info{status="",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      expr: label_replace(app_operator_app_info{status="",name=~"cluster-autoscaler.*"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
       for: 40m
       labels:
         area: managedservices
@@ -98,43 +99,7 @@ spec:
         severity: notify
         team: celestial
         topic: azure
-    - alert: CriticalPodNotRunningAzure
-      annotations:
-        description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
-        opsrecipe: critical-pod-is-not-running/
-      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
-      for: 5m
-      labels:
-        area: kaas
-        severity: page
-        team: celestial
-        topic: kubernetes
-    - alert: CriticalPodMetricMissingAzure
-      annotations:
-        description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
-        opsrecipe: critical-pod-is-not-running/
-      expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_kube_state_metrics_down: "true"
-        severity: page
-        team: celestial
-        topic: kubernetes
-    - alert: PodLimitAlmostReachedAzure
-      annotations:
-        description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
-      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        severity: notify
-        team: celestial
-        topic: kubernetes
-    - alert: PodStuckAzure
+    - alert: ManagementClusterPodStuckAzure
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
       expr: kube_pod_status_phase{cluster_type="management_cluster", phase="Pending"} == 1
@@ -144,21 +109,6 @@ spec:
         severity: notify
         team: celestial
         topic: managementcluster
-    - alert: MasterNodeMissingCelestial
-      annotations:
-        description: '{{`Master node is missing.`}}'
-        opsrecipe: master-node-missing/
-      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        master_node_down: "true"
-        severity: page
-        team: celestial
-        topic: kubernetes
     - alert: VPNConnectionStatusBad
       annotations:
         description: '{{`VPC Connection is in connection status {{ $labels.connection_status }}.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.rules.yml
@@ -1,0 +1,287 @@
+{{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: azure.rules
+spec:
+  groups:
+  - name: azure
+    rules:
+    - alert: AzureDeploymentStatusFailed
+      annotations:
+        description: '{{`Azure deployment {{ $labels.deployment_name }} in cluster {{ $labels.cluster_id }} has status "Failed".`}}'
+        opsrecipe: azure-deployments-failed/
+      expr: azure_operator_deployment_status{status="Failed"} == 1
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: AzureDeploymentIsRunningForTooLong
+      annotations:
+        description: '{{`Azure deployment {{ $labels.deployment_name }} in cluster {{ $labels.cluster_id }} has status "Running" for too long.`}}'
+        opsrecipe: azure-deployments-failed/
+      expr: azure_operator_deployment_status{status="Running"} == 1
+      for: 60m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: ClusterAutoscalerAppFailedAzure
+      annotations:
+        description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in failed state.`}}'
+      expr: label_replace(app_operator_app_info{status="FAILED",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 10m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: releng
+    - alert: ClusterAutoscalerAppPendingInstallAzure
+      annotations:
+        description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in pending install state.`}}'
+      expr: label_replace(app_operator_app_info{status="PENDING_INSTALL",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: releng
+    - alert: ClusterAutoscalerAppPendingUpgradeAzure
+      annotations:
+        description: '{{`App {{ $labels.name }}, version {{ $labels.version }} is in pending upgrade state.`}}'
+      expr: label_replace(app_operator_app_info{status="PENDING_UPGRADE",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 30m
+      labels:
+        area: managedservices
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: releng
+    - alert: ClusterAutoscalerAppNotInstalledAzure
+      annotations:
+        description: '{{`App {{ $labels.name }} was not installed in {{ $labels.namespace }} namespace.`}}'
+      expr: label_replace(app_operator_app_info{status="",name="cluster-autoscaler"}, "cluster_id", "$1", "namespace", "(([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])*)") == 1
+      for: 40m
+      labels:
+        area: managedservices
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: releng
+    - alert: ClusterWithNoResourceGroup
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} does not have a Resource Group.`}}'
+      expr: (cluster_service_cluster_info or cluster_operator_cluster_status) unless on(cluster_id) label_replace(azure_operator_resource_group_info{name=~"[a-z0-9]{5}"}, "cluster_id", "$1", "name", "(.*)")
+      for: 15m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: CriticalPodNotRunningAzure
+      annotations:
+        description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: kubernetes
+    - alert: CriticalPodMetricMissingAzure
+      annotations:
+        description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
+        opsrecipe: critical-pod-is-not-running/
+      expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_kube_state_metrics_down: "true"
+        severity: page
+        team: celestial
+        topic: kubernetes
+    - alert: PodLimitAlmostReachedAzure
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} is almost exceeding its pod limit.`}}'
+      expr: (sum(kube_pod_info) by (cluster_id) / sum(kube_node_status_capacity_pods) by (cluster_id)) > 0.8
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: kubernetes
+    - alert: PodStuckAzure
+      annotations:
+        description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
+      expr: kube_pod_status_phase{cluster_type="management_cluster", phase="Pending"} == 1
+      for: 15m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: managementcluster
+    - alert: MasterNodeMissingCelestial
+      annotations:
+        description: '{{`Master node is missing.`}}'
+        opsrecipe: master-node-missing/
+      expr: kubernetes_build_info{app="kubelet"} unless on(cluster_id) kubernetes_build_info{app="kubelet", role="master"}
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        master_node_down: "true"
+        severity: page
+        team: celestial
+        topic: kubernetes
+    - alert: VPNConnectionStatusBad
+      annotations:
+        description: '{{`VPC Connection is in connection status {{ $labels.connection_status }}.`}}'
+      expr: azure_operator_vpn_connection_info{connection_status!="Connected"}
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: VPNConnectionProvisioningStateBad
+      annotations:
+        description: '{{`VPC Connection is in provisioning state {{ $labels.provisioning_state }}.`}}'
+      expr: azure_operator_vpn_connection_info{provisioning_state!="Succeeded"}
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: ReadsRateLimitAlmostReached
+      annotations:
+        description: '{{`Azure API reads rate limit (12000 requests per hour) is almost reached on subscription {{ $labels.subscription }} for client {{ $labels.clientid }}.`}}'
+        opsrecipe: azure-service-principals/
+      expr: (azure_operator_rate_limit_reads / 12000) * 100 < 10
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: azure
+    - alert: WritesRateLimitAlmostReached
+      annotations:
+        description: '{{`Azure API writes rate limit (1200 requests per hour) is almost reached on subscription {{ $labels.subscription }} for client {{ $labels.clientid }}.`}}'
+        opsrecipe: azure-service-principals/
+      expr: (azure_operator_rate_limit_writes / 1200) * 100 < 10
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: azure
+    - alert: AzureVMSSRateLimit3MinutesAlmostReached
+      annotations:
+        description: '{{`Error 429: We almost hit the 3 minutes limit for the Azure API.`}}'
+        opsrecipe: azure-api-throttling-429/
+      expr: azure_operator_rate_limit_vmss_instance_list{countername="Microsoft.Compute/HighCostGetVMScaleSet3Min"} < (180*0.2)
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: observability
+    - alert: AzureVMSSRateLimit30MinutesAlmostReached
+      annotations:
+        description: '{{`Error 429: We almost hit the 30 minutes limit for the Azure API.`}}'
+        opsrecipe: azure-api-throttling-429/
+      expr: azure_operator_rate_limit_vmss_instance_list{countername="Microsoft.Compute/HighCostGetVMScaleSet30Min"} < (900*0.2)
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: observability
+    - alert: AzureVMSSRateLimit3MinutesReached
+      annotations:
+        description: '{{`Error 429: We hit the 3 minutes limit for the Azure API, the whole subscription is affected.`}}'
+        opsrecipe: azure-api-throttling-429/
+      expr: azure_operator_rate_limit_vmss_instance_list{countername="Microsoft.Compute/HighCostGetVMScaleSet3Min"} < 1
+      for: 1m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: observability
+    - alert: AzureVMSSRateLimit30MinutesReached
+      annotations:
+        description: '{{`Error 429: We hit the 30 minutes limit for the Azure API, the whole subscription is affected.`}}'
+        opsrecipe: azure-api-throttling-429/
+      expr: azure_operator_rate_limit_vmss_instance_list{countername="Microsoft.Compute/HighCostGetVMScaleSet30Min"} < 1
+      for: 1m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: observability
+    - alert: AzureServicePrincipalExpiresInOneMonth
+      annotations:
+        description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} will expire in less than one month.`}}'
+        opsrecipe: azure-service-principals/
+      expr: min(azure_operator_service_principal_token_expiration - time()) by (application_name,subscription_id) < 60*60*24*30
+      for: 10m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: AzureServicePrincipalExpiresInOneWeek
+      annotations:
+        description: '{{`Azure service principal for app {{ $labels.application_name }} in subscription {{ $labels.subscription_id }} is about to expire.`}}'
+        opsrecipe: azure-service-principals/
+      expr: min(azure_operator_service_principal_token_expiration - time()) by (application_name,subscription_id) < 60*60*24*7
+      for: 10m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: azure
+    - alert: AzureServicePrincipalExpirationDateUnknown
+      annotations:
+        description: '{{`Unable to check expiration date for azure service principal app (client) ID {{ $labels.client_id }} in subscription {{ $labels.subscription_id }}.`}}'
+        opsrecipe: azure-service-principals/
+      expr: max(azure_operator_service_principal_token_check_failed) by (client_id,subscription_id) == 1
+      for: 10m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: azure
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cloud.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cloud.rules.yml
@@ -4,6 +4,7 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: cloud.rules
 spec:
   groups:

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cloud.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cloud.rules.yml
@@ -1,0 +1,23 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: cloud.rules
+spec:
+  groups:
+  - name: cloud
+    rules:
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: AzureManagementClusterMissingNodes
+      annotations:
+        description: '{{`Management cluster {{ $labels.cluster_id }} has less than 4 minimum nodes.`}}'
+      expr: label_replace(sum(kube_node_status_condition{cluster_type="management_cluster", condition="Ready", status="true", provider="azure"}) by (cluster_id), "cluster_id", "$1", "cluster_id", "(.*)") < 4
+      for: 15m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: managementcluster
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cluster-autoscaler.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cluster-autoscaler.rules.yml
@@ -1,0 +1,25 @@
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: cluster-autoscaler.rules
+spec:
+  groups:
+  - name: cluster-autoscaler
+    rules:
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: AzureClusterAutoscalerIsRestartingFrequently
+      annotations:
+        description: '{{`Cluster-Autoscaler {{ $labels.cluster_id }}/{{ $labels.pod_name }} /{{ $labels.pod }} is restarting often.`}}'
+        opsrecipe: cluster-autoscaler-is-restarting-often/
+      expr: increase(kube_pod_container_status_restarts_total{container="cluster-autoscaler", provider="azure"}[3h]) > 3
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: kubernetes
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cluster-service.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cluster-service.rules.yml
@@ -14,6 +14,7 @@ spec:
       annotations:
         description: '{{`Number of keypairs limit almost reached in cluster-service storageconfig`}}'
         opsrecipe: https://github.com/giantswarm/giantswarm/pull/11618
+      # Observed max CR record was hit at ~2800 entries
       expr: cluster_service_key_pair_total > 2400
       for: 10m
       labels:

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cluster.rules.yml
@@ -26,7 +26,9 @@ spec:
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} creation is taking longer than expected.`}}'
         opsrecipe: cluster-creation-failed/
-      expr: (statusresource_cluster_status{app="azure-operator", status="Creating"} == 1 or cluster_operator_cluster_status{app="cluster-operator", status="Updating", provider="azure"} == 1)
+      # statusresource_cluster_status{app="azure-operator.*", status="Creating"} give us a vector with all cluster statuses
+      # in Azure clusters which stays at 'Creating' state.
+      expr: (statusresource_cluster_status{app=~"azure-operator.*", status="Creating"} == 1 or cluster_operator_cluster_status{app=~"cluster-operator.*", status="Updating", provider="azure"} == 1)
       for: 40m
       labels:
         area: kaas
@@ -34,19 +36,5 @@ spec:
         severity: notify
         team: celestial
         topic: azure
-    - alert: AzureClusterWithNoAPIServer
-      annotations:
-        description: '{{`Cluster {{ $labels.cluster_id }} has no api server.`}}'
-        opsrecipe: no-workload-cluster-metric/
-      expr: sum(cluster_service_cluster_info{provider="azure"} or cluster_operator_cluster_status{provider="azure"}) by (cluster_id) unless on(cluster_id)label_replace(up{app="kubernetes", cluster_type="workload_cluster"}==1, "cluster_id", "$1", "cluster_id", "(.*)")
-      for: 1h
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        severity: notify
-        team: celestial
-        topic: kubernetes
     {{- end }}
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/cluster.rules.yml
@@ -21,3 +21,32 @@ spec:
         severity: page
         team: biscuit
         topic: managementcluster
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: AzureClusterCreationFailed
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} creation is taking longer than expected.`}}'
+        opsrecipe: cluster-creation-failed/
+      expr: (statusresource_cluster_status{app="azure-operator", status="Creating"} == 1 or cluster_operator_cluster_status{app="cluster-operator", status="Updating", provider="azure"} == 1)
+      for: 40m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: celestial
+        topic: azure
+    - alert: AzureClusterWithNoAPIServer
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} has no api server.`}}'
+        opsrecipe: no-workload-cluster-metric/
+      expr: sum(cluster_service_cluster_info{provider="azure"} or cluster_operator_cluster_status{provider="azure"}) by (cluster_id) unless on(cluster_id)label_replace(up{app="kubernetes", cluster_type="workload_cluster"}==1, "cluster_id", "$1", "cluster_id", "(.*)")
+      for: 1h
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: celestial
+        topic: kubernetes
+    {{- end }}
+

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
@@ -31,3 +31,15 @@ spec:
         severity: notify
         team: atlas
         topic: managementcluster
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: ManagementClusterDaemonSetNotSatisfiedCelestial
+      annotations:
+        description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
+      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", daemonset=~"azure-imds-agent-app"} > 0
+      for: 30m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: managementcluster
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
@@ -31,15 +31,3 @@ spec:
         severity: notify
         team: atlas
         topic: managementcluster
-    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
-    - alert: ManagementClusterDaemonSetNotSatisfiedCelestial
-      annotations:
-        description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
-      expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", daemonset=~"azure-imds-agent-app"} > 0
-      for: 30m
-      labels:
-        area: kaas
-        severity: notify
-        team: celestial
-        topic: managementcluster
-    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.management-cluster.rules.yml
@@ -89,4 +89,30 @@ spec:
         severity: page
         team: biscuit
         topic: managementcluster
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: AzureManagementClusterDeploymentScaledDownToZero
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} on Azure has been scaled down to zero for prolonged period of time.`}}'
+      expr: kube_deployment_status_replicas_available{cluster_type="management_cluster", deployment=~"([a-z]*)-operator([a-z,-]*)",provider="azure"} + kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"([a-z]*)-operator([a-z,-]*)",provider="azure"} == 0
+      for: 4h
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: managementcluster
+    - alert: DeploymentNotSatisfiedCelestial
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment=~"azure-admission-controller-.+|azure-operator.*|azure-collector.*"} > 0
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: celestial
+        topic: managementcluster
+    {{- end }}
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.management-cluster.rules.yml
@@ -82,7 +82,7 @@ spec:
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
         opsrecipe: deployment-not-satisfied-china/
-      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"coredns|nginx-ingress-controller|.+-admission-controller-unique", cluster_id=~"axolotl|giraffe|argali"} > 0
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="management_cluster", deployment!~"coredns|nginx-ingress-controller|alertmanager.*|prometheus.*|promxy.*|.+-admission-controller-unique", cluster_id=~"axolotl|giraffe|argali"} > 0
       for: 3h
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.management-cluster.rules.yml
@@ -5,22 +5,11 @@ metadata:
   labels:
     {{- include "labels.common" . | nindent 4 }}
     cluster_type: "management_cluster"
-  name: etcd.rules
+  name: etcd.management-cluster.rules
 spec:
   groups:
   - name: etcd
     rules:
-    - alert: BackupJobFailedOrStuck
-      annotations:
-        description: '{{`Job {{ $labels.job }} failed or has not been completed for more than 30 minutes.`}}'
-        opsrecipe: etcd-backup-failed/
-      expr: kube_job_failed{cluster_type="management_cluster",condition="true",job=~"etcd-backup.+"} == 1 or kube_pod_status_phase{cluster_type="management_cluster",phase="Pending",pod=~"etcd-backup.+"} == 1 or kube_job_status_succeeded{cluster_type="management_cluster",job=~"etcd-backup.+"} == 0
-      for: 30m
-      labels:
-        area: kaas
-        severity: page
-        team: biscuit
-        topic: etcd
     - alert: ManagementClusterEtcdCommitDurationTooHigh
       annotations:
         description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.workload-cluster.rules.yml
@@ -1,0 +1,56 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "workload_cluster"
+  name: etcd.workload-cluster.rules
+spec:
+  groups:
+  - name: etcd
+    rules:
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: WorkloadClusterEtcdCommitDurationTooHighAzure
+      annotations:
+        description: '{{`Etcd ({{ $labels.instance }}) has a too high commit duration.`}}'
+        opsrecipe: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/etcd-high-commit-duration/
+      expr: histogram_quantile(0.95, rate(etcd_disk_backend_commit_duration_seconds_bucket{cluster_type="workload_cluster", provider="azure"}[5m])) > 1.0
+      for: 15m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: etcd
+    - alert: WorkloadClusterEtcdDBSizeTooLargeAzure
+      annotations:
+        description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
+        opsrecipe: etcd-db-size-too-large/
+      expr: etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster", provider="azure"} > 500 * 1024 * 1024
+      for: 10m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: etcd
+    - alert: WorkloadClusterEtcdNumberOfLeaderChangesTooHighAzure
+      annotations:
+        description: '{{`Etcd has too many leader changes.`}}'
+      expr: increase(etcd_server_leader_changes_seen_total{cluster_type="workload_cluster",provider="azure"}[1h]) > 8
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: etcd
+    - alert: WorkloadClusterEtcdHasNoLeaderAzure
+      annotations:
+        description: '{{`Etcd has no leader.`}}'
+        opsrecipe: etcd-has-no-leader/
+      expr: etcd_server_has_leader{cluster_type="workload_cluster", provider="azure"} == 0
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: etcd
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
@@ -1,0 +1,65 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: etcdbackup.rules
+spec:
+  groups:
+  - name: etcdbackup
+    rules:
+    - alert: BackupJobFailedOrStuck
+      annotations:
+        description: '{{`Job {{ $labels.job }} failed or has not been completed for more than 30 minutes.`}}'
+        opsrecipe: etcd-backup-failed/
+      expr: kube_job_failed{cluster_type="management_cluster",condition="true",job=~"etcd-backup.+"} == 1 or kube_pod_status_phase{cluster_type="management_cluster",phase="Pending",pod=~"etcd-backup.+"} == 1 or kube_job_status_succeeded{cluster_type="management_cluster",job=~"etcd-backup.+"} == 0
+      for: 30m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: etcd
+    - alert: LatestETCDBackup1DayOld
+      annotations:
+        description: '{{`Latest successfull ETCD backup for {{ $labels.cluster_id }}/{{ $labels.tenant_cluster_id }} was more than 24h ago.`}}'
+        opsrecipe: etcd-backup-failed/
+      expr: (time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) > 24 * 60 * 60 and (time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) < 48 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: celestial
+        topic: etcd-backup
+    - alert: LatestETCDBackup2DaysOld
+      annotations:
+        description: '{{`Latest successfull ETCD backup for {{ $labels.cluster_id }}/{{ $labels.tenant_cluster_id }} was more than 48h ago.`}}'
+        opsrecipe: etcd-backup-failed/
+      expr: (time() - etcd_backup_latest_success{tenant_cluster_id!="Control Plane"}) > 48 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: celestial
+        topic: etcd-backup
+    - alert: ManagementClusterNotBackedUp24h
+      annotations:
+        description: '{{`{{ $labels.cluster_id }} management cluster''s ETCD backup was unsuccessful.`}}'
+        opsrecipe: etcd-backup-failed/
+      expr: time() - etcd_backup_latest_success{etcd_version="v2",tenant_cluster_id="Control Plane"} > 60*60*24 or time() - etcd_backup_latest_success{etcd_version="v3",tenant_cluster_id="Control Plane"} > 60*60*24
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: page
+        team: celestial
+        topic: etcd-backup

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
@@ -4,12 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
   name: etcdbackup.rules
 spec:
   groups:
   - name: etcdbackup
     rules:
-    - alert: BackupJobFailedOrStuck
+    - alert: ETCDBackupJobFailedOrStuck
       annotations:
         description: '{{`Job {{ $labels.job }} failed or has not been completed for more than 30 minutes.`}}'
         opsrecipe: etcd-backup-failed/
@@ -53,7 +54,7 @@ spec:
       annotations:
         description: '{{`{{ $labels.cluster_id }} management cluster''s ETCD backup was unsuccessful.`}}'
         opsrecipe: etcd-backup-failed/
-      expr: time() - etcd_backup_latest_success{etcd_version="v2",tenant_cluster_id="Control Plane"} > 60*60*24 or time() - etcd_backup_latest_success{etcd_version="v3",tenant_cluster_id="Control Plane"} > 60*60*24
+      expr: time() - etcd_backup_latest_success{etcd_version="V2",tenant_cluster_id="Control Plane"} > 60*60*24 or time() - etcd_backup_latest_success{etcd_version="V3",tenant_cluster_id="Control Plane"} > 60*60*24
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/ingress-controller.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/ingress-controller.rules.yml
@@ -35,21 +35,6 @@ spec:
         severity: notify
         team: batman
         topic: ingress
-        ## TODO remove?
-    - alert: IngressControllerReloadIsFailing
-      annotations:
-        description: '{{`Ingress Controller cannot reload new configuration. Please check IC logs.`}}'
-        opsrecipe: ic-failed-to-reload/
-      expr: increase(ingress_controller_errors{count="reloads"}[5m]) > 1
-      for: 5m
-      labels:
-        area: managedservices
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        severity: notify
-        team: batman
-        topic: ingress
     - alert: IngressControllerReplicaSetNumberTooHigh
       annotations:
         description: '{{`Ingress Controller ReplicaSet in namespace {{ $labels.namespace}} has {{ $value }} pods.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/microendpoint.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/microendpoint.rules.yml
@@ -37,7 +37,7 @@ spec:
       annotations:
         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
         opsrecipe: multiple-operators-running-same-version/
-      expr: sum(label_replace(giantswarm_build_info{app=~"azure-operator"}, "version", "$1", "reconciled_version", "(.+)")) by (app, cluster_id, version) > 1
+      expr: sum(label_replace(giantswarm_build_info{app=~"azure-operator.*"}, "version", "$1", "reconciled_version", "(.+)")) by (app, cluster_id, version) > 1
       for: 5m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/microendpoint.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/microendpoint.rules.yml
@@ -33,3 +33,14 @@ spec:
         severity: page
         team: batman
         topic: releng
+    - alert: CollidingOperatorsCelestial
+      annotations:
+        description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
+        opsrecipe: multiple-operators-running-same-version/
+      expr: sum(label_replace(giantswarm_build_info{app=~"azure-operator"}, "version", "$1", "reconciled_version", "(.+)")) by (app, cluster_id, version) > 1
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: releng

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/network.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/network.rules.yml
@@ -1,0 +1,61 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: network.rules
+spec:
+  groups:
+  - name: network
+    rules:
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: DNSErrorRateTooHighAzure
+      annotations:
+        description: '{{`DNS error rate is too high for {{ or $labels.pod_name $labels.instance }} to {{ $labels.host }}, using {{ $labels.proto }}.`}}'
+        opsrecipe: network-error/
+      expr: rate(dns_resolve_error_total{provider="azure"}[15m]) > 0.015
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_with_no_nodepools: "true"
+        cancel_if_cluster_with_notready_nodepools: "true"
+        cancel_if_cluster_with_scaling_nodepools: "true"
+        severity: page
+        team: celestial
+        topic: network
+    - alert: DNSCheckErrorRateTooHighAzure
+      annotations:
+        description: '{{`DNS check error rate is too high for {{ or $labels.pod_name $labels.instance }}.`}}'
+        opsrecipe: network-error/
+      expr: rate(dns_error_total{provider="azure"}[15m]) > 0.015
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_with_no_nodepools: "true"
+        cancel_if_cluster_with_notready_nodepools: "true"
+        cancel_if_cluster_with_scaling_nodepools: "true"
+        severity: page
+        team: celestial
+        topic: network
+    - alert: AzureNetworkErrorRateTooHigh
+      annotations:
+        description: '{{`Network error rate is too high for {{ or $labels.pod_name $labels.instance }} to {{ $labels.host }}.`}}'
+        opsrecipe: network-error/
+      expr: rate(network_dial_error_total{provider="azure"}[15m]) > 0.002
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_cluster_with_no_nodepools: "true"
+        cancel_if_cluster_with_notready_nodepools: "true"
+        cancel_if_cluster_with_scaling_nodepools: "true"
+        cancel_if_nodes_down: "true"
+        severity: page
+        team: celestial
+        topic: network
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
@@ -35,3 +35,37 @@ spec:
         severity: notify
         team: batman
         topic: releng
+    - alert: OperatorkitErrorRateTooHighCelestial
+      annotations:
+        description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
+        opsrecipe: check-operator-error-rate-high/
+      expr: operatorkit_controller_error_total{app=~"azure-operator"} > 5
+      for: 1m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: qa
+    - alert: OperatorkitCRNotDeletedCelestial
+      annotations:
+        description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
+        opsrecipe: check-not-deleted-object/
+      expr: (time() - operatorkit_controller_deletion_timestamp{app=~"azure-operator|cluster-operator", provider="azure"}) > 18000
+      for: 5m
+      labels:
+        area: kaas
+        severity: notify
+        team: celestial
+        topic: qa
+    - alert: OperatorNotReconcilingCelestial
+      annotations:
+        description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'
+        opsrecipe: operator-not-reconciling/
+      expr: (sum by (instance, app, app_version, namespace)(increase(operatorkit_controller_event_count{app=~"azure-operator"}[10m])) == 0 and on (instance) (operatorkit_controller_deletion_timestamp or operatorkit_controller_creation_timestamp))
+      for: 20m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: notify
+        team: celestial
+        topic: qa

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
@@ -46,6 +46,10 @@ spec:
         severity: page
         team: celestial
         topic: qa
+    # Celestial
+    # It might happen that CRs get orphaned or deletion gets kind of stuck during
+    # the cleanup process. Then we want to get notified and figure out what went
+    # wrong to fix the root cause eventually.
     - alert: OperatorkitCRNotDeletedCelestial
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
@@ -57,6 +61,8 @@ spec:
         severity: notify
         team: celestial
         topic: qa
+    # In case something stops an operator from reconciling CRs we want to
+    # be paged to be able to fix the issue immediately.
     - alert: OperatorNotReconcilingCelestial
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
@@ -39,7 +39,7 @@ spec:
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
         opsrecipe: check-operator-error-rate-high/
-      expr: operatorkit_controller_error_total{app=~"azure-operator"} > 5
+      expr: operatorkit_controller_error_total{app=~"azure-operator.*"} > 5
       for: 1m
       labels:
         area: kaas
@@ -50,7 +50,7 @@ spec:
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has not deleted object {{ $labels.namespace }}/{{ $labels.name }} of type {{ $labels.kind }} for too long.`}}'
         opsrecipe: check-not-deleted-object/
-      expr: (time() - operatorkit_controller_deletion_timestamp{app=~"azure-operator|cluster-operator", provider="azure"}) > 18000
+      expr: (time() - operatorkit_controller_deletion_timestamp{app=~"azure-operator.*|cluster-operator.*", provider="azure"}) > 18000
       for: 5m
       labels:
         area: kaas
@@ -61,7 +61,7 @@ spec:
       annotations:
         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has stopped the reconciliation. Please check logs.`}}'
         opsrecipe: operator-not-reconciling/
-      expr: (sum by (instance, app, app_version, namespace)(increase(operatorkit_controller_event_count{app=~"azure-operator"}[10m])) == 0 and on (instance) (operatorkit_controller_deletion_timestamp or operatorkit_controller_creation_timestamp))
+      expr: (sum by (instance, app, app_version, namespace)(increase(operatorkit_controller_event_count{app=~"azure-operator.*"}[10m])) == 0 and on (instance) (operatorkit_controller_deletion_timestamp or operatorkit_controller_creation_timestamp))
       for: 20m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/timesync.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/timesync.rules.yml
@@ -1,0 +1,24 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: timesync.rules
+spec:
+  groups:
+  - name: timesync
+    rules:
+    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
+    - alert: ClockOutOfSyncAzure
+      annotations:
+        description: '{{`Clock is out of sync on {{ $labels.instance }}.`}}'
+        opsrecipe: clock-out-of-sync/
+      expr: timestamp(node_time_seconds{provider="azure"}) - node_time_seconds{provider="azure"} > 60
+      for: 30m
+      labels:
+        area: kaas
+        severity: page
+        team: celestial
+        topic: infrastructure
+    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
@@ -26,20 +26,3 @@ spec:
         severity: page
         team: batman
         topic: releng
-    {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
-    - alert: EtcdWorkloadClusterDownAzure
-      annotations:
-        description: '{{`Etcd ({{ $labels.instance }}) on workload cluster {{ $labels.cluster_id }} is down.`}}'
-        opsrecipe: etcd-down/
-      expr: up{cluster_type="workload_cluster", instance=~"etcd.*", provider="azure"} == 0
-      for: 20m
-      labels:
-        area: kaas
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_master_node_down: "true"
-        severity: page
-        team: celestial
-        topic: etcd
-    {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/up.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/up.workload-cluster.rules.yml
@@ -4,28 +4,13 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-  name: up.all.rules
+    cluster_type: "workload_cluster"
+  name: up.workload-cluster.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:
   groups:
   - name: up
     rules:
-    - alert: ChartOperatorDown
-      annotations:
-        description: '{{`ChartOperator ({{ $labels.instance }}) is down.`}}'
-        opsrecipe: chart-operator-down/
-      expr: up{app=~"chart-operator.*"} == 0
-      for: 15m
-      labels:
-        area: managedservices
-        cancel_if_apiserver_down: "true"
-        cancel_if_cluster_status_creating: "true"
-        cancel_if_cluster_status_deleting: "true"
-        cancel_if_cluster_status_updating: "true"
-        cancel_if_scrape_timeout: "true"
-        severity: page
-        team: batman
-        topic: releng
     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
     - alert: EtcdWorkloadClusterDownAzure
       annotations:

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -437,6 +437,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -437,6 +437,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -437,6 +437,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -437,6 +437,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -329,6 +329,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -437,6 +437,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -375,6 +375,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -375,6 +375,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -375,6 +375,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -375,6 +375,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -274,6 +274,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -375,6 +375,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -316,6 +316,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -316,6 +316,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -316,6 +316,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -316,6 +316,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -274,6 +274,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -316,6 +316,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # If role is empty, we default to worker
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: null
+    target_label: role
+    replacement: worker
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true


### PR DESCRIPTION
Add the generated rules to PMO towards https://github.com/giantswarm/giantswarm/issues/13763

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`

Diff: 

```diff

colordiff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files helm/prometheus-meta-operator/templates/prometheus-rules
Only in helm/prometheus-meta-operator/templates/prometheus-rules: alertmanager.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: app.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/azure.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/azure.rules.yml
0a1
> {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
285a287
> {{- end }}
Only in helm/prometheus-meta-operator/templates/prometheus-rules: calico.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: certificate.all.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: certificate.management-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: cert-manager.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: chart.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/cloud.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/cloud.rules.yml
11a12
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
21a23
>     {{- end }}
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/cluster-autoscaler.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/cluster-autoscaler.rules.yml
0a1
> 
11a13
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
22a25
>     {{- end }}
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/cluster.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/cluster.rules.yml
6a7
>     cluster_type: "management_cluster"
11a13,24
>     - alert: ManagementClusterHasLessThanThreeNodes
>       annotations:
>         description: '{{`Management cluster {{ $labels.cluster_id }} has less than 3 nodes.`}}'
>         opsrecipe: management-cluster-less-than-three-workers/
>       expr: sum(kube_node_labels{cluster_type="management_cluster", label_role="worker"}) < 3
>       for: 1h
>       labels:
>         area: kaas
>         severity: page
>         team: biscuit
>         topic: managementcluster
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
37a51,52
>     {{- end }}
> 
Only in helm/prometheus-meta-operator/templates/prometheus-rules: cluster-service.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: configmap.management-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: configmap.workload-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: crsync.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/daemonset.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/daemonset.rules.yml
6a7
>     cluster_type: "management_cluster"
7a9
>   namespace: '{{ include "resource.default.namespace" . }}'
11a14,34
>     - alert: ManagementClusterDaemonSetNotSatisfiedAtlas
>       annotations:
>         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
>       expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id!="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
>       for: 30m
>       labels:
>         area: kaas
>         severity: notify
>         team: atlas
>         topic: managementcluster
>     - alert: ManagementClusterDaemonSetNotSatisfiedChinaAtlas
>       annotations:
>         description: '{{`Daemonset {{ $labels.namespace}}/{{ $labels.daemonset }} is not satisfied.`}}'
>       expr: kube_daemonset_status_number_unavailable{cluster_type="management_cluster", cluster_id="axolotl|giraffe|argali", daemonset=~"fluentbit"} > 0
>       for: 3h
>       labels:
>         area: kaas
>         severity: notify
>         team: atlas
>         topic: managementcluster
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
21a45
>     {{- end }}
Only in helm/prometheus-meta-operator/templates/prometheus-rules: deployment.management-cluster.rules.yml
Only in /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files: deployment.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: deployment.workload-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: draughtsman.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: elasticsearch.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/etcdbackup.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
11a12,22
>     - alert: BackupJobFailedOrStuck
>       annotations:
>         description: '{{`Job {{ $labels.job }} failed or has not been completed for more than 30 minutes.`}}'
>         opsrecipe: etcd-backup-failed/
>       expr: kube_job_failed{cluster_type="management_cluster",condition="true",job=~"etcd-backup.+"} == 1 or kube_pod_status_phase{cluster_type="management_cluster",phase="Pending",pod=~"etcd-backup.+"} == 1 or kube_job_status_succeeded{cluster_type="management_cluster",job=~"etcd-backup.+"} == 0
>       for: 30m
>       labels:
>         area: kaas
>         severity: page
>         team: celestial
>         topic: etcd
Only in helm/prometheus-meta-operator/templates/prometheus-rules: etcd.management-cluster.rules.yml
Only in /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files: etcd.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: etcd.workload-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: external-dns.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: fluentbit.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: gatekeeper.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: helm.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: ingress-controller.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: inhibit.all.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: inhibit.management-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: managed-apps-basic-sli.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: managed-logging.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: management-cluster.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/microendpoint.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/microendpoint.rules.yml
6a7
>     cluster_type: "management_cluster"
7a9
>   namespace: '{{ include "resource.default.namespace" . }}'
11a14,35
>     - alert: CollidingOperatorsAtlas
>       annotations:
>         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
>         opsrecipe: multiple-operators-running-same-version/
>       expr: sum(label_replace(giantswarm_build_info{app=~"prometheus-meta-operator.*"}, "version", "$1", "reconciled_version", "(.+)")) by (app, cluster_id, version) > 1
>       for: 5m
>       labels:
>         area: empowerment
>         severity: page
>         team: atlas
>         topic: releng
>     - alert: CollidingOperatorsBatman
>       annotations:
>         description: '{{`CR version {{ $labels.version }} in cluster {{ $labels.cluster_id }} is reconciled by multiple apps including {{ $labels.app }}.`}}'
>         opsrecipe: multiple-operators-running-same-version/
>       expr: sum(label_replace(giantswarm_build_info{app=~"app-operator.*|chart-operator.*"}, "version", "$1", "reconciled_version", "(.+)")) by (app, cluster_id, version) > 1
>       for: 5m
>       labels:
>         area: managedservices
>         severity: page
>         team: batman
>         topic: releng
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/network.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/network.rules.yml
11a12
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
59a61
>     {{- end }}
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/operatorkit.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
6a7
>     cluster_type: "management_cluster"
7a9
>   namespace: '{{ include "resource.default.namespace" . }}'
11a14,37
>     - alert: OperatorkitErrorRateTooHighBatman
>       annotations:
>         description: '{{`{{ $labels.namespace }}/{{ $labels.app }}@{{ $labels.app_version }} has reported errors. Please check the logs.`}}'
>         opsrecipe: check-operator-error-rate-high/
>       expr: operatorkit_controller_error_total{app=~"app-operator.*|chart-operator.*"} > 5
>       for: 1m
>       labels:
>         area: kaas
>         severity: notify
>         team: batman
>         topic: qa
>     - alert: OperatorNotReconcilingBatman
>       annotations:
>         description: |-
>           {{`{{$labels.app_name}} (version {{$labels.app_version}}) not reconciling controller
>           {{$labels.controller}}.
>           `}}
>       expr: (time() - operatorkit_controller_last_reconciled{app=~"app-operator.*|chart-operator.*"}) / 60 > 30
>       for: 10m
>       labels:
>         area: managedservices
>         severity: notify
>         team: batman
>         topic: releng
Only in helm/prometheus-meta-operator/templates/prometheus-rules: prometheus-meta-operator.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: prometheus.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: secret.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: systemd.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: tiller.all.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: tiller.workload-cluster.rules.yml
diff /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files/timesync.rules.yml helm/prometheus-meta-operator/templates/prometheus-rules/timesync.rules.yml
11a12
>     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
22a24
>     {{- end }}
Only in helm/prometheus-meta-operator/templates/prometheus-rules: up.all.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: up.management-cluster.rules.yml
Only in /home/quentin/Documents/code/g8s-prometheus/tool/transform-rules/files: up.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: up.workload-cluster.rules.yml
Only in helm/prometheus-meta-operator/templates/prometheus-rules: vault.rules.yml
```


I will start testing the rules