### PR TITLE
add alert for HA master down for too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert for master node in HA setup down for too long.
+
 ## [1.28.0] - 2021-04-01
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
@@ -92,6 +92,22 @@ spec:
         severity: page
         team: firecracker
         topic: kubernetes
+    - alert: WorkloadClusterHAMasterDownForTooLong
+      annotations:
+        description: '{{`Master node in HA setup is down for a long time.`}}'
+        opsrecipe: master-node-missing/
+      expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet", role="master"}) by (cluster_id) == 2
+      for: 1h
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        master_node_down: "true"
+        severity: page
+        team: firecracker
+        topic: kubernetes
     - alert: WorkloadClusterPodPendingFirecracker
       annotations:
         description: '{{`Pod {{ $labels.namespace }}/{{ $labels.pod }} is stuck in Pending.`}}'

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
@@ -97,7 +97,7 @@ spec:
         description: '{{`Master node in HA setup is down for a long time.`}}'
         opsrecipe: master-node-missing/
       expr: kubernetes_build_info{app="kubelet"} and on(cluster_id) sum(kubernetes_build_info{app="kubelet", role="master"}) by (cluster_id) == 2
-      for: 1h
+      for: 30m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/15833

While HA Masters makes one master going down not such a big deal, we still want to get notified if this is the case for extended periods of time. (Is 1h appropriate here? We can also do 30 minutes instead.)

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
