### PR TITLE
Use resident memory for docker memory alerting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use `resident_memory` when calculating docker memory usage.
+
 ## [1.24.2] - 2021-02-24
 
 ### Added
@@ -334,7 +338,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.18.0] - 2021-02-08
 
-### Removed 
+### Removed
 
 - Added the batman alerts to PMO:
   - `AppExporterDown`

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/docker.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/docker.management-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Docker memory usage on {{ $labels.instance }} is too high.`}}'
         opsrecipe: docker-memory-usage-high
-      expr: process_virtual_memory_bytes{app="docker", cluster_type="management_cluster"} > (5 * 1024 * 1024 * 1024)
+      expr: process_resident_memory_bytes{app="docker", cluster_type="management_cluster"} > (5 * 1024 * 1024 * 1024)
       for: 15m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/docker.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/docker.workload-cluster.rules.yml
@@ -14,7 +14,7 @@ spec:
       annotations:
         description: '{{`Docker memory usage on {{ $labels.instance }} is too high.`}}'
         opsrecipe: docker-memory-usage-high
-      expr: process_virtual_memory_bytes{app="docker", cluster_type="workload_cluster"} > (5 * 1024 * 1024 * 1024)
+      expr: process_resident_memory_bytes{app="docker", cluster_type="workload_cluster"} > (5 * 1024 * 1024 * 1024)
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
We noticed that virtual memory does not make sense and does not reflect what systemd thinks.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
