### PR TITLE
drop v1alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Drop `v1alpha2` scheme.
+
 ## [1.50.0] - 2021-08-16
 
 ### Changed

--- a/pkg/unittest/input/case-0-cluster-api.golden
+++ b/pkg/unittest/input/case-0-cluster-api.golden
@@ -1,4 +1,0 @@
-apiVersion: cluster.x-k8s.io/v1alpha2
-kind: Cluster
-metadata:
-  name: bob

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -15,7 +15,6 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/yaml"
 )
@@ -162,10 +161,6 @@ func inputValue(inputFile string) (pkgruntime.Object, error) {
 	// Giant Swarm objects.
 	s := pkgruntime.NewScheme()
 	err = scheme.AddToScheme(s)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	err = v1alpha2.AddToScheme(s)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -12,7 +12,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -123,8 +122,6 @@ func getClusterFactoryFunc(ctrlClient client.Client) (func() runtime.Object, err
 	// Decide which object to construct based on storage version.
 	var fn func() runtime.Object
 	switch storageVersion {
-	case "v1alpha2":
-		fn = func() runtime.Object { return new(capiv1alpha2.Cluster) }
 	case "v1alpha3":
 		fn = func() runtime.Object { return new(capiv1alpha3.Cluster) }
 	default:

--- a/service/service.go
+++ b/service/service.go
@@ -19,7 +19,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/prometheus-meta-operator/flag"
@@ -92,7 +91,6 @@ func New(config Config) (*Service, error) {
 			RestConfig: restConfig,
 			SchemeBuilder: k8sclient.SchemeBuilder{
 				apiextensionsv1.AddToScheme,
-				capiv1alpha2.AddToScheme,
 				capiv1alpha3.AddToScheme,
 				providerv1alpha1.AddToScheme,
 			},


### PR DESCRIPTION
AWS only uses `v1alpha2` till now but we switched to `v1alpha3` as stored version.
CRD Webhook converts all `v1alpha2` CR's to `v1alpha3`.

Dropping `v1alpha2` is needed for migration.

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`