### PR TITLE
Add kube-state-metrics missing alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert for `kube-state-metrics` missing.
+
 ## [1.31.0] - 2021-04-16
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/up.all.rules.yml
@@ -56,6 +56,22 @@ spec:
         severity: page
         team: ludacris
         topic: observability
+    - alert: KubeStateMetricsMissing
+      annotations:
+        description: '{{`KubeStateMetrics ({{ $labels.instance }}) is missing.`}}'
+        opsrecipe: kube-state-metrics-down/
+      expr: absent(up{app="app_name"} == 1)
+      for: 15m
+      labels:
+        area: kaas
+        cancel_if_apiserver_down: "true"
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        kube_state_metrics_down: "true"
+        severity: page
+        team: ludacris
+        topic: observability
     - alert: NodeExporterDown
       annotations:
         description: '{{`NodeExporter ({{ $labels.ip }}) is down.`}}'


### PR DESCRIPTION
## Checklist

This is a preparation for https://github.com/giantswarm/prometheus-meta-operator/pull/505

We are currently getting paged by `kube-state-metrics` down quite a bit for different reasons. This will make it easier for oncallers to quickly identify why the problem is happening.

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
