### PR TITLE
Add runbook link to `MatchingNumberOfPrometheusAndCluster`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Page firecracker for failed cluster transitions.
 - Page Firecracker in working hours for restarting containers.
+- `MatchingNumberOfPrometheusAndCluster` now has a runbook, link added to alert.
 
 ### Changed
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus-meta-operator.rules.yml
@@ -23,6 +23,7 @@ spec:
     - alert: "MatchingNumberOfPrometheusAndCluster"
       annotations:
         description: This alert is used to ensure we have as many workload cluster prometheus as we have workload cluster CR.
+        opsrecipe: matching-number-of-prometheus-and-cluster/
       # This expression list all the cluster IDs that exist and are not being deleted and compares them (using unless) to the running prometheus pods.
       # If a prometheus is missing, this alert will fire. This alert will not check if a prometheus is running when it should not (e.g. deleted cluster)
       expr: |


### PR DESCRIPTION
As runbook now exists, ensure the alert will link to it to make it easy
for oncallers to find.

Towards: https://github.com/giantswarm/giantswarm/issues/15890

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
