### PR TITLE
Update Architect to 3.3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@2.7.0
+  architect: giantswarm/architect@3.3.0
 workflows:
   build:
     jobs:


### PR DESCRIPTION
To fix an issue with out of date key for pushing to catalog repo.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
