### PR TITLE
Lowers Prometheus disk space alert threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Lower Prometheus disk space alert from 10% to 5%.
+
 ## [1.40.0] - 2021-06-14
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/disk.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/disk.management-cluster.rules.yml
@@ -85,7 +85,7 @@ spec:
       annotations:
         description: '{{`Persistent volume {{ $labels.mountpoint}} on {{ $labels.instance }} does not have enough free space.`}}'
         opsrecipe: low-disk-space/#persistent-volume
-      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod_id) group_left label_replace(kube_pod_info{priority_class="prometheus"}, "pod_id", "$1", "uid", "(.*)")) < 10
+      expr: 100 * ((node_filesystem_free_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"} / node_filesystem_size_bytes{mountpoint=~"(/rootfs)?/var/lib/kubelet.*"}) * on (pod_id) group_left label_replace(kube_pod_info{priority_class="prometheus"}, "pod_id", "$1", "uid", "(.*)")) < 5
       for: 1h
       labels:
         area: empowerment


### PR DESCRIPTION
Prometheus does disk cleanup on its own, and can happily go below 10% free disk space on some clusters. 5% doesn't seem to occur on checked clusters. Updating alert threshold to reduce flappiness.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
