### PR TITLE
Moves SLO alert to opt-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lower Prometheus disk space alert from 10% to 5%.
 - Change severity of `ChartOperatorDown` alert to notify.
 - Merge all provider certificate.management-cluster.rules into one prometheus rule.
+- Change `ServiceLevelBurnRateTooHigh` to opt-in for services.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Lower Prometheus disk space alert from 10% to 5%.
 - Change severity of `ChartOperatorDown` alert to notify.
 - Merge all provider certificate.management-cluster.rules into one prometheus rule.
-- Change `ServiceLevelBurnRateTooHigh` to opt-in for services.
+- Change `ServiceLevelBurnRateTooHigh` and `ServiceLevelBurnRateTooHighTicket` to opt-out for services.
 
 ### Fixed
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/service-level.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/service-level.rules.yml
@@ -14,7 +14,7 @@ spec:
         description: '{{`Service level burn rate is too high for {{ $labels.service }} service.`}}'
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
-        slo_errors_per_request:ratio_rate1h{service=~"api-server|kubelet"}
+        slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"}
         and on (service)
         (
         slo_errors_per_request:ratio_rate1h > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_high
@@ -36,6 +36,9 @@ spec:
         description: '{{`There is a constant low burn rate for {{ $labels.service }} service. Please create a PM.`}}'
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
+        slo_errors_per_request:ratio_rate1h{service!~"efk-.*|.*external-dns.*|kong-.*|.*nginx-.*"}
+        and on (service)
+        (
         slo_errors_per_request:ratio_rate24h > on (service) group_left (cluster_type, cluster_id, class) 3 * slo_target
         and
         slo_errors_per_request:ratio_rate2h > on (service) group_left (cluster_type, cluster_id, class) 3 * slo_target
@@ -43,6 +46,7 @@ spec:
         slo_errors_per_request:ratio_rate3d > on (service) group_left (cluster_type, cluster_id, class) slo_target
         and
         slo_errors_per_request:ratio_rate6h > on (service) group_left (cluster_type, cluster_id, class) slo_target
+        )
       for: 5m
       labels:
         cancel_if_outside_working_hours: "true"

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/service-level.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/service-level.rules.yml
@@ -14,6 +14,9 @@ spec:
         description: '{{`Service level burn rate is too high for {{ $labels.service }} service.`}}'
         opsrecipe: service-level-burn-rate-too-high/
       expr: |
+        slo_errors_per_request:ratio_rate1h{service=~"api-server|kubelet"}
+        and on (service)
+        (
         slo_errors_per_request:ratio_rate1h > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_high
         and
         slo_errors_per_request:ratio_rate5m > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_high
@@ -21,6 +24,7 @@ spec:
         slo_errors_per_request:ratio_rate6h > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_low
         and
         slo_errors_per_request:ratio_rate30m > on (service) group_left (cluster_type, cluster_id, class) slo_threshold_low
+        )
       for: 5m
       labels:
         cancel_if_cluster_status_creating: "true"


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/17734

To avoid having services alerting that we don't - e.g: in the case where we're still testing a service's service level out, this adds support to opt-in to the service level alert, so we don't get unwanted pages.

See https://gigantic.slack.com/archives/C02MS174K/p1623828191186600 for more context.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
