### PR TITLE
Added/fixed azure WC creation and update failure alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add term to not count api-server errors for clusters in transitioning state.
+- Business-hours alert for azure clusters not updating in time.
 
 ### Changed
 
@@ -17,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix CoreDNSMaxHPAReplicasReached alert to not fire in case max and min are equal. 
+- Fix CoreDNSMaxHPAReplicasReached alert to not fire in case max and min are equal.
+- Business-hours alert for azure clusters not creating in time.
 
 ## [1.41.0] - 2021-06-17
 

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
@@ -23,9 +23,9 @@ spec:
         severity: notify
         team: celestial
         topic: azure
-    - alert: AzureClusterUpdateFailed
+    - alert: AzureClusterUpgradeFailed
       annotations:
-        description: '{{`Cluster {{ $labels.cluster_id }} update is taking longer than expected.`}}'
+        description: '{{`Cluster {{ $labels.cluster_id }} upgrade is taking longer than expected.`}}'
         opsrecipe: cluster-update-failed/
       expr: azure_operator_cluster_status(status="Upgrading"} == 1
       for: 2h

--- a/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
+++ b/helm/prometheus-meta-operator/templates/prometheus-rules/azure.management-cluster.rules.yml
@@ -15,14 +15,24 @@ spec:
       annotations:
         description: '{{`Cluster {{ $labels.cluster_id }} creation is taking longer than expected.`}}'
         opsrecipe: cluster-creation-failed/
-      # statusresource_cluster_status{app="azure-operator.*", status="Creating"} give us a vector with all cluster statuses
-      # in Azure clusters which stays at 'Creating' state.
-      expr: (statusresource_cluster_status{app=~"azure-operator.*", status="Creating"} == 1 or cluster_operator_cluster_status{app=~"cluster-operator.*", status="Updating", provider="azure"} == 1)
+      expr: azure_operator_cluster_status(status="Creating"} == 1
       for: 40m
       labels:
         area: kaas
         cancel_if_outside_working_hours: "true"
         severity: notify
+        team: celestial
+        topic: azure
+    - alert: AzureClusterUpdateFailed
+      annotations:
+        description: '{{`Cluster {{ $labels.cluster_id }} update is taking longer than expected.`}}'
+        opsrecipe: cluster-update-failed/
+      expr: azure_operator_cluster_status(status="Upgrading"} == 1
+      for: 2h
+      labels:
+        area: kaas
+        cancel_if_outside_working_hours: "true"
+        severity: page
         team: celestial
         topic: azure
     - alert: AzureDeploymentStatusFailed


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/17763

This PR adds a new alert for azure workload cluster which upgrade takes too long and fixes the alert for creation taking too long.


## Checklist

I have:

- [X] Described why this change is being introduced
- [X] Separated out refactoring/reformatting in a dedicated PR
- [X] Updated changelog in `CHANGELOG.md`
