### PR TITLE
Add CoreDNSMaxHPAReplicasReached alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add Alertmanager managed by Prometheus Operator.
 - Add Alertmanager ingress.
 - Add `WorkloadClusterDeploymentNotSatisfiedLudacris` to monitor `metrics-server` in workload clusters.
+- Add `CoreDNSMaxHPAReplicasReached` business hours alert for when CoreDNS has been scaled to its maximum for too long.
 
 ### Changed
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
@@ -67,3 +67,14 @@ spec:
         severity: page
         team: ludacris
         topic: dns
+    - alert: CoreDNSMaxHPAReplicasReached
+      expr: kube_hpa_status_current_replicas{hpa="coredns"} == kube_hpa_spec_max_replicas{hpa="coredns"}
+      for: 120m
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
+        team: se
+        topic: dns
+      annotations:
+        description: '{{`CoreDNS Deployment {{ $labels.namespace}}/{{ $labels.deployment }} has been scaled to its maximum replica count for too long.`}}'


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/17712
Adds a business hours alert when CoreDNS has been scaled to its maximum HPA replica count for 2 hours.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
