### PR TITLE
Remove absent from KSM alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed check for `absent` metric in `KubeStateMetricsDown` alert.
+
 ## [1.30.0] - 2021-04-12
 
 ### Removed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
@@ -44,7 +44,7 @@ spec:
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'
         opsrecipe: kube-state-metrics-down/
-      expr: up{app="kube-state-metrics"} == 0 or absent(up{app="kube-state-metrics"}) == 1
+      expr: up{app="kube-state-metrics"} == 0
       for: 15m
       labels:
         area: kaas


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/16178

This was just different from the other `Down` metrics. In all others we do not check for `absent`. Could it therefor be that the absent part leads to false pages?

My idea was to just merge this and try it.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
