### PR TITLE
Apply prometheus rule group to Workload Clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apply prometheus rule group (which includes
+  `PrometheusCantCommunicateWithKubernetesAPI` alert) to Workload Clusters
+
 ## [1.23.0] - 2021-02-17
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Prometheus can''t communicate with Kubernetes API.`}}'
         opsrecipe: prometheus-cant-communicate/
-      expr: rate(prometheus_sd_kubernetes_http_request_total{app!="promxy-app-unique", status_code="<error>"}[15m]) > 2
+      expr: rate(prometheus_sd_kubernetes_http_request_total{app!="promxy-app-unique", status_code="<error>"}[15m]) > 0.25
       for: 15m
       labels:
         area: empowerment

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   labels:
     {{- include "labels.common" . | nindent 4 }}
-    cluster_type: "management_cluster"
   name: prometheus.rules
   namespace: '{{ include "resource.default.namespace" . }}'
 spec:


### PR DESCRIPTION
That defines `PrometheusCantCommunicateWithKubernetesAPI` alert and it
should apply to Workload Cluster Prometheuses so that we get alerted if
they can't communicate with the Kubernetes API of the cluster they are
responsible for.

Closes: https://github.com/giantswarm/giantswarm/issues/15534

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
