### PR TITLE
Fix syntax errors in `management-cluster.rules`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed syntax error in expressions of `ManagementClusterPodPending*` alerts
+
 ## [1.24.0] - 2021-02-23
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
     - alert: ManagementClusterPodPendingFor15Min
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'
-      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending",pod~!"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
+      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending",pod!~"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
       for: 15m
       labels:
         area: kaas
@@ -25,7 +25,7 @@ spec:
       annotations:
         description: '{{`Pod {{ $labels.pod }} is stuck in Pending.`}}'
         opsrecipe: management-cluster-pod-pending/
-      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending", pod~!"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
+      expr: (kube_pod_status_phase{cluster_type="management_cluster", phase="Pending", pod!~"(aws-operator.*|azure-operator.*|cluster-operator.*)", namespace!~".*-prometheus"} * on (pod,namespace) group_left(node) kube_pod_info{}) == 1
       for: 1h
       labels:
         area: kaas


### PR DESCRIPTION
The expressions of `ManagementClusterPodPending*` alerts used syntax
`pod~!"..."` which is incorrect and causes _prometheus-operator_
admission controller to reject the rules and fail the deployment.
The correct syntax is `pod!~"..."`. This changes the expressions to use
that.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
