### PR TITLE
Extend WorkloadClusterContainerIsRestartingTooFrequentlyFirecracker a…

### DIFF
--- a/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/aws.workload-cluster.rules.yml
@@ -30,7 +30,7 @@ spec:
         description: '{{`Container {{ $labels.container }} in pod {{ $labels.namespace }}/{{ $labels.pod }} is restarting too often.`}}'
         opsrecipe: container-is-restarting-too-often/
       expr: increase(kube_pod_container_status_restarts_total{container=~"aws-node.*|kiam-.+"}[1h]) > 6
-      for: 5m
+      for: 15m
       labels:
         area: kaas
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
…larm

Extend the WorkloadClusterContainerIsRestartingTooFrequentlyFirecracker alarm to 15 minutes, otherwise we get paged due to cluster scaling up/down

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
