### PR TITLE
fix: Inhibit  when kube-state-metrics is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Inhibit `MatchingNumberOfPrometheusAndCluster` when kube-state-metrics is down
+  to prevent bogus pages when `kube_pod_container_status_running` metric
+  isn't available
 
 ## [1.24.5] - 2021-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Inhibit `MatchingNumberOfPrometheusAndCluster` when kube-state-metrics is down
+
 ## [1.24.5] - 2021-03-02
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -29,6 +29,7 @@ spec:
       for: 10m
       labels:
         area: "empowerment"
+        cancel_if_kube_state_metrics_down: "true"
         installation: {{ .Values.Installation.V1.Name }}
         severity: "page"
         team: "atlas"


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/15948

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
