### PR TITLE
Add firecracker EBSVolumeMountErrors alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Migrate and rename `EBSVolumeMountErrors` to `ManagementClusterEBSVolumeMountErrors` and `WorkloadClusterEBSVolumeMountErrors`
+
 ## [1.21.0] - 2021-02-16
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.management-cluster.rules.yml
@@ -73,6 +73,20 @@ spec:
         severity: page
         team: firecracker
         topic: aws
+    - alert: ManagementClusterEBSVolumeMountErrors
+      annotations:
+        description: '{{`EBS Volume mount error on the node {{ $labels.instance }}.`}}'
+        opsrecipe: aws-volume-mount-issues/
+      expr: rate(storage_operation_errors_total{volume_plugin="kubernetes.io/aws-ebs"}[15m]) > 0
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: firecracker
+        topic: aws
     - alert: NATGatewaysPerVPCApproachingLimit
       annotations:
         description: '{{`AWS number of NAT Gateways for {{ $labels.vpc }} in account {{ $labels.account_id }} is too close to limit.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
@@ -11,6 +11,20 @@ spec:
   groups:
   - name: aws
     rules:
+    - alert: WorkloadClusterEBSVolumeMountErrors
+      annotations:
+        description: '{{`EBS Volume mount error on the node {{ $labels.instance }}.`}}'
+        opsrecipe: aws-volume-mount-issues/
+      expr: rate(storage_operation_errors_total{volume_plugin="kubernetes.io/aws-ebs"}[15m]) > 0
+      for: 30m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        severity: notify
+        team: firecracker
+        topic: aws
     - alert: WorkloadClusterContainerIsRestartingTooFrequentlyFirecracker
       annotations:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'


### PR DESCRIPTION
Refactor the EBSVolumeMountErrors to only need workload cluster info

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
