### PR TITLE
Increases duration of Prometheus cant communicate alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increased alert duration of `PrometheusCantCommunicateWithKubernetesAPI`
+
 ## [1.37.0] - 2021-05-26
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -15,7 +15,7 @@ spec:
         description: '{{`Prometheus can''t communicate with Kubernetes API.`}}'
         opsrecipe: prometheus-cant-communicate/
       expr: rate(prometheus_sd_kubernetes_http_request_total{app!="promxy-app-unique", status_code="<error>"}[15m]) > 0.25
-      for: 15m
+      for: 30m
       labels:
         area: empowerment
         cancel_if_any_apiserver_down: "true"


### PR DESCRIPTION
I got hit with a flap of this, so increasing the duration so we can be more sure that Prometheus can't reach the API

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
