### PR TITLE
fix InhibitionKubeStateMetricsDown not firing longe enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix ManagedApp alert
+- Fix `InhibitionKubeStateMetricsDown` not firing long enough
 
 ## [1.33.0] - 2021-04-27
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/inhibit.all.rules.yml
@@ -22,7 +22,7 @@ spec:
     - alert: InhibitionKubeStateMetricsDown
       annotations:
         description: '{{`KubeStateMetrics ({{ $labels.instance }}) is down.`}}'
-      expr: up{app="kube-state-metrics"} == 0 or absent(up{app="kube-state-metrics"}) == 1
+      expr: up{app="kube-state-metrics"} == 0 or absent(up{app="kube-state-metrics"} == 1)
       labels:
         area: kaas
         kube_state_metrics_down: "true"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/16803

This PR fixes an issue with `InhibitionKubeStateMetricsDown` which does not fires long enough and result in `KubeStateMetricsMissing` firing too early.


* `KubeStateMetricsMissing` fires until at 11:55:35

![image](https://user-images.githubusercontent.com/6536819/117274654-8d417180-ae5d-11eb-918b-ee37408be9e7.png)


* `InhibitionKubeStateMetricsDown` fires until 11:53:01, which gives ~2mn for the alert to fire.

![image](https://user-images.githubusercontent.com/6536819/117274603-8286dc80-ae5d-11eb-939b-20e941e3b7ad.png)

* fixed `InhibitionKubeStateMetricsDown` fires until at 11:55:35, which gives no time for the alert to fire.

![image](https://user-images.githubusercontent.com/6536819/117274700-99c5ca00-ae5d-11eb-9178-d53a447fff75.png)

