### PR TITLE
Change Oauth2-proxy service name after appification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change oauth2-proxy service name.
 
 ### Removed
 

--- a/helm/prometheus-meta-operator/templates/ingress-oauth.yaml
+++ b/helm/prometheus-meta-operator/templates/ingress-oauth.yaml
@@ -15,7 +15,7 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: oauth2-proxy
+          serviceName: oauth2-proxy-app
           servicePort: 4180
         path: /oauth2
   tls:


### PR DESCRIPTION
## Checklist

Service name changed after https://github.com/giantswarm/oauth2-proxy-app/pull/31

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
