### PR TITLE
Add alerts for alloc orphan and time wait sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added alert `HighNumberOfAllocatedSockets` for High number of allocated sockets 
+- Added alert `HighNumberOfOrphanedSockets` for High number of orphaned sockets 
+- Added alert `HighNumberOfTimeWaitSockets` for High number of time wait sockets 
+
 ## [1.34.1] - 2021-05-10
 
 ### Fixed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
@@ -75,3 +75,37 @@ spec:
         team: rocket
         {{- end }}
         topic: network
+    - alert: HighNumberOfAllocatedSockets
+      annotations:
+        description: '{{`Over 90 percent of sockets are allocated on {{ or $labels.pod_name $labels.instance }}.`}}'
+      # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
+      expr: node_sockstat_TCP_alloc > ( 0.9 * ( 60999 - 32768 ) )
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: ludacris
+        topic: network
+    - alert: HighNumberOfOrphanedSockets
+      annotations:
+        description: '{{`Over 80 percent of ports are orphaned {{ or $labels.pod_name $labels.instance }}.`}}'
+      # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
+      expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: ludacris
+        topic: network
+    - alert: HighNumberOfTimeWaitSockets
+      annotations:
+        description: '{{`Over 80 percent of available ports are in time wait state on {{ or $labels.pod_name $labels.instance }}.`}}'
+      # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
+      expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
+      for: 5m
+      labels:
+        area: kaas
+        severity: page
+        team: ludacris
+        topic: network
+

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
@@ -77,34 +77,40 @@ spec:
         topic: network
     - alert: HighNumberOfAllocatedSockets
       annotations:
-        description: '{{`Over 90 percent of sockets are allocated on {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`Over 90 percent of sockets are allocated on {{ $labels.instance }}.`}}'
+        opsrecipe: high-port-usage/
       # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
       expr: node_sockstat_TCP_alloc > ( 0.9 * ( 60999 - 32768 ) )
       for: 5m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: ludacris
         topic: network
     - alert: HighNumberOfOrphanedSockets
       annotations:
-        description: '{{`Over 80 percent of ports are orphaned {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`Over 80 percent of ports are orphaned {{  $labels.instance }}.`}}'
+        opsrecipe: high-port-usage/
       # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
       expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
       for: 5m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: ludacris
         topic: network
     - alert: HighNumberOfTimeWaitSockets
       annotations:
-        description: '{{`Over 80 percent of available ports are in time wait state on {{ or $labels.pod_name $labels.instance }}.`}}'
+        description: '{{`Over 80 percent of available ports are in time wait state on {{ $labels.instance }}.`}}'
+        opsrecipe: high-port-usage/
       # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
       expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
       for: 5m
       labels:
         area: kaas
+        cancel_if_outside_working_hours: "true"
         severity: page
         team: ludacris
         topic: network

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/network.all.rules.yml
@@ -90,10 +90,10 @@ spec:
         topic: network
     - alert: HighNumberOfOrphanedSockets
       annotations:
-        description: '{{`Over 80 percent of ports are orphaned {{  $labels.instance }}.`}}'
+        description: '{{`Over 50 percent of ports are orphaned {{  $labels.instance }}.`}}'
         opsrecipe: high-port-usage/
       # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
-      expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
+      expr: node_sockstat_TCP_orphan > ( 0.5 * ( 60999 - 32768 ) )
       for: 5m
       labels:
         area: kaas
@@ -103,10 +103,10 @@ spec:
         topic: network
     - alert: HighNumberOfTimeWaitSockets
       annotations:
-        description: '{{`Over 80 percent of available ports are in time wait state on {{ $labels.instance }}.`}}'
+        description: '{{`Over 50 percent of available ports are in time wait state on {{ $labels.instance }}.`}}'
         opsrecipe: high-port-usage/
       # This threshold value is based off net.ipv4.ip_local_port_range = 32768 60999
-      expr: node_sockstat_TCP_orphan > ( 0.8 * ( 60999 - 32768 ) )
+      expr: node_sockstat_TCP_tw > ( 0.5 * ( 60999 - 32768 ) )
       for: 5m
       labels:
         area: kaas

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -5,7 +5,7 @@ var (
 	gitSHA      = "n/a"
 	name        = "prometheus-meta-operator"
 	source      = "https://github.com/giantswarm/prometheus-meta-operator"
-	version     = "1.34.1"
+	version     = "1.34.2-dev"
 )
 
 func Description() string {


### PR DESCRIPTION
## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`

This is related to https://github.com/giantswarm/giantswarm/issues/14756. 

This change introduces 3 alerts. One for number of allocated ports, one for orphaned ports, and one for time wait state ports.

This is to help early identify when the node runs out of ports and can start having issues. The limits are set at 90% and 80% in order early notify before there are errors


