### PR TITLE
Lower the severity to notify for managedApp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lower the severity to notify for managed app's error budget alerts
+
 ### Fixed
 
 - Fix ManagedApp alert

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/managed-apps-basic-sli.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/managed-apps-basic-sli.rules.yml
@@ -21,7 +21,7 @@ spec:
         cancel_if_cluster_status_creating: "true"
         cancel_if_cluster_status_deleting: "true"
         cancel_if_cluster_status_updating: "true"
-        severity: page
+        severity: notify
         team: batman
         topic: managed-apps-basic-sli
     - alert: ManagedAppBasicErrorBudgetBurnRateAboveSafeLevel


### PR DESCRIPTION
## Checklist

I have lowered the severity of managed apps alerts since it is mostly not affecting any customer's business 

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
