### PR TITLE
Split ManagementClusterCertificateWillExpireInLessThanTwoWeeks alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add support to calculate maximum CPU.
 
+### Changed
+
+- Split `ManagementClusterCertificateWillExpireInLessThanTwoWeeks` alert per provider.
+
 ## [1.27.4] - 2021-03-26
 
 - Add recording rules for dex activity, creating the metrics

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/certificate.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/certificate.management-cluster.rules.yml
@@ -11,11 +11,63 @@ spec:
   groups:
   - name: certificate
     rules:
-    - alert: ManagementClusterCertificateWillExpireInLessThanTwoWeeks
+    - alert: ManagementClusterKVMCertificateWillExpireInLessThanTwoWeeks
       annotations:
         description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
         opsrecipe: renew-certificates/
-      expr: (cert_exporter_not_after{cluster_type="management_cluster", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="kvm", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: rocket
+        topic: security
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: certificate.management-cluster.rules
+  namespace: '{{ include "resource.default.namespace" . }}'
+spec:
+  groups:
+  - name: certificate
+    rules:
+    - alert: ManagementClusterAWSCertificateWillExpireInLessThanTwoWeeks
+      annotations:
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
+        opsrecipe: renew-certificates/
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="aws", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
+      for: 5m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: biscuit
+        topic: security
+
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: certificate.management-cluster.rules
+  namespace: '{{ include "resource.default.namespace" . }}'
+spec:
+  groups:
+  - name: certificate
+    rules:
+    - alert: ManagementClusterAzureCertificateWillExpireInLessThanTwoWeeks
+      annotations:
+        description: '{{`Certificate {{ $labels.path }} on {{ $labels.instance }} will expire in less than two weeks.`}}'
+        opsrecipe: renew-certificates/
+      expr: (cert_exporter_not_after{cluster_type="management_cluster", provider="azure", path!="/etc/kubernetes/ssl/service-account-crt.pem"} - time()) < 2 * 7 * 24 * 60 * 60
       for: 5m
       labels:
         area: kaas


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/15969

This change is introduced because different teams manage MCs in AWS/Azure and on-prem

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
