### PR TITLE
Add aggregation for Docker actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add workload type and name labels for `ManagedAppBasicError*` alerts
 - Add alert for master node in HA setup down for too long.
+- Add aggregation for docker actions.
 
 ### Removed
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -76,7 +76,7 @@
 [[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 [[ end ]]
 # Add scrape configuration for cadvisor
@@ -99,7 +99,7 @@
     replacement: cadvisor
   # Add node name.
   - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
-    target_label: node  
+    target_label: node
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
@@ -216,7 +216,7 @@
     target_label: instance
   # Add ip label.
   - target_label: ip
-    source_labels: [__meta_kubernetes_node_address_InternalIP]    
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
 # Add kubelet configuration
@@ -295,7 +295,7 @@
     target_label: instance
   - source_labels: [__meta_kubernetes_pod_container_name]
     regex: (k8s-scheduler|kube-scheduler)
-    action: keep  
+    action: keep
   - target_label: __address__
     replacement: [[ .APIServerURL ]]
   - source_labels: [__meta_kubernetes_pod_name]
@@ -1737,7 +1737,7 @@
     ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
     insecure_skip_verify: true
   static_configs:
-  - targets: 
+  - targets:
     - [[ .Mayu ]]:4080
     labels:
       app: mayu
@@ -1868,9 +1868,9 @@
     labels:
       app: cert-exporter
 [[- if or (eq .Installation "dragon") (eq .Installation "dinosaur") ]]q
-# DVAG uses HAProxy to allow traffic inside the management clusters. 
+# DVAG uses HAProxy to allow traffic inside the management clusters.
 # We added an haproxy exporter on the vault node to ensure we can access vault from the management cluster
-  - targets: 
+  - targets:
     - [[ .Vault ]]:9101
     labels:
       app: haproxy-exporter

--- a/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
+++ b/helm/prometheus-meta-operator/templates/recording-rules/cortex.rules.yml
@@ -25,6 +25,8 @@ spec:
     # Spot Instances being used
     - expr: count(sum(aws_operator_ec2_instance_status{lifecycle != ""}) by (ec2_instance, lifecycle)) by  (lifecycle)
       record: aggregation:aws:instance_lifecycle
+    - expr: sum(engine_daemon_image_actions_seconds_count) by (cluster_id, cluster_type, action)
+      record: aggregation:docker:action_count
     # REST API usage: authentications successful via the "giantswarm" token method
     - expr: sum(rate(api_service_authentication_giantswarm_successful_attempts_total[5m]))
       record: aggregation:giantswarm:api_auth_giantswarm_successful_attempts_total

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -84,7 +84,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -159,7 +159,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -84,7 +84,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -100,7 +100,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -100,7 +100,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -100,7 +100,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -100,7 +100,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -84,7 +84,7 @@
     replacement: worker
   metric_relabel_configs:
   - source_labels: [__name__]
-    regex: (process_virtual_memory_bytes|process_resident_memory_bytes)
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
     action: keep
 
 # Add scrape configuration for cadvisor


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16599

I want to see how many pulls we're doing (as part of reducing overall registry usage), so adding the aggregation. New metric should add time series on the the order of O(nodes), which is fine.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
