### PR TITLE
Add alertmanager-dashboard alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alert `alertmanager-dashboard` not satisfied.
+
 ## [1.34.1] - 2021-05-10
 
 ### Fixed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager-dashboard.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/alertmanager-dashboard.rules.yml
@@ -1,0 +1,29 @@
+{{- if eq .Values.Installation.V1.Name "gorilla" }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  creationTimestamp: null
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+    cluster_type: "management_cluster"
+  name: alertmanager-dashboard.rules
+spec:
+  groups:
+  - name: alertmanager-dashboard
+    rules:
+    - alert: AlertManagerDashboardDeploymentNotSatisfied
+      annotations:
+        description: '{{`AlertManagerDashboard deployment is not satisfied.`}}'
+        opsrecipe: deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_available{cluster_type="workload_cluster", cluster_id="rfjh2", deployment=~"karma.*"} == 0
+      for: 10m
+      labels:
+        area: kaas
+        cancel_if_cluster_status_creating: "true"
+        cancel_if_cluster_status_deleting: "true"
+        cancel_if_cluster_status_updating: "true"
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: firecracker
+        topic: monitoring
+{{- end }}


### PR DESCRIPTION
Introducing alert for `alertmanager-dashboard` deployment not running, which pages only in business hours.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`