### PR TITLE
Removes unnecessary trailing whitespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add workload type and name labels for `ManagedAppBasicError*` alerts
 - Add alert for master node in HA setup down for too long.
 
+### Removed
+
+- Removed unnecessary whitespace in additional scrape configs.
+
 ## [1.28.0] - 2021-04-01
 
 ### Added

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -99,7 +99,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
@@ -216,7 +216,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
 # Add kubelet configuration
@@ -295,7 +295,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: [[ .APIServerURL ]]
   - source_labels: [__meta_kubernetes_pod_name]
@@ -1737,7 +1737,7 @@
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
   static_configs:
-  - targets: 
+  - targets:
     - [[ .Mayu ]]:4080
     labels:
       app: mayu
@@ -1868,9 +1868,9 @@
     labels:
       app: cert-exporter
 [[- if or (eq .Installation "dragon") (eq .Installation "dinosaur") ]]q
-# DVAG uses HAProxy to allow traffic inside the management clusters. 
+# DVAG uses HAProxy to allow traffic inside the management clusters.
 # We added an haproxy exporter on the vault node to ensure we can access vault from the management cluster
-  - targets: 
+  - targets:
     - [[ .Vault ]]:9101
     labels:
       app: haproxy-exporter

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -381,7 +381,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -544,7 +544,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bob:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -381,7 +381,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -544,7 +544,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -381,7 +381,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -544,7 +544,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -381,7 +381,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -544,7 +544,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -110,7 +110,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -280,7 +280,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -422,7 +422,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: 127.0.0.1:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -138,7 +138,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -328,7 +328,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -491,7 +491,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -319,7 +319,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -482,7 +482,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bob:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -319,7 +319,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -482,7 +482,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -319,7 +319,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -482,7 +482,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -192,7 +192,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -319,7 +319,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -482,7 +482,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -110,7 +110,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -225,7 +225,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -367,7 +367,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: 127.0.0.1:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -138,7 +138,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -266,7 +266,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -429,7 +429,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -133,7 +133,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -260,7 +260,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -423,7 +423,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bob:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -133,7 +133,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -260,7 +260,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -423,7 +423,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -133,7 +133,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -260,7 +260,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -423,7 +423,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -133,7 +133,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -260,7 +260,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -423,7 +423,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -110,7 +110,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -225,7 +225,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -367,7 +367,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: 127.0.0.1:443
   - source_labels: [__meta_kubernetes_pod_name]
@@ -2716,7 +2716,7 @@
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
   static_configs:
-  - targets: 
+  - targets:
     - :4080
     labels:
       app: mayu

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -79,7 +79,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -207,7 +207,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -370,7 +370,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]


### PR DESCRIPTION
We had a few lines with trailing whitespace in the additional scrape configs, my editor (and me) didn't like it, this PR gets rid of them.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR (this is a reformatting PR :D)
- [x] Updated changelog in `CHANGELOG.md`
