### PR TITLE
Upgrade alertmanager/config to v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade alertmanager to v0.23.0
+
 ## [1.51.2] - 2021-10-28
 
 ### Fixed

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,8 @@ require (
 	github.com/giantswarm/micrologger v0.5.0
 	github.com/giantswarm/operatorkit/v4 v4.3.1
 	github.com/giantswarm/versionbundle v0.2.0
-	github.com/go-kit/kit v0.12.0
+	github.com/go-kit/kit v0.12.0 // indirect
+	github.com/go-kit/log v0.2.0
 	github.com/go-logr/logr v0.3.0 // indirect
 	github.com/google/go-cmp v0.5.6
 	github.com/google/gofuzz v1.2.0 // indirect
@@ -30,6 +31,7 @@ require (
 	github.com/prometheus/alertmanager v0.23.0
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/common v0.30.0
+	github.com/prometheus/common/sigv4 v0.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/viper v1.9.0
 	golang.org/x/net v0.0.0-20210917221730-978cfadd31cf

--- a/go.sum
+++ b/go.sum
@@ -116,6 +116,7 @@ github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN
 github.com/aws/aws-sdk-go v1.34.28/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
 github.com/aws/aws-sdk-go v1.38.35/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go v1.40.11/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
+github.com/aws/aws-sdk-go v1.40.45 h1:QN1nsY27ssD/JmW4s83qmSb+uL6DG4GmCDzjmJB4xUI=
 github.com/aws/aws-sdk-go v1.40.45/go.mod h1:585smgzpB/KqRA+K3y/NL/oYRqQvpNJYvLm+LY1U59Q=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aws/aws-sdk-go-v2 v1.9.1/go.mod h1:cK/D0BBs0b/oWPIcX/Z/obahJK1TT7IPVjy53i/mX/4=
@@ -625,7 +626,9 @@ github.com/iris-contrib/schema v0.0.1/go.mod h1:urYA3uvUNG1TIIjOSCzHr9/LmbQo8LrO
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -897,6 +900,7 @@ github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9
 github.com/prometheus/common v0.29.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
 github.com/prometheus/common v0.30.0 h1:JEkYlQnpzrzQFxi6gnukFPdQ+ac82oRhzMcIduJu/Ug=
 github.com/prometheus/common v0.30.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
+github.com/prometheus/common/sigv4 v0.1.0 h1:qoVebwtwwEhS85Czm2dSROY5fTo2PAPEVdDeppTwGX4=
 github.com/prometheus/common/sigv4 v0.1.0/go.mod h1:2Jkxxk9yYvCkE5G1sQT7GuEXm57JrvHu9k5YwTjsNtI=
 github.com/prometheus/exporter-toolkit v0.6.1/go.mod h1:ZUBIj498ePooX9t/2xtDjeQYwvRpiPP2lh5u4iblj2g=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=

--- a/pkg/alertmanager/config/config.go
+++ b/pkg/alertmanager/config/config.go
@@ -95,7 +95,7 @@ func (u URL) MarshalJSON() ([]byte, error) {
 	if u.URL != nil {
 		return json.Marshal(u.URL.String())
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // UnmarshalJSON implements the json.Marshaler interface for URL.
@@ -215,6 +215,9 @@ func resolveFilepaths(baseDir string, cfg *Config) {
 			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
 		for _, cfg := range receiver.WechatConfigs {
+			cfg.HTTPConfig.SetDirectory(baseDir)
+		}
+		for _, cfg := range receiver.SNSConfigs {
 			cfg.HTTPConfig.SetDirectory(baseDir)
 		}
 	}
@@ -420,6 +423,11 @@ func (c *Config) UnmarshalYAML(unmarshal func(interface{}) error) error {
 					return fmt.Errorf("no global VictorOps API Key set")
 				}
 				voc.APIKey = c.Global.VictorOpsAPIKey
+			}
+		}
+		for _, sns := range rcv.SNSConfigs {
+			if sns.HTTPConfig == nil {
+				sns.HTTPConfig = c.Global.HTTPConfig
 			}
 		}
 		names[rcv.Name] = struct{}{}
@@ -759,6 +767,7 @@ type Receiver struct {
 	WechatConfigs    []*WechatConfig    `yaml:"wechat_configs,omitempty" json:"wechat_configs,omitempty"`
 	PushoverConfigs  []*PushoverConfig  `yaml:"pushover_configs,omitempty" json:"pushover_configs,omitempty"`
 	VictorOpsConfigs []*VictorOpsConfig `yaml:"victorops_configs,omitempty" json:"victorops_configs,omitempty"`
+	SNSConfigs       []*SNSConfig       `yaml:"sns_configs,omitempty" json:"sns_configs,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for Receiver.
@@ -842,7 +851,7 @@ func (re Regexp) MarshalJSON() ([]byte, error) {
 	if re.original != "" {
 		return json.Marshal(re.original)
 	}
-	return nil, nil
+	return []byte("null"), nil
 }
 
 // Matchers is label.Matchers with an added UnmarshalYAML method to implement the yaml.Unmarshaler interface
@@ -895,7 +904,7 @@ func (m *Matchers) UnmarshalJSON(data []byte) error {
 // MarshalJSON implements the json.Marshaler interface for Matchers.
 func (m Matchers) MarshalJSON() ([]byte, error) {
 	if len(m) == 0 {
-		return nil, nil
+		return []byte("[]"), nil
 	}
 	result := make([]string, len(m))
 	for i, matcher := range m {

--- a/pkg/alertmanager/config/coordinator.go
+++ b/pkg/alertmanager/config/coordinator.go
@@ -18,8 +18,8 @@ import (
 	"encoding/binary"
 	"sync"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 	"github.com/prometheus/client_golang/prometheus"
 )
 

--- a/pkg/alertmanager/config/notifiers.go
+++ b/pkg/alertmanager/config/notifiers.go
@@ -21,8 +21,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	commoncfg "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
 	"github.com/prometheus/common/sigv4"
+
+	commoncfg "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
 )
 
 var (

--- a/pkg/alertmanager/config/notifiers.go
+++ b/pkg/alertmanager/config/notifiers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 
 	commoncfg "github.com/giantswarm/prometheus-meta-operator/pkg/prometheus/common/config"
+	"github.com/prometheus/common/sigv4"
 )
 
 var (
@@ -126,6 +127,15 @@ var (
 		Retry:    duration(1 * time.Minute),
 		Expire:   duration(1 * time.Hour),
 		HTML:     false,
+	}
+
+	// DefaultSNSConfig defines default values for SNS configurations.
+	DefaultSNSConfig = SNSConfig{
+		NotifierConfig: NotifierConfig{
+			VSendResolved: true,
+		},
+		Subject: `{{ template "sns.default.subject" . }}`,
+		Message: `{{ template "sns.default.message" . }}`,
 	}
 )
 
@@ -576,6 +586,37 @@ func (c *PushoverConfig) UnmarshalYAML(unmarshal func(interface{}) error) error 
 	}
 	if c.Token == "" {
 		return fmt.Errorf("missing token in Pushover config")
+	}
+	return nil
+}
+
+type SNSConfig struct {
+	NotifierConfig `yaml:",inline" json:",inline"`
+
+	HTTPConfig *commoncfg.HTTPClientConfig `yaml:"http_config,omitempty" json:"http_config,omitempty"`
+
+	APIUrl      string            `yaml:"api_url,omitempty" json:"api_url,omitempty"`
+	Sigv4       sigv4.SigV4Config `yaml:"sigv4" json:"sigv4"`
+	TopicARN    string            `yaml:"topic_arn,omitempty" json:"topic_arn,omitempty"`
+	PhoneNumber string            `yaml:"phone_number,omitempty" json:"phone_number,omitempty"`
+	TargetARN   string            `yaml:"target_arn,omitempty" json:"target_arn,omitempty"`
+	Subject     string            `yaml:"subject,omitempty" json:"subject,omitempty"`
+	Message     string            `yaml:"message,omitempty" json:"message,omitempty"`
+	Attributes  map[string]string `yaml:"attributes,omitempty" json:"attributes,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *SNSConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	*c = DefaultSNSConfig
+	type plain SNSConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+	if (c.TargetARN == "") != (c.TopicARN == "") != (c.PhoneNumber == "") {
+		return fmt.Errorf("must provide either a Target ARN, Topic ARN, or Phone Number for SNS config")
+	}
+	if (c.Sigv4.AccessKey == "") != (c.Sigv4.SecretKey == "") {
+		return fmt.Errorf("must provide a AWS SigV4 Access key and Secret Key if credentials are specified in the SNS config")
 	}
 	return nil
 }

--- a/pkg/alertmanager/config/testdata/conf.sns-invalid.yml
+++ b/pkg/alertmanager/config/testdata/conf.sns-invalid.yml
@@ -1,0 +1,14 @@
+route:
+  receiver: 'sns-api-notifications'
+  group_by: [alertname]
+
+receivers:
+  - name: 'sns-api-notifications'
+    sns_configs:
+      - api_url: https://sns.us-east-2.amazonaws.com
+        sigv4:
+          region: us-east-2
+          access_key: access_key
+          secret_key: secret_ket
+        attributes:
+          severity: Sev2

--- a/pkg/alertmanager/config/testdata/conf.sns-topic-arn.yml
+++ b/pkg/alertmanager/config/testdata/conf.sns-topic-arn.yml
@@ -1,0 +1,15 @@
+route:
+  receiver: 'sns-api-notifications'
+  group_by: [alertname]
+
+receivers:
+- name: 'sns-api-notifications'
+  sns_configs:
+    - api_url: https://sns.us-east-2.amazonaws.com
+      topic_arn: arn:aws:sns:us-east-2:123456789012:My-Topic
+      sigv4:
+        region: us-east-2
+        access_key: access_key
+        secret_key: secret_ket
+      attributes:
+        severity: Sev2


### PR DESCRIPTION
This PR upgrade alertmanager/config upstream code in this repository to v0.23.0

This is to keep things aligned after merging https://github.com/giantswarm/prometheus-meta-operator/pull/707