### PR TITLE
Add additional scrape configs from installation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `additionalScrapeConfigs` flag which accepts a string which will be appended to the management cluster scrape config
+  template for installation specific configuration.
+
 ## [1.48.0] - 2021-08-09
 
 ### Added

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -1570,6 +1570,10 @@
   relabel_configs:
 [[ include "_labelingschema" . | indent 2 ]]
 [[ end ]]
+[[- if .AdditionalScrapeConfigs ]]
+# installation-specific configs from config repo
+[[ .AdditionalScrapeConfigs ]]
+[[- end ]]
 [[ if eq .Provider "aws" ]]
 # aws-operator
 - job_name: [[ .ClusterID ]]-prometheus/aws-operator-[[ .ClusterID ]]/0
@@ -1803,117 +1807,6 @@
       app: mayu
   relabel_configs:
 [[ include "_labelingschema" . | indent 2 ]]
-[[- if eq .Installation "puma" ]]
-- job_name: management-cluster-blackbox-ingress-http
-  honor_labels: true
-  metrics_path: /probe
-  params:
-    module: [upstream_check]
-  static_configs:
-  - targets:
-    - 10.127.3.131:30038
-    - 10.127.3.131:30040
-    - 10.127.3.131:30042
-    - 10.127.3.131:30044
-    - 10.127.3.132:30038
-    - 10.127.3.132:30040
-    - 10.127.3.132:30042
-    - 10.127.3.132:30044
-    - 10.127.3.133:30038
-    - 10.127.3.133:30040
-    - 10.127.3.133:30042
-    - 10.127.3.133:30044
-    - 10.127.3.134:30038
-    - 10.127.3.134:30040
-    - 10.127.3.134:30042
-    - 10.127.3.134:30044
-    - 10.127.3.135:30038
-    - 10.127.3.135:30040
-    - 10.127.3.135:30042
-    - 10.127.3.135:30044
-    - 10.127.3.136:30038
-    - 10.127.3.136:30040
-    - 10.127.3.136:30042
-    - 10.127.3.136:30044
-    - 10.127.3.137:30038
-    - 10.127.3.137:30040
-    - 10.127.3.137:30042
-    - 10.127.3.137:30044
-    - 10.127.3.138:30038
-    - 10.127.3.138:30040
-    - 10.127.3.138:30042
-    - 10.127.3.138:30044
-    - 10.127.3.139:30038
-    - 10.127.3.139:30040
-    - 10.127.3.139:30042
-    - 10.127.3.139:30044
-    - 10.127.3.140:30038
-    - 10.127.3.140:30040
-    - 10.127.3.140:30042
-    - 10.127.3.140:30044
-    - 10.127.3.141:30038
-    - 10.127.3.141:30040
-    - 10.127.3.141:30042
-    - 10.127.3.141:30044
-    - 10.127.3.142:30038
-    - 10.127.3.142:30040
-    - 10.127.3.142:30042
-    - 10.127.3.142:30044
-    - 10.127.3.143:30038
-    - 10.127.3.143:30040
-    - 10.127.3.143:30042
-    - 10.127.3.143:30044
-    - 10.127.3.144:30038
-    - 10.127.3.144:30040
-    - 10.127.3.144:30042
-    - 10.127.3.144:30044
-    - 10.127.3.145:30038
-    - 10.127.3.145:30040
-    - 10.127.3.145:30042
-    - 10.127.3.145:30044
-    - 10.127.3.146:30038
-    - 10.127.3.146:30040
-    - 10.127.3.146:30042
-    - 10.127.3.146:30044
-    - 10.127.3.147:30038
-    - 10.127.3.147:30040
-    - 10.127.3.147:30042
-    - 10.127.3.147:30044
-    - 10.127.3.148:30038
-    - 10.127.3.148:30040
-    - 10.127.3.148:30042
-    - 10.127.3.148:30044
-    - 10.127.3.149:30038
-    - 10.127.3.149:30040
-    - 10.127.3.149:30042
-    - 10.127.3.149:30044
-    - 10.127.3.150:30038
-    - 10.127.3.150:30040
-    - 10.127.3.150:30042
-    - 10.127.3.150:30044
-    - 10.127.3.151:30038
-    - 10.127.3.151:30040
-    - 10.127.3.151:30042
-    - 10.127.3.151:30044
-    - 10.127.3.152:30038
-    - 10.127.3.152:30040
-    - 10.127.3.152:30042
-    - 10.127.3.152:30044
-    - 10.127.3.153:30038
-    - 10.127.3.153:30040
-    - 10.127.3.153:30042
-    - 10.127.3.153:30044
-  relabel_configs:
-  - source_labels: [__address__]
-    target_label: __param_target
-  - source_labels: [module]
-    target_label: __param_module
-  - source_labels: [__param_target]
-    target_label: instance
-  - target_label: __address__
-    replacement: tenant-clusters-prometheus-blackbox-exporter:9115
-[[ include "_labelingschema" . | indent 2 ]]
-[[- end ]]
 [[ end ]]
 - job_name: [[ .ClusterID ]]-prometheus/vault-[[ .ClusterID ]]/0
   honor_labels: true
@@ -1927,14 +1820,6 @@
     - [[ .Vault ]]:9005
     labels:
       app: cert-exporter
-[[- if or (eq .Installation "dragon") (eq .Installation "dinosaur") ]]q
-# DVAG uses HAProxy to allow traffic inside the management clusters.
-# We added an haproxy exporter on the vault node to ensure we can access vault from the management cluster
-  - targets:
-    - [[ .Vault ]]:9101
-    labels:
-      app: haproxy-exporter
-[[- end ]]
   relabel_configs:
 [[ include "_labelingschema" . | indent 2 ]]
 # nginx-ingress-controller

--- a/flag/service/prometheus/prometheus.go
+++ b/flag/service/prometheus/prometheus.go
@@ -1,15 +1,16 @@
 package prometheus
 
 type Prometheus struct {
-	Address     string
-	BaseDomain  string
-	Bastions    string
-	LogLevel    string
-	Mayu        string
-	Storage     PrometheusStorage
-	Retention   PrometheusRetention
-	RemoteWrite PrometheusRemoteWrite
-	Version     string
+	AdditionalScrapeConfigs string
+	Address                 string
+	BaseDomain              string
+	Bastions                string
+	LogLevel                string
+	Mayu                    string
+	Storage                 PrometheusStorage
+	Retention               PrometheusRetention
+	RemoteWrite             PrometheusRemoteWrite
+	Version                 string
 }
 
 type PrometheusStorage struct {

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -29,6 +29,10 @@ data:
           createPVC: {{ and .Values.alertmanager.storage.enabled .Values.alertmanager.storage.createPVC }}
           size: {{ .Values.alertmanager.storage.pvcSize }}
       prometheus:
+        {{- if .Values.prometheus.additionalScrapeConfigs }}
+        additionalScrapeConfigs: |-
+          {{- .Values.prometheus.additionalScrapeConfigs | nindent 10 }}
+        {{- end }}
         address: {{ .Values.prometheus.address }}
         baseDomain: {{ .Values.prometheus.host }}
         bastions:

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -47,6 +47,7 @@ managementCluster:
     kind: ""
 
 prometheus:
+  additionalScrapeConfigs: ""
   address: "https://prometheus:9090"
   bastions: []
   cortex:

--- a/main.go
+++ b/main.go
@@ -125,6 +125,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Alertmanager.Storage.Size, "1Gi", "Storage size for alertmanagers.")
 	daemonCommand.PersistentFlags().String(f.Service.Alertmanager.Version, "v0.22.1", "Alertmanager container image version.")
 
+	daemonCommand.PersistentFlags().String(f.Service.Prometheus.AdditionalScrapeConfigs, "", "Additional installation-specific scrape configs.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Address, "", "Address to access Prometheus UI.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.BaseDomain, "", "Base domain to create Prometheus Ingress resources under.")
 	daemonCommand.PersistentFlags().StringSlice(f.Service.Prometheus.Bastions, make([]string, 0), "Address of the bastions.")

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -30,13 +30,14 @@ type ControllerConfig struct {
 	HTTPSProxy string
 	NoProxy    string
 
-	Bastions     []string
-	Customer     string
-	Installation string
-	Pipeline     string
-	Provider     string
-	Region       string
-	Registry     string
+	AdditionalScrapeConfigs string
+	Bastions                []string
+	Customer                string
+	Installation            string
+	Pipeline                string
+	Provider                string
+	Region                  string
+	Registry                string
 
 	OpsgenieKey string
 

--- a/service/controller/legacy/controller.go
+++ b/service/controller/legacy/controller.go
@@ -25,13 +25,14 @@ type ControllerConfig struct {
 	HTTPSProxy string
 	NoProxy    string
 
-	Bastions     []string
-	Customer     string
-	Installation string
-	Pipeline     string
-	Provider     string
-	Region       string
-	Registry     string
+	AdditionalScrapeConfigs string
+	Bastions                []string
+	Customer                string
+	Installation            string
+	Pipeline                string
+	Provider                string
+	Region                  string
+	Registry                string
 
 	OpsgenieKey string
 

--- a/service/controller/managementcluster/controller.go
+++ b/service/controller/managementcluster/controller.go
@@ -25,13 +25,14 @@ type ControllerConfig struct {
 	HTTPSProxy string
 	NoProxy    string
 
-	Bastions     []string
-	Customer     string
-	Installation string
-	Pipeline     string
-	Provider     string
-	Region       string
-	Registry     string
+	AdditionalScrapeConfigs string
+	Bastions                []string
+	Customer                string
+	Installation            string
+	Pipeline                string
+	Provider                string
+	Region                  string
+	Registry                string
 
 	AlertmanagerAddress     string
 	AlertmanagerCreatePVC   bool

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -36,13 +36,14 @@ type resourcesConfig struct {
 	HTTPSProxy string
 	NoProxy    string
 
-	Bastions     []string
-	Customer     string
-	Installation string
-	Pipeline     string
-	Provider     string
-	Region       string
-	Registry     string
+	AdditionalScrapeConfigs string
+	Bastions                []string
+	Customer                string
+	Installation            string
+	Pipeline                string
+	Provider                string
+	Region                  string
+	Registry                string
 
 	AlertmanagerAddress     string
 	AlertmanagerCreatePVC   bool
@@ -232,13 +233,15 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var scrapeConfigResource resource.Interface
 	{
 		c := scrapeconfigs.Config{
-			K8sClient:    config.K8sClient,
-			Logger:       config.Logger,
-			Bastions:     config.Bastions,
-			Provider:     config.Provider,
-			Installation: config.Installation,
-			Mayu:         config.Mayu,
-			Vault:        config.Vault,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			AdditionalScrapeConfigs: config.AdditionalScrapeConfigs,
+			Bastions:                config.Bastions,
+			Provider:                config.Provider,
+			Installation:            config.Installation,
+			Mayu:                    config.Mayu,
+			Vault:                   config.Vault,
 		}
 
 		scrapeConfigResource, err = scrapeconfigs.New(c)

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -24,8 +24,10 @@ const (
 )
 
 type Config struct {
-	K8sClient                 k8sclient.Interface
-	Logger                    micrologger.Logger
+	K8sClient k8sclient.Interface
+	Logger    micrologger.Logger
+
+	AdditionalScrapeConfigs   string
 	Bastions                  []string
 	Installation              string
 	Provider                  string
@@ -36,6 +38,7 @@ type Config struct {
 }
 
 type TemplateData struct {
+	AdditionalScrapeConfigs   string
 	APIServerURL              string
 	Bastions                  []string
 	Provider                  string
@@ -158,6 +161,7 @@ func getTemplateData(cluster metav1.Object, config Config) (*TemplateData, error
 	clusterID := key.ClusterID(cluster)
 
 	d := &TemplateData{
+		AdditionalScrapeConfigs:   config.AdditionalScrapeConfigs,
 		APIServerURL:              key.APIUrl(cluster),
 		Bastions:                  config.Bastions,
 		ClusterID:                 clusterID,

--- a/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
@@ -89,16 +89,32 @@ func TestAzureScrapeconfigs(t *testing.T) {
 	}
 }
 
+const additionalScrapeConfigs = `- job_name: test1
+  static_configs:
+  - targets:
+    - 1.1.1.1:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+- job_name: test2
+  static_configs:
+  - targets:
+    - 8.8.8.8:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target`
+
 func TestKVMScrapeconfigs(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
 		path := path.Join(unittest.ProjectRoot(), templatePath)
 
 		config := Config{
-			TemplatePath: path,
-			Provider:     "kvm",
-			Vault:        "vault1.some-installation.test",
-			Installation: "test-installation",
+			AdditionalScrapeConfigs: additionalScrapeConfigs,
+			TemplatePath:            path,
+			Provider:                "kvm",
+			Vault:                   "vault1.some-installation.test",
+			Installation:            "test-installation",
 		}
 		testFunc = func(v interface{}) (interface{}, error) {
 			return toData(v, config)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -2564,6 +2564,21 @@
   - target_label: installation
     replacement: test-installation
 
+# installation-specific configs from config repo
+- job_name: test1
+  static_configs:
+  - targets:
+    - 1.1.1.1:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+- job_name: test2
+  static_configs:
+  - targets:
+    - 8.8.8.8:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
 
 
 

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -34,13 +34,14 @@ type Config struct {
 	HTTPSProxy string
 	NoProxy    string
 
-	Bastions     []string
-	Customer     string
-	Installation string
-	Pipeline     string
-	Provider     string
-	Region       string
-	Registry     string
+	AdditionalScrapeConfigs string
+	Bastions                []string
+	Customer                string
+	Installation            string
+	Pipeline                string
+	Provider                string
+	Region                  string
+	Registry                string
 
 	OpsgenieKey string
 
@@ -176,11 +177,13 @@ func New(config Config) ([]resource.Interface, error) {
 	var scrapeConfigResource resource.Interface
 	{
 		c := scrapeconfigs.Config{
-			K8sClient:    config.K8sClient,
-			Logger:       config.Logger,
-			Bastions:     config.Bastions,
-			Provider:     config.Provider,
-			Installation: config.Installation,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+
+			AdditionalScrapeConfigs: config.AdditionalScrapeConfigs,
+			Bastions:                config.Bastions,
+			Provider:                config.Provider,
+			Installation:            config.Installation,
 		}
 
 		scrapeConfigResource, err = scrapeconfigs.New(c)

--- a/service/service.go
+++ b/service/service.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 
+	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8srestconfig"
 	"github.com/giantswarm/microendpoint/service/version"
@@ -15,11 +16,9 @@ import (
 	"github.com/giantswarm/versionbundle"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	"github.com/spf13/viper"
-	"k8s.io/client-go/rest"
-
-	providerv1alpha1 "github.com/giantswarm/apiextensions/v3/pkg/apis/provider/v1alpha1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	"k8s.io/client-go/rest"
 	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
@@ -135,13 +134,14 @@ func New(config Config) (*Service, error) {
 			HTTPSProxy: os.Getenv("HTTPS_PROXY"),
 			NoProxy:    os.Getenv("NO_PROXY"),
 
-			Bastions:     config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
-			Customer:     config.Viper.GetString(config.Flag.Service.Installation.Customer),
-			Installation: config.Viper.GetString(config.Flag.Service.Installation.Name),
-			Pipeline:     config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
-			Provider:     provider,
-			Region:       config.Viper.GetString(config.Flag.Service.Installation.Region),
-			Registry:     config.Viper.GetString(config.Flag.Service.Installation.Registry),
+			AdditionalScrapeConfigs: config.Viper.GetString(config.Flag.Service.Prometheus.AdditionalScrapeConfigs),
+			Bastions:                config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
+			Customer:                config.Viper.GetString(config.Flag.Service.Installation.Customer),
+			Installation:            config.Viper.GetString(config.Flag.Service.Installation.Name),
+			Pipeline:                config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
+			Provider:                provider,
+			Region:                  config.Viper.GetString(config.Flag.Service.Installation.Region),
+			Registry:                config.Viper.GetString(config.Flag.Service.Installation.Registry),
 
 			OpsgenieKey: config.Viper.GetString(config.Flag.Service.Opsgenie.Key),
 
@@ -179,13 +179,14 @@ func New(config Config) (*Service, error) {
 			HTTPSProxy: os.Getenv("HTTPS_PROXY"),
 			NoProxy:    os.Getenv("NO_PROXY"),
 
-			Bastions:     config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
-			Customer:     config.Viper.GetString(config.Flag.Service.Installation.Customer),
-			Installation: config.Viper.GetString(config.Flag.Service.Installation.Name),
-			Pipeline:     config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
-			Provider:     provider,
-			Region:       config.Viper.GetString(config.Flag.Service.Installation.Region),
-			Registry:     config.Viper.GetString(config.Flag.Service.Installation.Registry),
+			AdditionalScrapeConfigs: config.Viper.GetString(config.Flag.Service.Prometheus.AdditionalScrapeConfigs),
+			Bastions:                config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
+			Customer:                config.Viper.GetString(config.Flag.Service.Installation.Customer),
+			Installation:            config.Viper.GetString(config.Flag.Service.Installation.Name),
+			Pipeline:                config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
+			Provider:                provider,
+			Region:                  config.Viper.GetString(config.Flag.Service.Installation.Region),
+			Registry:                config.Viper.GetString(config.Flag.Service.Installation.Registry),
 
 			OpsgenieKey: config.Viper.GetString(config.Flag.Service.Opsgenie.Key),
 
@@ -224,13 +225,14 @@ func New(config Config) (*Service, error) {
 			HTTPSProxy: os.Getenv("HTTPS_PROXY"),
 			NoProxy:    os.Getenv("NO_PROXY"),
 
-			Bastions:     config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
-			Customer:     config.Viper.GetString(config.Flag.Service.Installation.Customer),
-			Installation: config.Viper.GetString(config.Flag.Service.Installation.Name),
-			Pipeline:     config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
-			Provider:     provider,
-			Region:       config.Viper.GetString(config.Flag.Service.Installation.Region),
-			Registry:     config.Viper.GetString(config.Flag.Service.Installation.Registry),
+			AdditionalScrapeConfigs: config.Viper.GetString(config.Flag.Service.Prometheus.AdditionalScrapeConfigs),
+			Bastions:                config.Viper.GetStringSlice(config.Flag.Service.Prometheus.Bastions),
+			Customer:                config.Viper.GetString(config.Flag.Service.Installation.Customer),
+			Installation:            config.Viper.GetString(config.Flag.Service.Installation.Name),
+			Pipeline:                config.Viper.GetString(config.Flag.Service.Installation.Pipeline),
+			Provider:                provider,
+			Region:                  config.Viper.GetString(config.Flag.Service.Installation.Region),
+			Registry:                config.Viper.GetString(config.Flag.Service.Installation.Registry),
 
 			AlertmanagerAddress:     config.Viper.GetString(config.Flag.Service.Alertmanager.Address),
 			AlertmanagerCreatePVC:   config.Viper.GetBool(config.Flag.Service.Alertmanager.Storage.CreatePVC),
@@ -240,7 +242,8 @@ func New(config Config) (*Service, error) {
 			GrafanaAddress:          config.Viper.GetString(config.Flag.Service.Grafana.Address),
 			SlackApiURL:             config.Viper.GetString(config.Flag.Service.Slack.ApiURL),
 			SlackProjectName:        config.Viper.GetString(config.Flag.Service.Slack.ProjectName),
-			OpsgenieKey:             config.Viper.GetString(config.Flag.Service.Opsgenie.Key),
+
+			OpsgenieKey: config.Viper.GetString(config.Flag.Service.Opsgenie.Key),
 
 			PrometheusAddress:             config.Viper.GetString(config.Flag.Service.Prometheus.Address),
 			PrometheusBaseDomain:          config.Viper.GetString(config.Flag.Service.Prometheus.BaseDomain),


### PR DESCRIPTION
Towards https://github.com/giantswarm/telekom-panamax/issues/104

This change is being introduced so that we can have installation specific scrape configs defined in the `config` repo. This helps PMO to be more general and improves security/privacy by not having customer information defined in a public repo. Discussed in SIG Security here https://gigantic.slack.com/archives/C3S23JE75/p1628529921003700.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
