### PR TITLE
Add `PrometheusHighMemoryUsage` alert

### DIFF
--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -34,3 +34,33 @@ spec:
         severity: page
         team: atlas
         topic: observability
+    - alert: PrometheusHighMemoryUsage
+      annotations:
+        description: |-
+          {{`Prometheus in pod {{ $labels.namespace }}/{{ $labels.pod }} is using >95% of node's memory.
+          VALUE = {{ $value }}
+          LABALE = {{ $labels }}`}}
+        opsrecipe: TODO/
+      # `node` label is sometimes a name and sometimes IP, and it was different
+      # between those metrics on kvm installations, so extract IP to be able to match
+      expr: |
+        sum by (node_ip, pod) (
+          label_replace(
+            container_memory_working_set_bytes{pod=~"^prometheus-.+-\\d+$", container="prometheus"},
+            "node_ip", "$1", "instance", "(.*):.*"
+          )
+        )
+        / on (node_ip) group_left
+        label_replace(
+          node_memory_MemTotal_bytes,
+          "node_ip", "$1", "instance", "(.*):.*"
+        )
+        * 100
+        > 95
+      for: 5m
+      labels:
+        area: empowerment
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: atlas
+        topic: observability

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/prometheus.rules.yml
@@ -39,7 +39,7 @@ spec:
         description: |-
           {{`Prometheus in pod {{ $labels.namespace }}/{{ $labels.pod }} is using >95% of node's memory.
           VALUE = {{ $value }}
-          LABALE = {{ $labels }}`}}
+          LABELS = {{ $labels }}`}}
         opsrecipe: TODO/
       # `node` label is sometimes a name and sometimes IP, and it was different
       # between those metrics on kvm installations, so extract IP to be able to match


### PR DESCRIPTION
To page us during working hours if Prometheus container memory usage
(specifically the working set size) grows beyond 95% of total memory on
the node it's running on. This is dangerously close to OOM crash-loop
territory and likely needs to be addressed by either cleaning up some
data or upgrading to nodes with more memory.

Closes https://github.com/giantswarm/giantswarm/issues/17350

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
