### PR TITLE
Add metrics-server deployment to monitored WC components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added Alertmanager managed by Prometheus Operator.
-- Added Alertmanager ingress.
+- Add Alertmanager managed by Prometheus Operator.
+- Add Alertmanager ingress.
+- Add `WorkloadClusterDeploymentNotSatisfiedLudacris` to monitor `metrics-server` in workload clusters.
 
 ### Changed
 
 - Lower Prometheus disk space alert from 10% to 5%.
 - Change severity of `ChartOperatorDown` alert to notify.
 
-### Fixed 
+### Fixed
 
 - Fix service name in ingress.
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.workload-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/deployment.workload-cluster.rules.yml
@@ -22,6 +22,17 @@ spec:
         severity: page
         team: batman
         topic: releng
+    - alert: WorkloadClusterDeploymentNotSatisfiedLudacris
+      annotations:
+        description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'
+        opsrecipe: workload-cluster-deployment-not-satisfied/
+      expr: kube_deployment_status_replicas_unavailable{cluster_type="workload_cluster", deployment="metrics-server"} > 0
+      for: 30m
+      labels:
+        area: kaas
+        severity: page
+        team: ludacris
+        topic: observability
     - alert: WorkloadClusterManagedDeploymentNotSatisfied
       annotations:
         description: '{{`Deployment {{ $labels.namespace}}/{{ $labels.deployment }} is not satisfied.`}}'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17712

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
