### PR TITLE
Merge AlertManager global HTTP config with generated receivers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added alert `HighNumberOfAllocatedSockets` for High number of allocated sockets 
 - Added alert `HighNumberOfOrphanedSockets` for High number of orphaned sockets 
 - Added alert `HighNumberOfTimeWaitSockets` for High number of time wait sockets 
+- Preserve and merge global HTTP client config when generating heartbeat
+  receivers in AlertManager config; this allows it to be used in environments
+  where internet access is only allowed through a proxy.
 
 ### Changed
 

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -28,16 +28,9 @@ func toReceiver(cfg alertmanagerconfig.Config, cluster metav1.Object, installati
 			return alertmanagerconfig.Receiver{}, err
 		}
 		httpConfig = httpConfigCp
-		// httpConfig = cfg.Global.HTTPConfig
 	}
 	httpConfig.BasicAuth = &promcommonconfig.BasicAuth{
 		Password: promcommonconfig.Secret(opsgenieKey),
-	}
-
-	if cfg.Global != nil && cfg.Global.HTTPConfig != nil {
-		if reflect.DeepEqual(cfg.Global.HTTPConfig, httpConfig) {
-			return alertmanagerconfig.Receiver{}, fmt.Errorf("HTTPConfig not cloned correctly")
-		}
 	}
 
 	r := alertmanagerconfig.Receiver{

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -25,7 +25,7 @@ func toReceiver(cfg alertmanagerconfig.Config, cluster metav1.Object, installati
 	if cfg.Global != nil && cfg.Global.HTTPConfig != nil {
 		httpConfigCp, err := cloneHttpConfig(cfg.Global.HTTPConfig)
 		if err != nil {
-			return alertmanagerconfig.Receiver{}, err
+			return alertmanagerconfig.Receiver{}, microerror.Mask(err)
 		}
 		httpConfig = httpConfigCp
 	}
@@ -105,12 +105,12 @@ func getReceiver(cfg alertmanagerconfig.Config, receiver alertmanagerconfig.Rece
 func cloneHttpConfig(hc *promcommonconfig.HTTPClientConfig) (*promcommonconfig.HTTPClientConfig, error) {
 	s, err := yaml.Marshal(hc)
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 	r := &promcommonconfig.HTTPClientConfig{}
 	err = yaml.Unmarshal(s, r)
 	if err != nil {
-		return nil, err
+		return nil, microerror.Mask(err)
 	}
 	return r, nil
 }

--- a/service/controller/resource/heartbeatrouting/receiver/receiver.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"reflect"
 
+	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/microerror"
@@ -14,10 +15,29 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
 )
 
-func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) (alertmanagerconfig.Receiver, error) {
+func toReceiver(cfg alertmanagerconfig.Config, cluster metav1.Object, installation string, opsgenieKey string) (alertmanagerconfig.Receiver, error) {
 	u, err := url.Parse(fmt.Sprintf("https://api.opsgenie.com/v2/heartbeats/%s/ping", key.HeartbeatName(cluster, installation)))
 	if err != nil {
 		return alertmanagerconfig.Receiver{}, microerror.Mask(err)
+	}
+
+	httpConfig := &promcommonconfig.HTTPClientConfig{}
+	if cfg.Global != nil && cfg.Global.HTTPConfig != nil {
+		httpConfigCp, err := cloneHttpConfig(cfg.Global.HTTPConfig)
+		if err != nil {
+			return alertmanagerconfig.Receiver{}, err
+		}
+		httpConfig = httpConfigCp
+		// httpConfig = cfg.Global.HTTPConfig
+	}
+	httpConfig.BasicAuth = &promcommonconfig.BasicAuth{
+		Password: promcommonconfig.Secret(opsgenieKey),
+	}
+
+	if cfg.Global != nil && cfg.Global.HTTPConfig != nil {
+		if reflect.DeepEqual(cfg.Global.HTTPConfig, httpConfig) {
+			return alertmanagerconfig.Receiver{}, fmt.Errorf("HTTPConfig not cloned correctly")
+		}
 	}
 
 	r := alertmanagerconfig.Receiver{
@@ -27,11 +47,7 @@ func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) 
 				URL: &alertmanagerconfig.URL{
 					URL: u,
 				},
-				HTTPConfig: &promcommonconfig.HTTPClientConfig{
-					BasicAuth: &promcommonconfig.BasicAuth{
-						Password: promcommonconfig.Secret(opsgenieKey),
-					},
-				},
+				HTTPConfig: httpConfig,
 				NotifierConfig: alertmanagerconfig.NotifierConfig{
 					VSendResolved: false,
 				},
@@ -45,7 +61,7 @@ func toReceiver(cluster metav1.Object, installation string, opsgenieKey string) 
 // EnsureCreated ensure receiver exist in cfg.Receivers and is up to date. Returns true when changes have been made to cfg.
 // Return untouched cfg and false when no changes are made.
 func EnsureCreated(cfg alertmanagerconfig.Config, cluster metav1.Object, installation, opsgenieKey string) (alertmanagerconfig.Config, bool, error) {
-	desired, err := toReceiver(cluster, installation, opsgenieKey)
+	desired, err := toReceiver(cfg, cluster, installation, opsgenieKey)
 	if err != nil {
 		return cfg, false, microerror.Mask(err)
 	}
@@ -68,7 +84,7 @@ func EnsureCreated(cfg alertmanagerconfig.Config, cluster metav1.Object, install
 // EnsureDeleted ensure receiver is removed from cfg.Receivers. Returns true when changes have been made to cfg.
 // Return untouched cfg and false when no changes are made.
 func EnsureDeleted(cfg alertmanagerconfig.Config, cluster metav1.Object, installation, opsgenieKey string) (alertmanagerconfig.Config, bool, error) {
-	desired, err := toReceiver(cluster, installation, opsgenieKey)
+	desired, err := toReceiver(cfg, cluster, installation, opsgenieKey)
 	if err != nil {
 		return cfg, false, microerror.Mask(err)
 	}
@@ -91,4 +107,17 @@ func getReceiver(cfg alertmanagerconfig.Config, receiver alertmanagerconfig.Rece
 	}
 
 	return nil, -1
+}
+
+func cloneHttpConfig(hc *promcommonconfig.HTTPClientConfig) (*promcommonconfig.HTTPClientConfig, error) {
+	s, err := yaml.Marshal(hc)
+	if err != nil {
+		return nil, err
+	}
+	r := &promcommonconfig.HTTPClientConfig{}
+	err = yaml.Unmarshal(s, r)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
 }

--- a/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
@@ -89,6 +89,40 @@ func TestEnsureReceiver(t *testing.T) {
 			index:          0,
 		},
 		{
+			// The HTTPConfig from global config should be merged when creating HTTPConfig for the receiver
+			name: "update merges global proxy settings",
+			cfg: alertmanagerconfig.Config{
+				Global: &alertmanagerconfig.GlobalConfig{
+					HTTPConfig: &promcommonconfig.HTTPClientConfig{
+						ProxyURL: promcommonconfig.URL{URL: &url.URL{Host: "proxyhost:8080"}},
+					},
+				},
+				Receivers: []*alertmanagerconfig.Receiver{
+					&alertmanagerconfig.Receiver{
+						Name: "heartbeat_installation_cluster",
+						WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+							&alertmanagerconfig.WebhookConfig{
+								URL: &alertmanagerconfig.URL{
+									URL: u,
+								},
+								HTTPConfig: &promcommonconfig.HTTPClientConfig{
+									BasicAuth: &promcommonconfig.BasicAuth{
+										Password: "secret-key",
+									},
+								},
+								NotifierConfig: alertmanagerconfig.NotifierConfig{
+									VSendResolved: false,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedUpdate: true,
+			len:            1,
+			index:          0,
+		},
+		{
 			name: "add",
 			cfg: alertmanagerconfig.Config{
 				Receivers: []*alertmanagerconfig.Receiver{

--- a/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
@@ -2,6 +2,7 @@ package receiver
 
 import (
 	"net/url"
+	"reflect"
 	"testing"
 
 	v1 "k8s.io/api/core/v1"
@@ -89,40 +90,6 @@ func TestEnsureReceiver(t *testing.T) {
 			index:          0,
 		},
 		{
-			// The HTTPConfig from global config should be merged when creating HTTPConfig for the receiver
-			name: "update merges global proxy settings",
-			cfg: alertmanagerconfig.Config{
-				Global: &alertmanagerconfig.GlobalConfig{
-					HTTPConfig: &promcommonconfig.HTTPClientConfig{
-						ProxyURL: promcommonconfig.URL{URL: &url.URL{Host: "proxyhost:8080"}},
-					},
-				},
-				Receivers: []*alertmanagerconfig.Receiver{
-					&alertmanagerconfig.Receiver{
-						Name: "heartbeat_installation_cluster",
-						WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
-							&alertmanagerconfig.WebhookConfig{
-								URL: &alertmanagerconfig.URL{
-									URL: u,
-								},
-								HTTPConfig: &promcommonconfig.HTTPClientConfig{
-									BasicAuth: &promcommonconfig.BasicAuth{
-										Password: "secret-key",
-									},
-								},
-								NotifierConfig: alertmanagerconfig.NotifierConfig{
-									VSendResolved: false,
-								},
-							},
-						},
-					},
-				},
-			},
-			expectedUpdate: true,
-			len:            1,
-			index:          0,
-		},
-		{
 			name: "add",
 			cfg: alertmanagerconfig.Config{
 				Receivers: []*alertmanagerconfig.Receiver{
@@ -176,6 +143,60 @@ func TestEnsureReceiver(t *testing.T) {
 				t.Fatalf("len(c.Receivers) %d, expected %d\n", len(c.Receivers), tc.len)
 			}
 		})
+	}
+}
+
+func TestEnsureReceiverWithProxy(t *testing.T) {
+	// The HTTPConfig from global config should be merged when creating
+	// HTTPConfig for the receiver
+
+	cfg := alertmanagerconfig.Config{
+		Global: &alertmanagerconfig.GlobalConfig{
+			HTTPConfig: &promcommonconfig.HTTPClientConfig{
+				ProxyURL: promcommonconfig.URL{URL: &url.URL{Host: "proxyhost:8080"}},
+			},
+		},
+
+		Receivers: []*alertmanagerconfig.Receiver{},
+	}
+
+	expectedCfg := alertmanagerconfig.Config{
+		Global: &alertmanagerconfig.GlobalConfig{
+			HTTPConfig: &promcommonconfig.HTTPClientConfig{
+				ProxyURL: promcommonconfig.URL{URL: &url.URL{Host: "proxyhost:8080"}},
+			},
+		},
+
+		Receivers: []*alertmanagerconfig.Receiver{
+			{
+				Name: "heartbeat_installation_cluster",
+				WebhookConfigs: []*alertmanagerconfig.WebhookConfig{
+					{
+						URL: &alertmanagerconfig.URL{
+							URL: u,
+						},
+						HTTPConfig: &promcommonconfig.HTTPClientConfig{
+							BasicAuth: &promcommonconfig.BasicAuth{
+								Password: "secret-key",
+							},
+							ProxyURL: promcommonconfig.URL{URL: &url.URL{Host: "proxyhost:8080"}},
+						},
+						NotifierConfig: alertmanagerconfig.NotifierConfig{
+							VSendResolved: false,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	newCfg, _, err := EnsureCreated(cfg, cluster, installation, opsgenieKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(newCfg, expectedCfg) {
+		t.Fatalf("\n# expected:\n%+v\n\n# got:\n%+v\n", expectedCfg, newCfg)
 	}
 }
 

--- a/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
+++ b/service/controller/resource/heartbeatrouting/receiver/receiver_test.go
@@ -146,9 +146,8 @@ func TestEnsureReceiver(t *testing.T) {
 	}
 }
 
+// TestEnsureReceiverWithProxy ensures the global HTTPConfig is merged into receiver HTTPConfig.
 func TestEnsureReceiverWithProxy(t *testing.T) {
-	// The HTTPConfig from global config should be merged when creating
-	// HTTPConfig for the receiver
 
 	cfg := alertmanagerconfig.Config{
 		Global: &alertmanagerconfig.GlobalConfig{


### PR DESCRIPTION
AlertManager doesn't do merging itself, which means that if we specify
HTTP config in the receivers (e.g. to specify auth credentials), then
the global config is not used for those receivers.

We want to preserve any options set in the global config which may
specify things like a proxy server to use, which affects the entire
environment.

Towards: https://github.com/giantswarm/giantswarm/issues/17238

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
