### PR TITLE
Fix memory limit to avoid going over node capacity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Fixed the way VPA `maxAllowed` parameter for memory is calculated so that we
+  avoid going over node memory capacity with the memory limit (`maxAllowed` is
+  used for request and limit is that multiplied by 1.2).
+
 ## [1.38.0] - 2021-05-28
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -71,7 +71,7 @@ spec:
   resources:
     limits:
       cpu: 150m
-      memory: "1287651328"
+      memory: "1288490188"
     requests:
       cpu: 100m
       memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -203,6 +203,11 @@ func (r *Resource) getMaxMemory(ctx context.Context) (*resource.Quantity, error)
 		return nil, microerror.Mask(err)
 	}
 
+	q, err = quantityMultiply(q, 1/key.PrometheusMemoryLimitCoefficient)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	return q, nil
 }
 

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-0-cluster-api.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -13,7 +13,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "7"
-        memory: "9"
+        memory: "7"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -2,6 +2,7 @@ package key
 
 import (
 	"fmt"
+	"math"
 
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/core/v1"
@@ -13,7 +14,11 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 )
 
-const monitoring = "monitoring"
+const (
+	monitoring = "monitoring"
+
+	PrometheusMemoryLimitCoefficient float64 = 1.2
+)
 
 func ToCluster(obj interface{}) (metav1.Object, error) {
 	clusterMetaObject, ok := obj.(metav1.Object)
@@ -100,7 +105,12 @@ func PrometheusDefaultMemory() *resource.Quantity {
 }
 
 func PrometheusDefaultMemoryLimit() *resource.Quantity {
-	return resource.NewQuantity(1024*1024*1228, resource.DecimalSI)
+	return resource.NewQuantity(
+		int64(math.Floor(
+			1024*1024*1024*PrometheusMemoryLimitCoefficient,
+		)),
+		resource.DecimalSI,
+	)
 }
 
 func PrometheusPort() int32 {


### PR DESCRIPTION
VPA takes the maxAllowed to be based on memory request, that means the
request can be set to almost max memory available to the node, but since
the limit is calculated based on the request and multiplied by 1.2 it
means the limit can go higher than available memory.

Prevent this by lowering the maxAllowed value by the request-limit
coefficient.

Towards: https://github.com/giantswarm/giantswarm/issues/17350

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
