### PR TITLE
Increases duration for prometheus low disk space alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increased duration for `PrometheusPersistentVolumeSpaceTooLow` alert
+
 ## [1.35.0] - 2021-05-12
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/disk.management-cluster.rules.yml
@@ -86,7 +86,7 @@ spec:
         description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         opsrecipe: low-disk-space/#persistent-volume
       expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod_id) group_left label_replace(kube_pod_info{priority_class="prometheus"}, "pod_id", "$1", "uid", "(.*)")) < 10
-      for: 10m
+      for: 1h
       labels:
         area: empowerment
         cancel_if_outside_working_hours: "true"


### PR DESCRIPTION
This alert resolves itself very often - Prometheus does disk cleanup, so let's give it more time to do so before alerting

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
