### PR TITLE
fix follow_redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove follow_redirects from alertmanager config
   - Update prometheus/alertmanger@v0.21.0
-  - Update prometheus/commond@v0.17.0
+  - Update prometheus/common@v0.17.0
 
 ## [1.27.0] - 2021-03-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove follow_redirects from alertmanager config
+  - Update prometheus/alertmanger@v0.21.0
+  - Update prometheus/commond@v0.17.0
 
 ## [1.27.0] - 2021-03-24
 

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,10 @@ require (
 	github.com/giantswarm/versionbundle v0.2.0
 	github.com/go-kit/kit v0.10.0
 	github.com/go-logr/logr v0.3.0 // indirect
+	github.com/go-openapi/errors v0.20.0 // indirect
+	github.com/go-openapi/runtime v0.19.26 // indirect
+	github.com/go-openapi/validate v0.20.2 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-cmp v0.5.5
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gnostic v0.5.3 // indirect
@@ -28,14 +32,16 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus-operator/prometheus-operator v0.43.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0
-	github.com/prometheus/alertmanager v0.21.1-0.20210321154706-72deec44a869
-	github.com/prometheus/client_golang v1.10.0
-	github.com/prometheus/common v0.20.0
+	github.com/prometheus/client_golang v1.9.0
+	github.com/prometheus/common v0.17.0
+	github.com/prometheus/procfs v0.6.0 // indirect
 	github.com/prometheus/prometheus v2.23.0+incompatible
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/crypto v0.0.0-20201208171446-5f87f3452ae9 // indirect
 	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
+	golang.org/x/sys v0.0.0-20210309074719-68d13333faf2 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -194,7 +194,6 @@ github.com/cenkalti/backoff v2.1.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QH
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/cenkalti/backoff/v4 v4.0.2/go.mod h1:eEew/i+1Q6OrCDZh3WiXYv3+nJwBASZ8Bog/87DQnVg=
-github.com/cenkalti/backoff/v4 v4.1.0/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -545,7 +544,6 @@ github.com/gocql/gocql v0.0.0-20200121121104-95d072f1b5bb/go.mod h1:DL0ekTmBSTdl
 github.com/gocql/gocql v0.0.0-20200526081602-cd04bd7f22a7/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/godbus/dbus v0.0.0-20190402143921-271e53dc4968/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
 github.com/gofrs/uuid v3.3.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.1.0/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/protobuf v1.0.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -1084,9 +1082,8 @@ github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0 h
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0/go.mod h1:udmeCxAYc7D6folUmLnaCXW4RUSX9Y+maxf00eE1meE=
 github.com/prometheus/alertmanager v0.19.0/go.mod h1:Eyp94Yi/T+kdeb2qvq66E3RGuph5T/jm/RBVh4yz1xo=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
+github.com/prometheus/alertmanager v0.21.0 h1:qK51JcUR9l/unhawGA9F9B64OCYfcGewhPNprem/Acc=
 github.com/prometheus/alertmanager v0.21.0/go.mod h1:h7tJ81NA0VLWvWEayi1QltevFkLF3KxmC/malTcT8Go=
-github.com/prometheus/alertmanager v0.21.1-0.20210321154706-72deec44a869 h1:W+eyG3NpXID08IpCxfKQFftbYZZKPBZVhYeeF9mUpbQ=
-github.com/prometheus/alertmanager v0.21.1-0.20210321154706-72deec44a869/go.mod h1:g6wbBgNXmelfXjJhLLl5NIJDpejM5oEjiSKDsqnTzio=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
@@ -1102,9 +1099,8 @@ github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3O
 github.com/prometheus/client_golang v1.6.0/go.mod h1:ZLOG9ck3JLRdB5MgO8f+lLTe83AXG6ro35rLTxvnIl4=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
 github.com/prometheus/client_golang v1.8.0/go.mod h1:O9VU6huf47PktckDQfMTX0Y8tY0/7TSWwj+ITvv0TnM=
+github.com/prometheus/client_golang v1.9.0 h1:Rrch9mh17XcxvEu9D9DEpb4isxjGBtcevQjKvxPRQIU=
 github.com/prometheus/client_golang v1.9.0/go.mod h1:FqZLKOZnGdFAhOK4nqGHa7D66IdsO+O441Eve7ptJDU=
-github.com/prometheus/client_golang v1.10.0 h1:/o0BDeWzLWXNZ+4q5gXltUvaMpJqckTa+jTNoB+z4cg=
-github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
 github.com/prometheus/client_model v0.0.0-20170216185247-6f3806018612/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
 github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -1128,10 +1124,8 @@ github.com/prometheus/common v0.11.1/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16
 github.com/prometheus/common v0.13.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.14.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.20.0 h1:pfeDeUdQcIxOMutNjCejsEFp7qeP+/iltHSSmLpE+hU=
-github.com/prometheus/common v0.20.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/exporter-toolkit v0.5.0/go.mod h1:OCkM4805mmisBhLmVFw858QYi3v0wKdY6/UxrT0pZVg=
+github.com/prometheus/common v0.17.0 h1:kDIZLI74SS+3tedSvEkykgBkD7txMxaJAPj8DtJUKYA=
+github.com/prometheus/common v0.17.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/node_exporter v1.0.0-rc.0.0.20200428091818-01054558c289/go.mod h1:FGbBv5OPKjch+jNUJmEQpMZytIdyW0NdBtWFcfSKusc=
 github.com/prometheus/procfs v0.0.0-20180612222113-7d6f385de8be/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/go.sum
+++ b/go.sum
@@ -1082,7 +1082,6 @@ github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0 h
 github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.43.0/go.mod h1:udmeCxAYc7D6folUmLnaCXW4RUSX9Y+maxf00eE1meE=
 github.com/prometheus/alertmanager v0.19.0/go.mod h1:Eyp94Yi/T+kdeb2qvq66E3RGuph5T/jm/RBVh4yz1xo=
 github.com/prometheus/alertmanager v0.20.0/go.mod h1:9g2i48FAyZW6BtbsnvHtMHQXl2aVtrORKwKVCQ+nbrg=
-github.com/prometheus/alertmanager v0.21.0 h1:qK51JcUR9l/unhawGA9F9B64OCYfcGewhPNprem/Acc=
 github.com/prometheus/alertmanager v0.21.0/go.mod h1:h7tJ81NA0VLWvWEayi1QltevFkLF3KxmC/malTcT8Go=
 github.com/prometheus/client_golang v0.8.0/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=

--- a/pkg/alertmanager/config/config.go
+++ b/pkg/alertmanager/config/config.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"path/filepath"
 	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,9 +29,6 @@ import (
 	"gopkg.in/yaml.v2"
 
 	commoncfg "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
-
-	"github.com/prometheus/alertmanager/pkg/labels"
-	"github.com/prometheus/alertmanager/timeinterval"
 )
 
 const secretToken = "<secret>"
@@ -53,7 +49,7 @@ type Secret string
 // MarshalYAML implements the yaml.Marshaler interface for Secret.
 func (s Secret) MarshalYAML() (interface{}, error) {
 	if s != "" {
-		return string(s), nil
+		return secretToken, nil
 	}
 	return nil, nil
 }
@@ -66,7 +62,7 @@ func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // MarshalJSON implements the json.Marshaler interface for Secret.
 func (s Secret) MarshalJSON() ([]byte, error) {
-	return json.Marshal(string(s))
+	return json.Marshal(secretToken)
 }
 
 // URL is a custom type that represents an HTTP or HTTPS URL and allows validation at configuration load time.
@@ -219,59 +215,15 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 	for i, tf := range cfg.Templates {
 		cfg.Templates[i] = join(tf)
 	}
-
-	cfg.Global.HTTPConfig.SetDirectory(baseDir)
-	for _, receiver := range cfg.Receivers {
-		for _, cfg := range receiver.OpsGenieConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.PagerdutyConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.PushoverConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.SlackConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.VictorOpsConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.WebhookConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-		for _, cfg := range receiver.WechatConfigs {
-			cfg.HTTPConfig.SetDirectory(baseDir)
-		}
-	}
-}
-
-// MuteTimeInterval represents a named set of time intervals for which a route should be muted.
-type MuteTimeInterval struct {
-	Name          string                      `yaml:"name"`
-	TimeIntervals []timeinterval.TimeInterval `yaml:"time_intervals"`
-}
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for MuteTimeInterval.
-func (mt *MuteTimeInterval) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	type plain MuteTimeInterval
-	if err := unmarshal((*plain)(mt)); err != nil {
-		return err
-	}
-	if mt.Name == "" {
-		return fmt.Errorf("missing name in mute time interval")
-	}
-	return nil
 }
 
 // Config is the top-level configuration for Alertmanager's config files.
 type Config struct {
-	Global            *GlobalConfig      `yaml:"global,omitempty" json:"global,omitempty"`
-	Route             *Route             `yaml:"route,omitempty" json:"route,omitempty"`
-	InhibitRules      []*InhibitRule     `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
-	Receivers         []*Receiver        `yaml:"receivers,omitempty" json:"receivers,omitempty"`
-	Templates         []string           `yaml:"templates" json:"templates"`
-	MuteTimeIntervals []MuteTimeInterval `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
+	Global       *GlobalConfig  `yaml:"global,omitempty" json:"global,omitempty"`
+	Route        *Route         `yaml:"route,omitempty" json:"route,omitempty"`
+	InhibitRules []*InhibitRule `yaml:"inhibit_rules,omitempty" json:"inhibit_rules,omitempty"`
+	Receivers    []*Receiver    `yaml:"receivers,omitempty" json:"receivers,omitempty"`
+	Templates    []string       `yaml:"templates" json:"templates"`
 
 	// original is the input from which the config was parsed.
 	original string
@@ -457,23 +409,9 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if len(c.Route.Match) > 0 || len(c.Route.MatchRE) > 0 {
 		return fmt.Errorf("root route must not have any matchers")
 	}
-	if len(c.Route.MuteTimeIntervals) > 0 {
-		return fmt.Errorf("root route must not have any mute time intervals")
-	}
 
 	// Validate that all receivers used in the routing tree are defined.
-	if err := checkReceiver(c.Route, names); err != nil {
-		return err
-	}
-
-	tiNames := make(map[string]struct{})
-	for _, mt := range c.MuteTimeIntervals {
-		if _, ok := tiNames[mt.Name]; ok {
-			return fmt.Errorf("mute time interval %q is not unique", mt.Name)
-		}
-		tiNames[mt.Name] = struct{}{}
-	}
-	return checkTimeInterval(c.Route, tiNames)
+	return checkReceiver(c.Route, names)
 }
 
 // checkReceiver returns an error if a node in the routing tree
@@ -493,29 +431,11 @@ func checkReceiver(r *Route, receivers map[string]struct{}) error {
 	return nil
 }
 
-func checkTimeInterval(r *Route, timeIntervals map[string]struct{}) error {
-	for _, sr := range r.Routes {
-		if err := checkTimeInterval(sr, timeIntervals); err != nil {
-			return err
-		}
-	}
-	if len(r.MuteTimeIntervals) == 0 {
-		return nil
-	}
-	for _, mt := range r.MuteTimeIntervals {
-		if _, ok := timeIntervals[mt]; !ok {
-			return fmt.Errorf("undefined time interval %q used in route", mt)
-		}
-	}
-	return nil
-}
-
 // DefaultGlobalConfig returns GlobalConfig with default values.
 func DefaultGlobalConfig() GlobalConfig {
-	var defaultHTTPConfig = commoncfg.DefaultHTTPClientConfig
 	return GlobalConfig{
 		ResolveTimeout: model.Duration(5 * time.Minute),
-		HTTPConfig:     &defaultHTTPConfig,
+		HTTPConfig:     &commoncfg.HTTPClientConfig{},
 
 		SMTPHello:       "localhost",
 		SMTPRequireTLS:  true,
@@ -631,7 +551,7 @@ type GlobalConfig struct {
 	SMTPAuthPassword Secret     `yaml:"smtp_auth_password,omitempty" json:"smtp_auth_password,omitempty"`
 	SMTPAuthSecret   Secret     `yaml:"smtp_auth_secret,omitempty" json:"smtp_auth_secret,omitempty"`
 	SMTPAuthIdentity string     `yaml:"smtp_auth_identity,omitempty" json:"smtp_auth_identity,omitempty"`
-	SMTPRequireTLS   bool       `yaml:"smtp_require_tls" json:"smtp_require_tls,omitempty"`
+	SMTPRequireTLS   bool       `yaml:"smtp_require_tls,omitempty" json:"smtp_require_tls,omitempty"`
 	SlackAPIURL      *SecretURL `yaml:"slack_api_url,omitempty" json:"slack_api_url,omitempty"`
 	PagerdutyURL     *URL       `yaml:"pagerduty_url,omitempty" json:"pagerduty_url,omitempty"`
 	OpsGenieAPIURL   *URL       `yaml:"opsgenie_api_url,omitempty" json:"opsgenie_api_url,omitempty"`
@@ -657,14 +577,11 @@ type Route struct {
 	GroupByStr []string          `yaml:"group_by,omitempty" json:"group_by,omitempty"`
 	GroupBy    []model.LabelName `yaml:"-" json:"-"`
 	GroupByAll bool              `yaml:"-" json:"-"`
-	// Deprecated. Remove before v1.0 release.
-	Match map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
-	// Deprecated. Remove before v1.0 release.
-	MatchRE           MatchRegexps `yaml:"match_re,omitempty" json:"match_re,omitempty"`
-	Matchers          Matchers     `yaml:"matchers,omitempty" json:"matchers,omitempty"`
-	MuteTimeIntervals []string     `yaml:"mute_time_intervals,omitempty" json:"mute_time_intervals,omitempty"`
-	Continue          bool         `yaml:"continue" json:"continue,omitempty"`
-	Routes            []*Route     `yaml:"routes,omitempty" json:"routes,omitempty"`
+
+	Match    map[string]string `yaml:"match,omitempty" json:"match,omitempty"`
+	MatchRE  MatchRegexps      `yaml:"match_re,omitempty" json:"match_re,omitempty"`
+	Continue bool              `yaml:"continue,omitempty" json:"continue,omitempty"`
+	Routes   []*Route          `yaml:"routes,omitempty" json:"routes,omitempty"`
 
 	GroupWait      *model.Duration `yaml:"group_wait,omitempty" json:"group_wait,omitempty"`
 	GroupInterval  *model.Duration `yaml:"group_interval,omitempty" json:"group_interval,omitempty"`
@@ -724,21 +641,17 @@ func (r *Route) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // Both alerts have to have a set of labels being equal.
 type InhibitRule struct {
 	// SourceMatch defines a set of labels that have to equal the given
-	// value for source alerts. Deprecated. Remove before v1.0 release.
+	// value for source alerts.
 	SourceMatch map[string]string `yaml:"source_match,omitempty" json:"source_match,omitempty"`
 	// SourceMatchRE defines pairs like SourceMatch but does regular expression
-	// matching. Deprecated. Remove before v1.0 release.
+	// matching.
 	SourceMatchRE MatchRegexps `yaml:"source_match_re,omitempty" json:"source_match_re,omitempty"`
-	// SourceMatchers defines a set of label matchers that have to be fulfilled for source alerts.
-	SourceMatchers Matchers `yaml:"source_matchers,omitempty" json:"source_matchers,omitempty"`
 	// TargetMatch defines a set of labels that have to equal the given
-	// value for target alerts. Deprecated. Remove before v1.0 release.
+	// value for target alerts.
 	TargetMatch map[string]string `yaml:"target_match,omitempty" json:"target_match,omitempty"`
 	// TargetMatchRE defines pairs like TargetMatch but does regular expression
-	// matching. Deprecated. Remove before v1.0 release.
+	// matching.
 	TargetMatchRE MatchRegexps `yaml:"target_match_re,omitempty" json:"target_match_re,omitempty"`
-	// TargetMatchers defines a set of label matchers that have to be fulfilled for target alerts.
-	TargetMatchers Matchers `yaml:"target_matchers,omitempty" json:"target_matchers,omitempty"`
 	// A set of labels that must be equal between the source and target alert
 	// for them to be a match.
 	Equal model.LabelNames `yaml:"equal,omitempty" json:"equal,omitempty"`
@@ -842,7 +755,7 @@ func (re Regexp) MarshalYAML() (interface{}, error) {
 	return nil, nil
 }
 
-// UnmarshalJSON implements the json.Unmarshaler interface for Regexp
+// UnmarshalJSON implements the json.Marshaler interface for Regexp
 func (re *Regexp) UnmarshalJSON(data []byte) error {
 	var s string
 	if err := json.Unmarshal(data, &s); err != nil {
@@ -863,63 +776,4 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 		return json.Marshal(re.original)
 	}
 	return nil, nil
-}
-
-// Matchers is label.Matchers with an added UnmarshalYAML method to implement the yaml.Unmarshaler interface
-// and MarshalYAML to implement the yaml.Marshaler interface.
-type Matchers labels.Matchers
-
-// UnmarshalYAML implements the yaml.Unmarshaler interface for Matchers.
-func (m *Matchers) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	var lines []string
-	if err := unmarshal(&lines); err != nil {
-		return err
-	}
-	for _, line := range lines {
-		pm, err := labels.ParseMatchers(line)
-		if err != nil {
-			return err
-		}
-		*m = append(*m, pm...)
-	}
-	sort.Sort(labels.Matchers(*m))
-	return nil
-}
-
-// MarshalYAML implements the yaml.Marshaler interface for Matchers.
-func (m Matchers) MarshalYAML() (interface{}, error) {
-	result := make([]string, len(m))
-	for i, matcher := range m {
-		result[i] = matcher.String()
-	}
-	return result, nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface for Matchers.
-func (m *Matchers) UnmarshalJSON(data []byte) error {
-	var lines []string
-	if err := json.Unmarshal(data, &lines); err != nil {
-		return err
-	}
-	for _, line := range lines {
-		pm, err := labels.ParseMatchers(line)
-		if err != nil {
-			return err
-		}
-		*m = append(*m, pm...)
-	}
-	sort.Sort(labels.Matchers(*m))
-	return nil
-}
-
-// MarshalJSON implements the json.Marshaler interface for Matchers.
-func (m Matchers) MarshalJSON() ([]byte, error) {
-	if len(m) == 0 {
-		return nil, nil
-	}
-	result := make([]string, len(m))
-	for i, matcher := range m {
-		result[i] = matcher.String()
-	}
-	return json.Marshal(result)
 }

--- a/pkg/alertmanager/config/notifiers.go
+++ b/pkg/alertmanager/config/notifiers.go
@@ -340,7 +340,7 @@ type SlackConfig struct {
 	Pretext     string         `yaml:"pretext,omitempty" json:"pretext,omitempty"`
 	Text        string         `yaml:"text,omitempty" json:"text,omitempty"`
 	Fields      []*SlackField  `yaml:"fields,omitempty" json:"fields,omitempty"`
-	ShortFields bool           `yaml:"short_fields" json:"short_fields,omitempty"`
+	ShortFields bool           `yaml:"short_fields,omitempty" json:"short_fields,omitempty"`
 	Footer      string         `yaml:"footer,omitempty" json:"footer,omitempty"`
 	Fallback    string         `yaml:"fallback,omitempty" json:"fallback,omitempty"`
 	CallbackID  string         `yaml:"callback_id,omitempty" json:"callback_id,omitempty"`
@@ -348,7 +348,7 @@ type SlackConfig struct {
 	IconURL     string         `yaml:"icon_url,omitempty" json:"icon_url,omitempty"`
 	ImageURL    string         `yaml:"image_url,omitempty" json:"image_url,omitempty"`
 	ThumbURL    string         `yaml:"thumb_url,omitempty" json:"thumb_url,omitempty"`
-	LinkNames   bool           `yaml:"link_names" json:"link_names,omitempty"`
+	LinkNames   bool           `yaml:"link_names,omitempty" json:"link_names,omitempty"`
 	MrkdwnIn    []string       `yaml:"mrkdwn_in,omitempty" json:"mrkdwn_in,omitempty"`
 	Actions     []*SlackAction `yaml:"actions,omitempty" json:"actions,omitempty"`
 }
@@ -396,38 +396,21 @@ type WechatConfig struct {
 
 	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
 
-	APISecret   Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
-	CorpID      string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
-	Message     string `yaml:"message,omitempty" json:"message,omitempty"`
-	APIURL      *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
-	ToUser      string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
-	ToParty     string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
-	ToTag       string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
-	AgentID     string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
-	MessageType string `yaml:"message_type,omitempty" json:"message_type,omitempty"`
+	APISecret Secret `yaml:"api_secret,omitempty" json:"api_secret,omitempty"`
+	CorpID    string `yaml:"corp_id,omitempty" json:"corp_id,omitempty"`
+	Message   string `yaml:"message,omitempty" json:"message,omitempty"`
+	APIURL    *URL   `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	ToUser    string `yaml:"to_user,omitempty" json:"to_user,omitempty"`
+	ToParty   string `yaml:"to_party,omitempty" json:"to_party,omitempty"`
+	ToTag     string `yaml:"to_tag,omitempty" json:"to_tag,omitempty"`
+	AgentID   string `yaml:"agent_id,omitempty" json:"agent_id,omitempty"`
 }
-
-const wechatValidTypesRe = `^(text|markdown)$`
-
-var wechatTypeMatcher = regexp.MustCompile(wechatValidTypesRe)
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.
 func (c *WechatConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*c = DefaultWechatConfig
 	type plain WechatConfig
-	if err := unmarshal((*plain)(c)); err != nil {
-		return err
-	}
-
-	if c.MessageType == "" {
-		c.MessageType = "text"
-	}
-
-	if !wechatTypeMatcher.MatchString(c.MessageType) {
-		return errors.Errorf("WeChat message type %q does not match valid options %s", c.MessageType, wechatValidTypesRe)
-	}
-
-	return nil
+	return unmarshal((*plain)(c))
 }
 
 // OpsGenieConfig configures notifications via OpsGenie.
@@ -551,7 +534,7 @@ type PushoverConfig struct {
 	Priority string   `yaml:"priority,omitempty" json:"priority,omitempty"`
 	Retry    duration `yaml:"retry,omitempty" json:"retry,omitempty"`
 	Expire   duration `yaml:"expire,omitempty" json:"expire,omitempty"`
-	HTML     bool     `yaml:"html" json:"html,omitempty"`
+	HTML     bool     `yaml:"html,omitempty" json:"html,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/pkg/alertmanager/config/notifiers_test.go
+++ b/pkg/alertmanager/config/notifiers_test.go
@@ -14,6 +14,7 @@
 package config
 
 import (
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v2"
@@ -191,6 +192,30 @@ url: 'http://example.com'
 
 	if err != nil {
 		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+}
+
+func TestWebhookPasswordIsObfuscated(t *testing.T) {
+	in := `
+url: 'http://example.com'
+http_config:
+  basic_auth:
+    username: foo
+    password: supersecret
+`
+	var cfg WebhookConfig
+	err := yaml.UnmarshalStrict([]byte(in), &cfg)
+
+	if err != nil {
+		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+
+	ycfg, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("no error expected, returned:\n%v", err.Error())
+	}
+	if strings.Contains(string(ycfg), "supersecret") {
+		t.Errorf("Found password in the YAML cfg: %s\n", ycfg)
 	}
 }
 
@@ -560,21 +585,6 @@ func TestOpsgenieTypeMatcher(t *testing.T) {
 	bad := []string{"0user", "team1", "2escalation3", "sche4dule", "User", "TEAM"}
 	for _, b := range bad {
 		if opsgenieTypeMatcher.MatchString(b) {
-			t.Errorf("mistakenly match with %s", b)
-		}
-	}
-}
-
-func TestWeChatTypeMatcher(t *testing.T) {
-	good := []string{"text", "markdown"}
-	for _, g := range good {
-		if !wechatTypeMatcher.MatchString(g) {
-			t.Fatalf("failed to match with %s", g)
-		}
-	}
-	bad := []string{"TEXT", "MarkDOwn"}
-	for _, b := range bad {
-		if wechatTypeMatcher.MatchString(b) {
 			t.Errorf("mistakenly match with %s", b)
 		}
 	}

--- a/pkg/prometheus/common/config/config.go
+++ b/pkg/prometheus/common/config/config.go
@@ -24,7 +24,7 @@ type Secret string
 // MarshalYAML implements the yaml.Marshaler interface for Secrets.
 func (s Secret) MarshalYAML() (interface{}, error) {
 	if s != "" {
-		return string(s), nil
+		return "<secret>", nil
 	}
 	return nil, nil
 }

--- a/pkg/prometheus/common/config/http_config.go
+++ b/pkg/prometheus/common/config/http_config.go
@@ -17,7 +17,7 @@ package config
 
 import (
 	"bytes"
-	"crypto/sha256"
+	"crypto/md5"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -32,11 +32,6 @@ import (
 	"golang.org/x/net/http2"
 	"gopkg.in/yaml.v2"
 )
-
-// DefaultHTTPClientConfig is the default HTTP client configuration.
-var DefaultHTTPClientConfig = HTTPClientConfig{
-	FollowRedirects: true,
-}
 
 type closeIdler interface {
 	CloseIdleConnections()
@@ -116,10 +111,6 @@ type HTTPClientConfig struct {
 	ProxyURL URL `yaml:"proxy_url,omitempty"`
 	// TLSConfig to use to connect to the targets.
 	TLSConfig TLSConfig `yaml:"tls_config,omitempty"`
-	// FollowRedirects specifies whether the client should follow HTTP 3xx redirects.
-	// The omitempty flag is not set, because it would be hidden from the
-	// marshalled configuration when set to false.
-	FollowRedirects bool `yaml:"follow_redirects"`
 }
 
 // SetDirectory joins any relative file paths with dir.
@@ -181,7 +172,6 @@ func (c *HTTPClientConfig) Validate() error {
 // UnmarshalYAML implements the yaml.Unmarshaler interface
 func (c *HTTPClientConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain HTTPClientConfig
-	*c = DefaultHTTPClientConfig
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
 	}
@@ -206,13 +196,7 @@ func NewClientFromConfig(cfg HTTPClientConfig, name string, disableKeepAlives, e
 	if err != nil {
 		return nil, err
 	}
-	client := newClient(rt)
-	if !cfg.FollowRedirects {
-		client.CheckRedirect = func(*http.Request, []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
-	}
-	return client, nil
+	return newClient(rt), nil
 }
 
 // NewRoundTripperFromConfig returns a new HTTP RoundTripper configured for the
@@ -533,7 +517,7 @@ func (t *tlsRoundTripper) getCAWithHash() ([]byte, []byte, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	h := sha256.Sum256(b)
+	h := md5.Sum(b)
 	return b, h[:], nil
 
 }

--- a/pkg/prometheus/common/config/http_config_test.go
+++ b/pkg/prometheus/common/config/http_config_test.go
@@ -474,52 +474,6 @@ func TestBearerAuthFileRoundTripper(t *testing.T) {
 	}
 }
 
-func TestTLSConfig(t *testing.T) {
-	configTLSConfig := TLSConfig{
-		CAFile:             TLSCAChainPath,
-		CertFile:           ClientCertificatePath,
-		KeyFile:            ClientKeyNoPassPath,
-		ServerName:         "localhost",
-		InsecureSkipVerify: false}
-
-	tlsCAChain, err := ioutil.ReadFile(TLSCAChainPath)
-	if err != nil {
-		t.Fatalf("Can't read the CA certificate chain (%s)",
-			TLSCAChainPath)
-	}
-	rootCAs := x509.NewCertPool()
-	rootCAs.AppendCertsFromPEM(tlsCAChain)
-
-	expectedTLSConfig := &tls.Config{
-		RootCAs:            rootCAs,
-		ServerName:         configTLSConfig.ServerName,
-		InsecureSkipVerify: configTLSConfig.InsecureSkipVerify}
-
-	tlsConfig, err := NewTLSConfig(&configTLSConfig)
-	if err != nil {
-		t.Fatalf("Can't create a new TLS Config from a configuration (%s).", err)
-	}
-
-	clientCertificate, err := tls.LoadX509KeyPair(ClientCertificatePath, ClientKeyNoPassPath)
-	if err != nil {
-		t.Fatalf("Can't load the client key pair ('%s' and '%s'). Reason: %s",
-			ClientCertificatePath, ClientKeyNoPassPath, err)
-	}
-	cert, err := tlsConfig.GetClientCertificate(nil)
-	if err != nil {
-		t.Fatalf("unexpected error returned by tlsConfig.GetClientCertificate(): %s", err)
-	}
-	if !reflect.DeepEqual(cert, &clientCertificate) {
-		t.Fatalf("Unexpected client certificate result: \n\n%+v\n expected\n\n%+v", cert, clientCertificate)
-	}
-
-	// non-nil functions are never equal.
-	tlsConfig.GetClientCertificate = nil
-	if !reflect.DeepEqual(tlsConfig, expectedTLSConfig) {
-		t.Fatalf("Unexpected TLS Config result: \n\n%+v\n expected\n\n%+v", tlsConfig, expectedTLSConfig)
-	}
-}
-
 func TestTLSConfigEmpty(t *testing.T) {
 	configTLSConfig := TLSConfig{
 		InsecureSkipVerify: true,

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -31,7 +31,6 @@ func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) 
 					BasicAuth: &promcommonconfig.BasicAuth{
 						Password: promcommonconfig.Secret(opsgenieKey),
 					},
-					FollowRedirects: false,
 				},
 				NotifierConfig: alertmanagerconfig.NotifierConfig{
 					VSendResolved: false,

--- a/service/controller/resource/promxy/test/case-0-cluster-api.golden
+++ b/service/controller/resource/promxy/test/case-0-cluster-api.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: bob
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - bob-prometheus

--- a/service/controller/resource/promxy/test/case-1-awsconfig.golden
+++ b/service/controller/resource/promxy/test/case-1-awsconfig.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: alice
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - alice-prometheus

--- a/service/controller/resource/promxy/test/case-2-azureconfig.golden
+++ b/service/controller/resource/promxy/test/case-2-azureconfig.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: foo
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - foo-prometheus

--- a/service/controller/resource/promxy/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/promxy/test/case-3-kvmconfig.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: bar
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - bar-prometheus

--- a/service/controller/resource/promxy/test/case-4-control-plane.golden
+++ b/service/controller/resource/promxy/test/case-4-control-plane.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: kubernetes
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - kubernetes-prometheus

--- a/service/controller/resource/promxy/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/promxy/test/case-5-cluster-api-v1alpha3.golden
@@ -2,7 +2,6 @@ remote_read: true
 remote_read_path: api/v1/read
 http_client:
   dial_timeout: 200ms
-  follow_redirects: false
 scheme: http
 labels:
   cluster_id: baz
@@ -21,7 +20,6 @@ kubernetes_sd_configs:
   tls_config:
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
-  follow_redirects: false
   namespaces:
     names:
     - baz-prometheus


### PR DESCRIPTION
The new `follow_redirects` directive in alertmanager config, break PMO which cannot update alertmanager config because the versions do not match anymore

This PR fixes it by aligning dependencies version:

- prometheus/alertmanger@v0.21.0
- prometheus/common@v0.17.0

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`