### PR TITLE
Fixes finding certificates in organization namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix finding certificates in organization namespaces.
 
 ### Removed
 

--- a/service/controller/resource/certificates/resource.go
+++ b/service/controller/resource/certificates/resource.go
@@ -137,9 +137,12 @@ func (r *Resource) getSource(ctx context.Context, v interface{}) (*corev1.Secret
 		secretName := source.NameFunc(cluster)
 		secretNamespace := source.NamespaceFunc(cluster)
 
+		r.logger.Debugf(ctx, "searching for secret %v/%v", secretNamespace, secretName)
+
 		secret, err = r.k8sClient.K8sClient().CoreV1().Secrets(secretNamespace).Get(ctx, secretName, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			// fallthrough
+			r.logger.Debugf(ctx, "did not find secret %v/%v", secretNamespace, secretName)
 			secret = nil
 		} else if err != nil {
 			return nil, microerror.Mask(err)
@@ -147,6 +150,7 @@ func (r *Resource) getSource(ctx context.Context, v interface{}) (*corev1.Secret
 
 		if secret != nil {
 			// We return the first secret we find
+			r.logger.Debugf(ctx, "found secret %v/%v", secretNamespace, secretName)
 			return secret, nil
 		}
 	}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -89,6 +89,10 @@ func New(config Config) ([]resource.Interface, error) {
 					NamespaceFunc: key.NamespaceDefault,
 				},
 				{
+					NameFunc:      key.Namespace,
+					NamespaceFunc: key.OrganizationNamespace,
+				},
+				{
 					NameFunc:      key.CAPICertificateName,
 					NamespaceFunc: key.CAPICertificateNamespace,
 				},

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -51,6 +51,10 @@ func NamespaceDefault(cluster metav1.Object) string {
 	return v1.NamespaceDefault
 }
 
+func OrganizationNamespace(cluster metav1.Object) string {
+	return cluster.GetNamespace()
+}
+
 func NamespaceMonitoring() string {
 	return monitoring
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/19571

With AWS clusters > v16.0.0, we store certificates in the organization namespace. This PR adds support for searching the organization namespace for certificates.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
