### PR TITLE
Silence Some celestial alerts outside business hours

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increased duration for `PrometheusPersistentVolumeSpaceTooLow` alert
+- Silence `OperatorkitErrorRateTooHighCelestial` and `OperatorkitCRNotDeletedCelestial` outside working hours.
 
 ## [1.35.0] - 2021-05-12
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/operatorkit.rules.yml
@@ -45,6 +45,7 @@ spec:
         area: kaas
         severity: page
         team: celestial
+        cancel_if_outside_working_hours: "true"
         topic: qa
     # Celestial
     # It might happen that CRs get orphaned or deletion gets kind of stuck during
@@ -60,6 +61,7 @@ spec:
         area: kaas
         severity: notify
         team: celestial
+        cancel_if_outside_working_hours: "true"
         topic: qa
     # In case something stops an operator from reconciling CRs we want to
     # be paged to be able to fix the issue immediately.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/17287

Celestial thinks the operatorkit-related alerts shouldn't page during the night.
The reasons behind this are:

- The main reason why this happened in the past was because of expired service principal credentials, and this is not a problem any more
- If this happens for other reasons, they usually are external things (such as azure API being down) and they self solve and we can't do a thing about it
- operatorkit operators are going to disappear because of CAPI
- customer workloads should not be affected or, if they are, should page with more specific alerts.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
