### PR TITLE
Use Grafana Cloud config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use Grafana Cloud remote-write URL from config instead of hardcoding it, to
+  allow overriding the URL in installations which can't access Grafana Cloud
+  directly.
+
 ## [1.44.2] - 2021-06-24
 
 ## [1.44.1] - 2021-06-24

--- a/helm/prometheus-meta-operator/ci/default-values.yaml
+++ b/helm/prometheus-meta-operator/ci/default-values.yaml
@@ -17,6 +17,8 @@ Installation:
           Size: 1Gi
       Grafana:
         Address: ""
+      GrafanaCloud:
+        RemoteWriteURL: ""
       Prometheus:
         Address: "https://prometheus:9090"
         Bastions: []

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -37,7 +37,7 @@ data:
         logLevel: {{ .Values.prometheus.logLevel }}
         mayu: {{ .Values.Installation.V1.Monitoring.Prometheus.Mayu }}
         remoteWrite:
-          url: https://prometheus-us-central1.grafana.net/api/prom/push
+          url: {{ .Values.Installation.V1.Monitoring.GrafanaCloud.RemoteWriteURL }}
         retention:
           duration: 2w
           size: 90GB


### PR DESCRIPTION
Instead of hardcoding the remote-write URL. This is needed so that we
can override the URL in installations which can't access Grafana Cloud
directly.

Towards: https://github.com/giantswarm/giantswarm/issues/17366

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
