### PR TITLE
Increase memory limits to 1.2 * memory requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Push to `shared-app-collection`
 - Rename `EtcdWorkloadClusterDown` to `WorkloadClusterEtcdDown`
+- Increased memory limits by 1.2 factor
 
 ### Fixed
 

--- a/service/controller/resource/prometheus/resource.go
+++ b/service/controller/resource/prometheus/resource.go
@@ -145,13 +145,6 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 
 	labels["giantswarm.io/monitoring"] = "true"
 
-	prometheusResourceList := corev1.ResourceList{
-		// cpu: 100m
-		corev1.ResourceCPU: *key.PrometheusDefaultCPU(),
-		// memory: 1Gi
-		corev1.ResourceMemory: *key.PrometheusDefaultMemory(),
-	}
-
 	image := fmt.Sprintf("%s/giantswarm/prometheus:%s", config.Registry, config.PrometheusVersion)
 	pageTitle := fmt.Sprintf("%s/%s Prometheus", config.Installation, key.ClusterID(cluster))
 	prometheus := &promv1.Prometheus{
@@ -178,8 +171,18 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 			},
 			Replicas: &replicas,
 			Resources: corev1.ResourceRequirements{
-				Requests: prometheusResourceList,
-				Limits:   prometheusResourceList,
+				Requests: corev1.ResourceList{
+					// cpu: 100m
+					corev1.ResourceCPU: *key.PrometheusDefaultCPU(),
+					// memory: 1Gi
+					corev1.ResourceMemory: *key.PrometheusDefaultMemory(),
+				},
+				Limits: corev1.ResourceList{
+					// cpu: 100m
+					corev1.ResourceCPU: *key.PrometheusDefaultCPU(),
+					// memory: 1.2Gi
+					corev1.ResourceMemory: *key.PrometheusMemoryLimit(),
+				},
 			},
 			Retention:      config.RetentionDuration,
 			RetentionSize:  config.RetentionSize,

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/prometheus/test/case-0-cluster-api.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /bob

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/prometheus/test/case-1-awsconfig.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /alice

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /foo

--- a/service/controller/resource/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/prometheus/test/case-2-azureconfig.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /bar

--- a/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/prometheus/test/case-3-kvmconfig.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/prometheus/test/case-4-control-plane.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /kubernetes

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -67,7 +67,7 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1Gi
+      memory: 1228Mi
     requests:
       cpu: 100m
       memory: 1Gi

--- a/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -67,10 +67,10 @@ spec:
   resources:
     limits:
       cpu: 100m
-      memory: 1228Mi
+      memory: "1287651328"
     requests:
       cpu: 100m
-      memory: 1Gi
+      memory: "1073741824"
   retention: 2w
   retentionSize: 45Gi
   routePrefix: /baz

--- a/service/controller/resource/verticalpodautoscaler/test/case-0-cluster-api.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-0-cluster-api.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/controller/resource/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/controller/resource/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/controller/resource/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/controller/resource/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/controller/resource/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -15,7 +15,7 @@ spec:
         memory: "9"
       minAllowed:
         cpu: 100m
-        memory: 1Gi
+        memory: "1073741824"
       mode: Auto
     - containerName: prometheus-config-reloader
       mode: "Off"

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -99,6 +99,10 @@ func PrometheusDefaultMemory() *resource.Quantity {
 	return resource.NewQuantity(1024*1024*1024, resource.BinarySI)
 }
 
+func PrometheusMemoryLimit() *resource.Quantity {
+	return resource.NewQuantity(1024*1024*1228, resource.BinarySI)
+}
+
 func PrometheusPort() int32 {
 	return 9090
 }

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -96,11 +96,11 @@ func PrometheusDefaultCPU() *resource.Quantity {
 }
 
 func PrometheusDefaultMemory() *resource.Quantity {
-	return resource.NewQuantity(1024*1024*1024, resource.BinarySI)
+	return resource.NewQuantity(1024*1024*1024, resource.DecimalSI)
 }
 
 func PrometheusMemoryLimit() *resource.Quantity {
-	return resource.NewQuantity(1024*1024*1228, resource.BinarySI)
+	return resource.NewQuantity(1024*1024*1228, resource.DecimalSI)
 }
 
 func PrometheusPort() int32 {


### PR DESCRIPTION
This is an attempt at raising memory limits, to give prometheus more room and avoid OOMKill.

I raised the memory limit to 1.2 * memory request so (limits: 1.2G, request: 1G). VPA will always conserve this ratio when computing request/limits.

Tested on `anteater`:

```
$ k get po -lapp=prometheus -oyaml|yq -y '.items[].spec.containers[]|select(.name == "prometheus").resources'
limits:
  cpu: 163m
  memory: 12743276984089m
requests:
  cpu: 163m
  memory: '10626315661'
$ numfmt --to=si 12743276984 10626315661
13G
11G
```

`12743276984089m` stands for `12743276984.089 bytes` I believe.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Updated changelog in `CHANGELOG.md`
