### PR TITLE
Removes expensive unnecessary systemd rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed memory-intensive notify only systemd alerts.
+
 ## [1.26.0] - 2021-03-24
 
-### Changed 
+### Changed
 
 - Push to `shared-app-collection`
 - Rename `EtcdWorkloadClusterDown` to `WorkloadClusterEtcdDown`
@@ -40,7 +44,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add support for monitoring vmware clusters
 - Add support to get the API Server URL for both legacy and CAPI clusters
 
-### Changed 
+### Changed
 
 - Upgrade ingress version to networking.k8s.io/v1beta1
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/systemd.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/systemd.management-cluster.rules.yml
@@ -10,16 +10,6 @@ spec:
   groups:
   - name: systemd
     rules:
-    - alert: ManagementClusterSystemdUnitFailed
-      annotations:
-        description: '{{`Systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
-      expr: node_systemd_unit_state{cluster_type="management_cluster",name!~"coreos-metadata-sshkeys@core.service|debug-tools.service|k8s-addons.service|locksmithd.service|sshd.+service|systemd-coredump.+service|systemd-networkd.service|update-engine.service|update-engine-stub.service", state="failed"} == 1
-      for: 5m
-      labels:
-        area: kaas
-        severity: notify
-        team: biscuit
-        topic: infrastructure
     - alert: ManagementClusterCriticalSystemdUnitFailed
       annotations:
         description: '{{`Critical systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
@@ -40,15 +30,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: biscuit
-        topic: infrastructure
-    - alert: ManagementClusterHighNumberSystemdUnits
-      annotations:
-        description: '{{`Node {{ $labels.ip }} has too many systemd units active.`}}'
-      expr: sum(node_systemd_unit_state{cluster_type="management_cluster", state="active"}) by (ip) > 1500
-      for: 10m
-      labels:
-        area: kaas
-        severity: notify
         team: biscuit
         topic: infrastructure

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/systemd.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/systemd.workload-cluster.rules.yml
@@ -10,16 +10,6 @@ spec:
   groups:
   - name: systemd
     rules:
-    - alert: WorkloadClusterSystemdUnitFailed
-      annotations:
-        description: '{{`Systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
-      expr: node_systemd_unit_state{cluster_type="workload_cluster",name!~"coreos-metadata-sshkeys@core.service|debug-tools.service|k8s-addons.service|locksmithd.service|sshd.+service|systemd-coredump.+service|systemd-networkd.service|update-engine.service|update-engine-stub.service", state="failed"} == 1
-      for: 5m
-      labels:
-        area: kaas
-        severity: notify
-        team: ludacris
-        topic: infrastructure
     - alert: WorkloadClusterCriticalSystemdUnitFailed
       annotations:
         description: '{{`Critical systemd unit {{ $labels.name }} is failed on {{ $labels.instance }}.`}}'
@@ -40,15 +30,5 @@ spec:
       labels:
         area: kaas
         severity: page
-        team: ludacris
-        topic: infrastructure
-    - alert: WorkloadClusterHighNumberSystemdUnits
-      annotations:
-        description: '{{`Node {{ $labels.ip }} has too many systemd units active.`}}'
-      expr: sum(node_systemd_unit_state{cluster_type="workload_cluster", state="active"}) by (ip) > 1500
-      for: 10m
-      labels:
-        area: kaas
-        severity: notify
         team: ludacris
         topic: infrastructure


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16428

These alerts are notify only, and are some of the most expensive in terms of memory in the entire system. Removing to improve overall performance (and reduce heartbeat failures).

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
