### PR TITLE
move-cluster-auto-scaler-app-install-failure-to-batman

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add `ManagementClusterPodStuckCelestial` alert for Celestial.
 - Send samples per second to cortex
 
+### Changed
+
+- Move Cluster Autoscaller app installation/upgrade related alerts to team Batman.
+
 ## [1.23.1] - 2021-02-22
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/app.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/app.rules.yml
@@ -136,7 +136,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: firecracker
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppNotInstalledAWS
       annotations:
@@ -150,7 +150,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: firecracker
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppPendingInstallAWS
       annotations:
@@ -163,7 +163,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: firecracker
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppPendingUpgradeAWS
       annotations:
@@ -176,7 +176,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: firecracker
+        team: batman
         topic: releng
     {{- end }}
     {{- if eq .Values.Installation.V1.Provider.Kind "azure" }}
@@ -191,7 +191,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: celestial
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppPendingInstallAzure
       annotations:
@@ -204,7 +204,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: celestial
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppPendingUpgradeAzure
       annotations:
@@ -217,7 +217,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: celestial
+        team: batman
         topic: releng
     - alert: ClusterAutoscalerAppNotInstalledAzure
       annotations:
@@ -231,7 +231,7 @@ spec:
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
         severity: notify
-        team: celestial
+        team: batman
         topic: releng
     {{- end }}
     - alert: AppWithoutTeamLabel


### PR DESCRIPTION
These alerts are usually related to app-operator/chart-operator process and we do not feel responsible for a potential fix in case these components do not work properly so transferring the alert to batman as they manage the process.

discussion happened on slack: https://gigantic.slack.com/archives/CRZN9GLJW/p1614068260030900


The alert is now anyway in `severity: notify` so it does not page, I will leave it to you if you wanna make it paging on not.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`

towards https://github.com/giantswarm/giantswarm/issues/15613