### PR TITLE
Polish CoreDNSMaxHPAReplicasReached alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix CoreDNSMaxHPAReplicasReached alert to not fire in case max and min are equal. 
+
 ## [1.41.0] - 2021-06-17
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
@@ -68,7 +68,7 @@ spec:
         team: ludacris
         topic: dns
     - alert: CoreDNSMaxHPAReplicasReached
-      expr: kube_hpa_status_current_replicas{hpa="coredns", cluster_id="peu01"} == kube_hpa_spec_max_replicas{hpa="coredns"} AND kube_hpa_spec_min_replicas{hpa="coredns"} != kube_hpa_spec_max_replicas{hpa="coredns"} 
+      expr: kube_hpa_status_current_replicas{hpa="coredns"} == kube_hpa_spec_max_replicas{hpa="coredns"} AND kube_hpa_spec_min_replicas{hpa="coredns"} != kube_hpa_spec_max_replicas{hpa="coredns"} 
       for: 120m
       labels:
         area: kaas

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/coredns.rules.yml
@@ -68,7 +68,7 @@ spec:
         team: ludacris
         topic: dns
     - alert: CoreDNSMaxHPAReplicasReached
-      expr: kube_hpa_status_current_replicas{hpa="coredns"} == kube_hpa_spec_max_replicas{hpa="coredns"}
+      expr: kube_hpa_status_current_replicas{hpa="coredns", cluster_id="peu01"} == kube_hpa_spec_max_replicas{hpa="coredns"} AND kube_hpa_spec_min_replicas{hpa="coredns"} != kube_hpa_spec_max_replicas{hpa="coredns"} 
       for: 120m
       labels:
         area: kaas


### PR DESCRIPTION
When max and min number of replicas are the same don't alert. After deploying the new alert we have been paged for clusters where they fix number of max/min replicas. I don't see the point of alert in such a case

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
