### PR TITLE
Avoid alerting for ETCD backups outside business hours.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Avoid alerting for ETCD backups outside business hours.
+
 ## [1.24.3] - 2021-02-24
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcdbackup.rules.yml
@@ -47,6 +47,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: celestial
         topic: etcd-backup
@@ -61,6 +62,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: celestial
         topic: etcd-backup


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15936

why this change is being introduced: Joe asked for this, who are we to say no to Joe?

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
