### PR TITLE
Keep container network metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Keep the container_network.* metrics for the kubernetes mixins
+
 ## [1.30.0] - 2021-04-12
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Keep the container_network.* metrics for the kubernetes mixins
+- Keep the `container_network.*` metrics as they are needed for the [kubernetes mixins dashboards](https://github.com/giantswarm/g8s-grafana/tree/master/helm/g8s-grafana/dashboards/mixin)
 
 ## [1.30.0] - 2021-04-12
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -112,9 +112,6 @@
     regex: (kube-system|giantswarm.*)
     action: keep
 [[- end ]]
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: [[ .ClusterID ]]-prometheus/calico-node-[[ .ClusterID ]]/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bob-prometheus/calico-node-bob/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -135,9 +135,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -163,9 +163,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bob-prometheus/calico-node-bob/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -217,9 +217,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -135,9 +135,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -163,9 +163,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -158,9 +158,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bob-prometheus/calico-node-bob/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -158,9 +158,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -158,9 +158,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -158,9 +158,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -135,9 +135,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -104,9 +104,6 @@
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
     action: keep
-  - source_labels: [__name__]
-    regex: container_network_.*
-    action: drop
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true
   scheme: https


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/13725
Kubernetes mixins dashboards in grafana needs the container_network metrics to function

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
