### PR TITLE
Request team Atlas for review of release PRs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# Automatically request reviews from team Atlas on **release PRs**.
+# This uses the fact that release PRs always modify this file but almost no
+# other PR does.
+pkg/project/project.go  @giantswarm/team-atlas


### PR DESCRIPTION
We want to be automatically requested for review of **release** PRs so
that we can advise in case there are reasons to postpone a release, e.g.
in case we want to bundle changes that are about to land, or we're aware
of a problem in the master branch, etc.

Towards: https://github.com/giantswarm/roadmap/issues/352

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
