### PR TITLE
Add draughtsman cadvisor metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support to calculate maximum CPU.
+- Include cadvisor metrics from the pod in `draughtsman` namespace.
 
 ### Changed
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -103,7 +103,7 @@
   metric_relabel_configs:
 [[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 [[- else ]]
   - source_labels: [namespace]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -132,7 +132,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
   - source_labels: [__name__]
     regex: container_network_.*

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -132,7 +132,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
   - source_labels: [__name__]
     regex: container_network_.*

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -132,7 +132,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
   - source_labels: [__name__]
     regex: container_network_.*


### PR DESCRIPTION
Toward https://github.com/giantswarm/giantswarm/issues/16558

We are not fetching cadvisor metrics from the pod located in the `draughtsman` namespace. Since Helm operations are memory-intensive, we would like to know the pattern better by metrics. 

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
