### PR TITLE
add catalog label to app-exporter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add 'catalog' label to metrics pushed from `app-exporter` to cortex
+
 ## [1.24.1] - 2021-02-23
 
 ### Fixed

--- a/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
@@ -34,9 +34,9 @@ spec:
     # GS Rest API requests
     - expr: sum(rate(nginx_ingress_controller_requests{namespace="giantswarm", ingress="api"}[5m])) by (status)
       record: aggregation:giantswarm:api_requests
-    - expr: count(app_operator_app_info{status="deployed",namespace="giantswarm"}) by (name,version)
+    - expr: count(app_operator_app_info{status="deployed",namespace="giantswarm"}) by (name,version,catalog)
       record: aggregation:giantswarm:app_deployed_management_cluster_total
-    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (name,version)
+    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (name,version,catalog)
       record: aggregation:giantswarm:app_deployed_workload_cluster_total
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)
       record: aggregation:giantswarm:cluster_certificate_not_after_seconds


### PR DESCRIPTION
This PR adds one more label ('catalog') to the metrics exported to cortex from `app-exporter`.
