### PR TITLE
Add Falco noise slack receiver and route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add receiver and route for `#noise-falco` Slack channel.
+
 ### Changed
 
 - Add the service label in the alert templates for the `ServiceLevelBurnRateTooHigh` alert.

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -16,6 +16,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -113,6 +120,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
@@ -12,6 +12,13 @@ route:
   repeat_interval: 4h
   receiver: root
   routes:
+
+  # Falco noise Slack
+  - receiver: falco_noise_slack
+    matchers:
+    - alertname=~"Falco.*"
+    continue: false
+
     # Team Ops Opsgenie
   - receiver: opsgenie_router
     match:
@@ -105,6 +112,29 @@ route:
 
 receivers:
 - name: root
+
+- name: falco_noise_slack
+  slack_configs:
+  - channel: '#noise-falco'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '{{ .Values.grafana.address }}/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{`{{ template "__alert_silence_link" . }}`}}'
+      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
 - name: sig_customers_slack
   slack_configs:


### PR DESCRIPTION
From https://github.com/giantswarm/g8s-prometheus/pull/1308

Towards https://github.com/giantswarm/giantswarm/issues/13754

We have a `#noise-falco` Slack channel. This sends stuff to it.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
