### PR TITLE
Fix v1alpha2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Re-introduce `v1alpha2` scheme.
+
 ## [1.51.0] - 2021-09-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Drop `v1alpha2` scheme.
-- Reconcile `v1alpha3` cluster.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Drop `v1alpha2` scheme.
+- Reconcile `v1alpha3` cluster.
 
 ### Fixed
 

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd // indirect
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
 	sigs.k8s.io/cluster-api v0.3.19
+	sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/yaml v1.2.0
 )
 

--- a/pkg/unittest/input/case-0-cluster-api.golden
+++ b/pkg/unittest/input/case-0-cluster-api.golden
@@ -1,0 +1,4 @@
+apiVersion: cluster.x-k8s.io/v1alpha2
+kind: Cluster
+metadata:
+  name: bob

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -15,6 +15,7 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/yaml"
 )
@@ -161,6 +162,10 @@ func inputValue(inputFile string) (pkgruntime.Object, error) {
 	// Giant Swarm objects.
 	s := pkgruntime.NewScheme()
 	err = scheme.AddToScheme(s)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	err = v1alpha2.AddToScheme(s)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -129,5 +129,5 @@ func getClusterFactoryFunc(ctrlClient client.Client) (func() runtime.Object, err
 		}
 	}
 
-	return nil, microerror.Maskf(unsupportedStorageVersionError, "implementation does not support storage version %#v", crdVersions)
+	return nil, microerror.Maskf(unsupportedStorageVersionError, "implementation does not support storage version %q", crdVersions)
 }

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -1,15 +1,19 @@
 package clusterapi
 
 import (
+	"context"
+
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/v4/pkg/controller"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
@@ -69,16 +73,19 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		}
 	}
 
+	runtimeObjectFactoryFunc, err := getClusterFactoryFunc(config.K8sClient.CtrlClient())
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
-			Name:      project.Name() + "-cluster-api-controller",
-			NewRuntimeObjectFunc: func() runtime.Object {
-				return new(capiv1alpha3.Cluster)
-			},
-			Resources: resources,
+			K8sClient:            config.K8sClient,
+			Logger:               config.Logger,
+			Name:                 project.Name() + "-cluster-api-controller",
+			NewRuntimeObjectFunc: runtimeObjectFactoryFunc,
+			Resources:            resources,
 		}
 
 		operatorkitController, err = controller.New(c)
@@ -92,4 +99,34 @@ func NewController(config ControllerConfig) (*Controller, error) {
 	}
 
 	return c, nil
+}
+
+func getClusterFactoryFunc(ctrlClient client.Client) (func() runtime.Object, error) {
+	var clusterCRD apiextensionsv1.CustomResourceDefinition
+	err := ctrlClient.Get(context.Background(), client.ObjectKey{
+		Name: "clusters.cluster.x-k8s.io",
+	}, &clusterCRD)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Find out configured storage version.
+	var storageVersion string
+	for _, v := range clusterCRD.Spec.Versions {
+		if v.Storage {
+			storageVersion = v.Name
+			break
+		}
+	}
+
+	// Decide which object to construct based on storage version.
+	var fn func() runtime.Object
+	switch storageVersion {
+	case "v1alpha3":
+		fn = func() runtime.Object { return new(capiv1alpha3.Cluster) }
+	default:
+		return nil, microerror.Maskf(unsupportedStorageVersionError, "implementation does not support storage version %q", storageVersion)
+	}
+
+	return fn, nil
 }

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -12,6 +12,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -122,6 +123,8 @@ func getClusterFactoryFunc(ctrlClient client.Client) (func() runtime.Object, err
 	// Decide which object to construct based on storage version.
 	var fn func() runtime.Object
 	switch storageVersion {
+	case "v1alpha2":
+		fn = func() runtime.Object { return new(capiv1alpha2.Cluster) }
 	case "v1alpha3":
 		fn = func() runtime.Object { return new(capiv1alpha3.Cluster) }
 	default:

--- a/service/service.go
+++ b/service/service.go
@@ -21,6 +21,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
+	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/prometheus-meta-operator/flag"
@@ -93,6 +94,7 @@ func New(config Config) (*Service, error) {
 			RestConfig: restConfig,
 			SchemeBuilder: k8sclient.SchemeBuilder{
 				apiextensionsv1.AddToScheme,
+				capiv1alpha2.AddToScheme,
 				capiv1alpha3.AddToScheme,
 				providerv1alpha1.AddToScheme,
 			},


### PR DESCRIPTION
This PR make sure we reconcile v1alpha2 when needed, otherwise prefer v1alpha3.

`puma` only runs cluster v1alpha2

```
$ k --context giantswarm-puma get crd clusters.cluster.x-k8s.io -oyaml|yq -y '.spec.versions[]|{name, storage}'
name: v1alpha2
storage: true
```