### PR TITLE
inhibit-updating-10min-after

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved inhibition alert `InhibitionClusterStatusUpdating` to  inhibit alerts 10 minutes after the update has finished to avoid unecessery pages.
+
 ## [1.20.0] - 2021-02-16
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.management-cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
     - alert: InhibitionClusterStatusUpdating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updating''.`}}'
-      expr: statusresource_cluster_status{status="Updating"} == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or changes(statusresource_cluster_status{status="Updating"}[10m]) != 0 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) != 0
+      expr: statusresource_cluster_status{status="Updating"} == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or changes(statusresource_cluster_status{status="Updating"}[10m]) == 1 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) == 1
       labels:
         area: kaas
         cluster_status_updating: "true"

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.management-cluster.rules.yml
@@ -32,7 +32,7 @@ spec:
     - alert: InhibitionClusterStatusUpdating
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} has status condition ''Updating''.`}}'
-      expr: statusresource_cluster_status{status="Updating"} == 1 or cluster_operator_cluster_status{status="Updating"} == 1
+      expr: statusresource_cluster_status{status="Updating"} == 1 or cluster_operator_cluster_status{status="Updating"} == 1 or changes(statusresource_cluster_status{status="Updating"}[10m]) != 0 or changes(cluster_operator_cluster_status{status="Updating"}[10m]) != 0
       labels:
         area: kaas
         cluster_status_updating: "true"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/15764


To avoid pages that happens right after the update of a cluster.
 I am adjusting the inhibition alert to inhibit the alert 10 mins after the update finished.

We often see an update finished but the error counters are still high or error budged be still depleted right after the update finished and this causes pages that resolve in a few minutes. 


function `changes()` will be equal to 1 in case there was a change of the value over a period of the time (in our case 10 minutes)

So when the update finishes the value of the metric will change from 1 to 0 but the inhibition will still work for 10 minutes. This will have no effect on the start of the inhibition since we don't drop the old rules.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
