### PR TITLE
firecracker-cirtical-pod-improvement

### DIFF
--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
@@ -40,22 +40,13 @@ spec:
       annotations:
         description: '{{`Critical pod {{ $labels.namespace }}/{{ $labels.pod }} is not running.`}}'
         opsrecipe: critical-pod-is-not-running/
-      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1
+      expr: kube_pod_container_status_running{container=~"(k8s-api-server|k8s-controller-manager|k8s-scheduler)"} != 1 or absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
       for: 5m
       labels:
         area: kaas
-        severity: page
-        team: firecracker
-        topic: kubernetes
-    - alert: WorkloadClusterCriticalPodMetricMissingAWS
-      annotations:
-        description: '{{`Critical pod {{ $labels.container }} does not have metrics.`}}'
-        opsrecipe: critical-pod-is-not-running/
-      expr: absent(kube_pod_container_status_running{container="k8s-api-server"}) == 1 or absent(kube_pod_container_status_running{container="k8s-controller-manager"}) == 1 or absent(kube_pod_container_status_running{container="k8s-scheduler"}) == 1
-      for: 5m
-      labels:
-        area: kaas
-        cancel_if_kube_state_metrics_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
         severity: page
         team: firecracker
         topic: kubernetes


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/15614

merge both alerts into one, since they are related and should page if the critical pod is not running as expected



## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
