### PR TITLE
update PrometheusFailsToCommunicateWithRemoteStorageAPI alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silence `OperatorkitErrorRateTooHighCelestial` and `OperatorkitCRNotDeletedCelestial` outside working hours.
 - Add atlas, and installation tag onto Heartbeats.
 
+### Fixed
+
+- Fix `PrometheusFailsToCommunicateWithRemoteStorageAPI` alert not firing on china clusters.
+
 ## [1.35.0] - 2021-05-12
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -26,7 +26,7 @@ spec:
     - alert: PrometheusFailsToCommunicateWithRemoteStorageAPI
       annotations:
         description: '{{`Prometheus can''t communicate with Remote Storage API at {{ $labels.url }}.`}}'
-      expr: rate(prometheus_remote_storage_samples_failed_total[1h]) > 0.10 or rate(prometheus_remote_storage_samples_total[1h]) == 0
+      expr: rate(prometheus_remote_storage_samples_failed_total[1h]) > 0.10 or rate(prometheus_remote_storage_samples_total[1h]) == 0 or rate(prometheus_remote_storage_metadata_retried_total[5m]) > 0
       for: 1h
       labels:
         area: empowerment
@@ -34,5 +34,3 @@ spec:
         severity: page
         team: atlas
         topic: observability
-
-        


### PR DESCRIPTION
Prometheus servers running in china seems to never have sent data to cortex, and the alert about remote write never fired for them

![image](https://user-images.githubusercontent.com/6536819/119143029-739c4e80-ba47-11eb-9a9b-276b157469ac.png)

So I updated the alert to take into account the `prometheus_remote_storage_metadata_retried_total` metric

![image](https://user-images.githubusercontent.com/6536819/119143204-a0506600-ba47-11eb-87de-ecaf14c76bd2.png)
