### PR TITLE
Adds support for calculating maximum CPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support to calculate maximum CPU.
+
 ## [1.27.3] - 2021-03-25
 
 - Fix prometheus/common secret token in imported code.

--- a/service/controller/resource/verticalpodautoscaler/error.go
+++ b/service/controller/resource/verticalpodautoscaler/error.go
@@ -22,6 +22,15 @@ func IsQuantityConversion(err error) bool {
 	return microerror.Cause(err) == quantityConversionError
 }
 
+var nodeCpuNotFoundError = &microerror.Error{
+	Kind: "nodeCpuNotFoundError",
+}
+
+// IsNodeCpuNotFound asserts nodeCpuNotFoundError.
+func IsNodeCpuNotFound(err error) bool {
+	return microerror.Cause(err) == nodeCpuNotFoundError
+}
+
 var nodeMemoryNotFoundError = &microerror.Error{
 	Kind: "nodeMemoryNotFoundError",
 }

--- a/service/controller/resource/verticalpodautoscaler/resource_test.go
+++ b/service/controller/resource/verticalpodautoscaler/resource_test.go
@@ -41,6 +41,7 @@ func TestVerticalPodAutoScaler(t *testing.T) {
 		node = &v1.Node{
 			Status: v1.NodeStatus{
 				Allocatable: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("8"),
 					v1.ResourceMemory: resource.MustParse("10"),
 				},
 			},

--- a/service/controller/resource/verticalpodautoscaler/test/case-0-cluster-api.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-0-cluster-api.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -12,6 +12,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
+        cpu: "7"
         memory: "9"
       minAllowed:
         cpu: 100m


### PR DESCRIPTION
Similarly to how we specify a maximum amount of memory (to fit within the nodes of a cluster), this PR adds support to specify a maximum amount of CPU.

e.g:
```
$ kubectl get nodes ip-10-0-5-109.eu-central-1.compute.internal -o yaml | grep -A 2 allocatable
        f:allocatable:
          .: {}
          f:attachable-volumes-aws-ebs: {}
--
  allocatable:
    attachable-volumes-aws-ebs: "25"
    cpu: "4"
```
```
$ kubectl -n=gorilla-prometheus get vpa prometheus -o yaml | grep -A 2 maxAllowed
      maxAllowed:
        cpu: "3"
        memory: 14325966Ki
```

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
