### PR TITLE
Add aggregation for use of legacy login method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support to copy CAPI cluster's certificates
+- Add aggregation `aggregation:giantswarm:api_auth_giantswarm_successful_attempts_total`.
 
 ## [1.24.6] - 2021-03-02
 

--- a/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
@@ -25,7 +25,7 @@ spec:
     # Spot Instances being used
     - expr: count(sum(aws_operator_ec2_instance_status{lifecycle != ""}) by (ec2_instance, lifecycle)) by  (lifecycle)
       record: aggregation:aws:instance_lifecycle
-    # REST API usage: authentications successfull via the "giantswarm" token method
+    # REST API usage: authentications successful via the "giantswarm" token method
     - expr: sum(rate(api_service_authentication_giantswarm_successful_attempts_total[5m]))
       record: aggregation:giantswarm:api_auth_giantswarm_successful_attempts_total
     # REST API usage: authentication fails via the "giantswarm" token method

--- a/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
@@ -25,10 +25,13 @@ spec:
     # Spot Instances being used
     - expr: count(sum(aws_operator_ec2_instance_status{lifecycle != ""}) by (ec2_instance, lifecycle)) by  (lifecycle)
       record: aggregation:aws:instance_lifecycle
-    # API usage: authentication fails via the "giantswarm" auth method (customers)
+    # REST API usage: authentications successfull via the "giantswarm" token method
+    - expr: sum(rate(api_service_authentication_giantswarm_successful_attempts_total[5m]))
+      record: aggregation:giantswarm:api_auth_giantswarm_successful_attempts_total
+    # REST API usage: authentication fails via the "giantswarm" token method
     - expr: sum(rate(api_service_authentication_giantswarm_failed_attempts_total[5m]))
       record: aggregation:giantswarm:api_auth_giantswarm_failed_attempts_total
-    # API usage: authentication fails via the "Bearer" auth method (staff)
+    # API usage: authentication fails via the "Bearer" auth method (SSO)
     - expr: sum(rate(api_service_authentication_jwt_failed_attempts_total[5m]))
       record: aggregation:giantswarm:api_auth_jwt_failed_attempts_total
     # GS Rest API requests


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/218

In order to know in which installations the legacy authentication mechanism is still in use, we add an aggregation for a new metric of the REST API (added via https://github.com/giantswarm/api/pull/1242).

Plus a tiny bit of comment updating on related aggregations.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Updated changelog in `CHANGELOG.md`
