### PR TITLE
increase-time-for-etcd-alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Increased duration for `PrometheusPersistentVolumeSpaceTooLow` alert
+- Increased duration for `WorkloadClusterEtcdDBSizeTooLarge` alert.
+- Increased duration for `WorkloadClusterEtcdHasNoLeader` alert.
 
 ## [1.35.0] - 2021-05-12
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/etcd.workload-cluster.rules.yml
@@ -53,7 +53,7 @@ spec:
         description: '{{`Etcd ({{ $labels.instance }}) has a too large database.`}}'
         opsrecipe: etcd-db-size-too-large/
       expr: etcd_debugging_mvcc_db_total_size_in_bytes{cluster_type="workload_cluster"} > 500 * 1024 * 1024
-      for: 10m
+      for: 35m
       labels:
         area: kaas
         severity: page
@@ -85,7 +85,7 @@ spec:
         description: '{{`Etcd has no leader.`}}'
         opsrecipe: etcd-has-no-leader/
       expr: etcd_server_has_leader{cluster_type="workload_cluster"} == 0
-      for: 5m
+      for: 35m
       labels:
         area: kaas
         severity: page


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/17199

these seem to page when the cluster is upgrading from single master to multi-master HA, but resolve afterward

I think we should be safe to increase the duration for the alerts, specially fro the DB size
and if the Etcd has really "no leader" we would get paged by tons of other alerts as API would be basically dead

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
