### PR TITLE
added app label for metrics going from app-exporter to cortex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Set the prometheus UI Web page title.
+- Add 'app' label to metrics pushed from `app-exporter` to cortex
 
 ## [1.24.4] - 2021-02-26
 

--- a/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
@@ -34,9 +34,9 @@ spec:
     # GS Rest API requests
     - expr: sum(rate(nginx_ingress_controller_requests{namespace="giantswarm", ingress="api"}[5m])) by (status)
       record: aggregation:giantswarm:api_requests
-    - expr: count(app_operator_app_info{status="deployed",namespace="giantswarm"}) by (name,version,catalog)
+    - expr: count(app_operator_app_info{status="deployed",namespace="giantswarm"}) by (app,name,version,catalog)
       record: aggregation:giantswarm:app_deployed_management_cluster_total
-    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (name,version,catalog)
+    - expr: count(app_operator_app_info{status=~"deployed|DEPLOYED",namespace!="giantswarm"}) by (app,name,version,catalog)
       record: aggregation:giantswarm:app_deployed_workload_cluster_total
     - expr: min(cert_exporter_not_after) by (cluster_id, cluster_type)
       record: aggregation:giantswarm:cluster_certificate_not_after_seconds


### PR DESCRIPTION
Added:

* 'app' label for metrics going from app-exporter to cortex
