### PR TITLE
Format `MatchingNumberOfPrometheusAndCluster` expression

### DIFF
--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -25,7 +25,17 @@ spec:
         description: This alert is used to ensure we have as many workload cluster prometheus as we have workload cluster CR.
       # This expression list all the cluster IDs that exist and are not being deleted and compares them (using unless) to the running prometheus pods.
       # If a prometheus is missing, this alert will fire. This alert will not check if a prometheus is running when it should not (e.g. deleted cluster)
-      expr: (sum({__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status", status!="Deleting"}) by (cluster_id) unless sum(label_replace(kube_pod_container_status_running{container="prometheus", namespace=~".*-prometheus",namespace!="{{ .Values.Installation.V1.Name }}-prometheus"}, "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)") ) by (cluster_id)) > 0
+      expr: |
+        (
+          sum by(cluster_id) (
+            {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status",status!="Deleting"}
+          ) unless sum by(cluster_id) (
+            label_replace(
+              kube_pod_container_status_running{container="prometheus",namespace!="{{ .Values.Installation.V1.Name }}-prometheus",namespace=~".*-prometheus"},
+              "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)"
+            )
+          )
+        ) > 0
       for: 10m
       labels:
         area: "empowerment"

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -31,7 +31,7 @@ spec:
             {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status",status!="Deleting"}
           ) unless sum by(cluster_id) (
             label_replace(
-              kube_pod_container_status_running{container="prometheus",namespace!="{{ .Values.Installation.V1.Name }}-prometheus",namespace=~".*-prometheus"},
+              kube_pod_container_status_running{container="prometheus", namespace!="{{ .Values.Installation.V1.Name }}-prometheus", namespace=~".*-prometheus"},
               "cluster_id", "$2", "pod", "(prometheus-)(.+)(-.+)"
             )
           )

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -28,7 +28,7 @@ spec:
       expr: |
         (
           sum by(cluster_id) (
-            {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status",status!="Deleting"}
+            {__name__=~"cluster_service_cluster_info|cluster_operator_cluster_status", status!="Deleting"}
           ) unless sum by(cluster_id) (
             label_replace(
               kube_pod_container_status_running{container="prometheus", namespace!="{{ .Values.Installation.V1.Name }}-prometheus", namespace=~".*-prometheus"},


### PR DESCRIPTION
to be a bit more readable. No functionality changes.

Towards: https://github.com/giantswarm/giantswarm/issues/15890

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
