### PR TITLE
Don't alert on WC PVs running out of space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Discover ETCD targets through the LoadBalancer using the `giantswarm.io/etcd-domain` annotation
 
+### Fixed
+
+- Remove `PersistentVolumeSpaceTooLow` from Workload Clusters.
+
 ## [1.23.0] - 2021-02-17
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/disk.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/disk.workload-cluster.rules.yml
@@ -57,18 +57,6 @@ spec:
         severity: page
         team: ludacris
         topic: storage
-    - alert: PersistentVolumeSpaceTooLow
-      annotations:
-        description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
-        opsrecipe: low-disk-space/#persistent-volume
-      expr: 100 * node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} < 10
-      for: 10m
-      labels:
-        area: kaas
-        cancel_if_outside_working_hours: "true"
-        severity: page
-        team: ludacris
-        topic: storage
     - alert: RootVolumeSpaceTooLow
       annotations:
         description: '{{`Root volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'


### PR DESCRIPTION
This PR:

- removes `PersistentVolumeSpaceTooLow` from WC clusters - it was accidentally added when alerts were migrated over.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] ~Separated out refactoring/reformatting in a dedicated PR~
- [x] Updated changelog in `CHANGELOG.md`
