### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inhibition for `MatchingNumberOfPrometheusAndCluster` alert by matching it with
+  source from Management Cluster instead of the cluster the alert is firing for.
+
 ## [1.29.0] - 2021-04-09
 
 ### Added
@@ -23,11 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Removed unnecessary whitespace in additional scrape configs.
-
-### Fixed
-
-- Fix inhibition for `MatchingNumberOfPrometheusAndCluster` alert by matching it with
-  source from Management Cluster instead of the cluster the alert is firing for.
 
 ## [1.28.0] - 2021-04-01
 


### PR DESCRIPTION
Somehow the changelog entry from https://github.com/giantswarm/prometheus-meta-operator/pull/481 ended up under previous release header. This fixes by moving into _Unreleased_ section.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
