### PR TITLE
Enable usage of service monitors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add the service label in the alert templates for the `ServiceLevelBurnRateTooHigh` alert.
 - Update Prometheus to 2.28.1.
-- Ensure the workload cluster Prometheus detects Service Monitor in the cluster and workload cluster prometheus namespace and that management cluster prometheus detects Service Monitors from all the other namespaces.
+- Allow the use of Prometheus Operator Service Monitor for management clusters.
 
 ## [1.46.0] - 2021-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Add the service label in the alert templates for the `ServiceLevelBurnRateTooHigh` alert.
-- Update Prometheus to 2.28.1
+- Update Prometheus to 2.28.1.
+- Ensure the workload cluster Prometheus detects Service Monitor in the cluster and workload cluster prometheus namespace and that management cluster prometheus detects Service Monitors from all the other namespaces.
 
 ## [1.46.0] - 2021-07-14
 

--- a/service/controller/resource/monitoring/ingress/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-0-cluster-api.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: bob
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bob
   name: prometheus-bob
   namespace: bob-prometheus
 spec:

--- a/service/controller/resource/monitoring/ingress/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-1-awsconfig.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: alice
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: alice
   name: prometheus-alice
   namespace: alice-prometheus
 spec:

--- a/service/controller/resource/monitoring/ingress/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-2-azureconfig.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: foo
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: foo
   name: prometheus-foo
   namespace: foo-prometheus
 spec:

--- a/service/controller/resource/monitoring/ingress/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-3-kvmconfig.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: bar
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bar
   name: prometheus-bar
   namespace: bar-prometheus
 spec:

--- a/service/controller/resource/monitoring/ingress/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-4-control-plane.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: kubernetes
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: kubernetes
   name: prometheus-kubernetes
   namespace: kubernetes-prometheus
 spec:

--- a/service/controller/resource/monitoring/ingress/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/ingress/test/case-5-cluster-api-v1alpha3.golden
@@ -10,6 +10,7 @@ metadata:
     app.kubernetes.io/instance: baz
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: baz
   name: prometheus-baz
   namespace: baz-prometheus
 spec:

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -192,11 +192,6 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 			Retention:      config.RetentionDuration,
 			RetentionSize:  config.RetentionSize,
 			WALCompression: &walCompression,
-			ServiceMonitorSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					key.ClusterIDKey(): key.ClusterID(cluster),
-				},
-			},
 			AdditionalScrapeConfigs: &corev1.SecretKeySelector{
 				LocalObjectReference: corev1.LocalObjectReference{
 					Name: key.PrometheusAdditionalScrapeConfigsSecretName(),
@@ -328,6 +323,18 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 				},
 			},
 		}
+
+		prometheus.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"giantswarm.io/cluster": key.ClusterID(cluster),
+			},
+		}
+
+		prometheus.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"giantswarm.io/cluster": key.ClusterID(cluster),
+			},
+		}
 	} else {
 		// Management cluster
 		prometheus.Spec.APIServerConfig = &promv1.APIServerConfig{
@@ -351,6 +358,24 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 					Key:      "cluster_type",
 					Operator: metav1.LabelSelectorOpNotIn,
 					Values:   []string{"workload_cluster"},
+				},
+			},
+		}
+
+		prometheus.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				metav1.LabelSelectorRequirement{
+					Key:      "giantswarm.io/cluster",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
+				},
+			},
+		}
+
+		prometheus.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
+			MatchExpressions: []metav1.LabelSelectorRequirement{
+				metav1.LabelSelectorRequirement{
+					Key:      "giantswarm.io/cluster",
+					Operator: metav1.LabelSelectorOpDoesNotExist,
 				},
 			},
 		}

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -323,18 +323,6 @@ func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
 				},
 			},
 		}
-
-		prometheus.Spec.ServiceMonitorSelector = &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"giantswarm.io/cluster": key.ClusterID(cluster),
-			},
-		}
-
-		prometheus.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
-			MatchLabels: map[string]string{
-				"giantswarm.io/cluster": key.ClusterID(cluster),
-			},
-		}
 	} else {
 		// Management cluster
 		prometheus.Spec.APIServerConfig = &promv1.APIServerConfig{

--- a/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: bob
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bob
   name: bob
   namespace: bob-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: bob
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: bob
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,12 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      giantswarm.io/cluster: bob
   serviceMonitorSelector:
     matchLabels:
-      cluster_id: bob
+      giantswarm.io/cluster: bob
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-0-cluster-api.golden
@@ -99,12 +99,6 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      giantswarm.io/cluster: bob
-  serviceMonitorSelector:
-    matchLabels:
-      giantswarm.io/cluster: bob
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: alice
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: alice
   name: alice
   namespace: alice-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: alice
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: alice
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,12 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      giantswarm.io/cluster: alice
   serviceMonitorSelector:
     matchLabels:
-      cluster_id: alice
+      giantswarm.io/cluster: alice
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -99,12 +99,6 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      giantswarm.io/cluster: alice
-  serviceMonitorSelector:
-    matchLabels:
-      giantswarm.io/cluster: alice
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -99,12 +99,6 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      giantswarm.io/cluster: foo
-  serviceMonitorSelector:
-    matchLabels:
-      giantswarm.io/cluster: foo
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: foo
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: foo
   name: foo
   namespace: foo-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: foo
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: foo
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,12 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      giantswarm.io/cluster: foo
   serviceMonitorSelector:
     matchLabels:
-      cluster_id: foo
+      giantswarm.io/cluster: foo
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -99,12 +99,6 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      giantswarm.io/cluster: bar
-  serviceMonitorSelector:
-    matchLabels:
-      giantswarm.io/cluster: bar
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: bar
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bar
   name: bar
   namespace: bar-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: bar
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: bar
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,12 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      giantswarm.io/cluster: bar
   serviceMonitorSelector:
     matchLabels:
-      cluster_id: bar
+      giantswarm.io/cluster: bar
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: kubernetes
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: kubernetes
   name: kubernetes
   namespace: kubernetes-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: kubernetes
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: kubernetes
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,14 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchExpressions:
+    - key: giantswarm.io/cluster
+      operator: DoesNotExist
   serviceMonitorSelector:
-    matchLabels:
-      cluster_id: kubernetes
+    matchExpressions:
+    - key: giantswarm.io/cluster
+      operator: DoesNotExist
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -99,12 +99,6 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
-  serviceMonitorNamespaceSelector:
-    matchLabels:
-      giantswarm.io/cluster: baz
-  serviceMonitorSelector:
-    matchLabels:
-      giantswarm.io/cluster: baz
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: baz
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: baz
   name: baz
   namespace: baz-prometheus
 spec:
@@ -47,6 +48,7 @@ spec:
       app.kubernetes.io/instance: baz
       app.kubernetes.io/managed-by: prometheus-meta-operator
       app.kubernetes.io/name: prometheus
+      giantswarm.io/cluster: baz
       giantswarm.io/monitoring: "true"
   priorityClassName: prometheus
   remoteWrite:
@@ -97,9 +99,12 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+  serviceMonitorNamespaceSelector:
+    matchLabels:
+      giantswarm.io/cluster: baz
   serviceMonitorSelector:
     matchLabels:
-      cluster_id: baz
+      giantswarm.io/cluster: baz
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-0-cluster-api.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: bob
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bob
   name: prometheus
   namespace: bob-prometheus
 spec:

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: alice
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: alice
   name: prometheus
   namespace: alice-prometheus
 spec:

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: foo
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: foo
   name: prometheus
   namespace: foo-prometheus
 spec:

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: bar
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bar
   name: prometheus
   namespace: bar-prometheus
 spec:

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: kubernetes
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: kubernetes
   name: prometheus
   namespace: kubernetes-prometheus
 spec:

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -4,6 +4,7 @@ metadata:
     app.kubernetes.io/instance: baz
     app.kubernetes.io/managed-by: prometheus-meta-operator
     app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: baz
   name: prometheus
   namespace: baz-prometheus
 spec:

--- a/service/controller/resource/namespace/resource.go
+++ b/service/controller/resource/namespace/resource.go
@@ -49,7 +49,8 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}
 
 	return metav1.ObjectMeta{
-		Name: key.Namespace(cluster),
+		Name:   key.Namespace(cluster),
+		Labels: key.PrometheusLabels(cluster),
 	}, nil
 }
 

--- a/service/controller/resource/namespace/test/case-0-cluster-api.golden
+++ b/service/controller/resource/namespace/test/case-0-cluster-api.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: bob
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bob
   name: bob-prometheus
 spec: {}
 status: {}

--- a/service/controller/resource/namespace/test/case-1-awsconfig.golden
+++ b/service/controller/resource/namespace/test/case-1-awsconfig.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: alice
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: alice
   name: alice-prometheus
 spec: {}
 status: {}

--- a/service/controller/resource/namespace/test/case-2-azureconfig.golden
+++ b/service/controller/resource/namespace/test/case-2-azureconfig.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: foo
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: foo
   name: foo-prometheus
 spec: {}
 status: {}

--- a/service/controller/resource/namespace/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/namespace/test/case-3-kvmconfig.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: bar
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: bar
   name: bar-prometheus
 spec: {}
 status: {}

--- a/service/controller/resource/namespace/test/case-4-control-plane.golden
+++ b/service/controller/resource/namespace/test/case-4-control-plane.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: kubernetes
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: kubernetes
   name: kubernetes-prometheus
 spec: {}
 status: {}

--- a/service/controller/resource/namespace/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/namespace/test/case-5-cluster-api-v1alpha3.golden
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: baz
+    app.kubernetes.io/managed-by: prometheus-meta-operator
+    app.kubernetes.io/name: prometheus
+    giantswarm.io/cluster: baz
   name: baz-prometheus
 spec: {}
 status: {}

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -97,6 +97,7 @@ func PrometheusLabels(cluster metav1.Object) map[string]string {
 		"app.kubernetes.io/name":       "prometheus",
 		"app.kubernetes.io/managed-by": project.Name(),
 		"app.kubernetes.io/instance":   ClusterID(cluster),
+		"giantswarm.io/cluster":        ClusterID(cluster),
 	}
 }
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/18243

This PR uses the `giantswarm.io/cluster` label already set on the workload cluster namespace to differentciate between workload cluster namespaces and management cluster namespaces

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
