### PR TITLE
Avoid defaulting node role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix defaulting of node role when the `role` label is missing in the Kubernetes `Node` resource.
+- Avoid defaulting of `role` label (containing the role of the k8s node). If data is missing we can't reliably default it.
 
 ## [1.51.2] - 2021-10-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade alertmanager to v0.23.0
 
+### Fixed
+
+- Fix defaulting of node role when the `role` label is missing in the Kubernetes `Node` resource.
+
 ## [1.51.2] - 2021-10-28
 
 ### Fixed

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -4,7 +4,7 @@
   target_label: role
 # If role is empty, we default to worker
 - source_labels: [__meta_kubernetes_node_label_role]
-  regex: null
+  regex: ^$
   target_label: role
   replacement: worker
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -2,15 +2,4 @@
 # Add role label.
 - source_labels: [__meta_kubernetes_node_label_role]
   target_label: role
-# Add a temporary label.
-- source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-  target_label: default_role
-  replacement: worker
-# If role is empty, we default to worker
-#- source_labels: [role, default_role]
-#  action: replace
-#  separator: ;
-#  regex: ;(.*)
-#  target_label: role
-#  replacement: $1
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -2,9 +2,14 @@
 # Add role label.
 - source_labels: [__meta_kubernetes_node_label_role]
   target_label: role
-# If role is empty, we default to worker
-- source_labels: [__meta_kubernetes_node_label_role]
-  regex: ''
-  target_label: role
+# Add a temporary label.
+- source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+  target_label: default_role
   replacement: worker
+# If role is empty, we default to worker
+- source_labels: [role, default_role]
+  separator: ;
+  regex: ';(.*)'
+  target_label: role
+  replacement: $1
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -7,10 +7,10 @@
   target_label: default_role
   replacement: worker
 # If role is empty, we default to worker
-- source_labels: [role, default_role]
-  action: replace
-  separator: ;
-  regex: ;(.*)
-  target_label: role
-  replacement: $1
+#- source_labels: [role, default_role]
+#  action: replace
+#  separator: ;
+#  regex: ;(.*)
+#  target_label: role
+#  replacement: $1
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -9,7 +9,7 @@
 # If role is empty, we default to worker
 - source_labels: [role, default_role]
   separator: ;
-  regex: ';(.*)'
+  regex: ;(.*)
   target_label: role
   replacement: $1
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -4,7 +4,7 @@
   target_label: role
 # If role is empty, we default to worker
 - source_labels: [__meta_kubernetes_node_label_role]
-  regex: ^$
+  regex: ''
   target_label: role
   replacement: worker
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_role.yaml
+++ b/files/templates/scrapeconfigs/_node_role.yaml
@@ -8,6 +8,7 @@
   replacement: worker
 # If role is empty, we default to worker
 - source_labels: [role, default_role]
+  action: replace
   separator: ;
   regex: ;(.*)
   target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -358,7 +358,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -431,7 +431,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -484,7 +484,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -544,7 +544,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -616,7 +616,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -689,7 +689,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -764,7 +764,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -841,7 +841,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -920,7 +920,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -999,7 +999,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1168,7 +1168,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1281,7 +1281,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -361,12 +361,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -435,12 +435,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -489,12 +489,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -550,12 +550,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -623,12 +623,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -697,12 +697,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -773,12 +773,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -851,12 +851,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -931,12 +931,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1011,12 +1011,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1096,12 +1096,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1182,12 +1182,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1296,12 +1296,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -356,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -430,17 +364,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -484,17 +407,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -545,17 +457,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -618,17 +519,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -692,17 +582,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -768,17 +647,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -846,17 +714,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -926,17 +783,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1006,17 +852,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1091,17 +926,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1177,17 +1001,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1291,17 +1104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -326,11 +351,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -394,11 +424,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -442,11 +477,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -497,11 +537,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -564,11 +609,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -632,11 +682,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -702,11 +757,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -774,11 +834,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -848,11 +913,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -922,11 +992,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1001,11 +1076,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1081,11 +1161,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1189,11 +1274,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -357,6 +362,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -430,6 +436,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -483,6 +490,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -543,6 +551,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -615,6 +624,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -688,6 +698,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -763,6 +774,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -840,6 +852,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -919,6 +932,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -998,6 +1012,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1082,6 +1097,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1167,6 +1183,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1280,6 +1297,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -358,7 +358,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -431,7 +431,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -484,7 +484,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -544,7 +544,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -616,7 +616,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -689,7 +689,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -764,7 +764,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -841,7 +841,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -920,7 +920,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -999,7 +999,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1168,7 +1168,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1281,7 +1281,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -356,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -430,17 +364,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -484,17 +407,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -545,17 +457,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -618,17 +519,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -692,17 +582,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -768,17 +647,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -846,17 +714,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -926,17 +783,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1006,17 +852,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1091,17 +926,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1177,17 +1001,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1291,17 +1104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -361,12 +361,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -435,12 +435,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -489,12 +489,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -550,12 +550,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -623,12 +623,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -697,12 +697,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -773,12 +773,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -851,12 +851,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -931,12 +931,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1011,12 +1011,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1096,12 +1096,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1182,12 +1182,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1296,12 +1296,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -326,11 +351,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -394,11 +424,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -442,11 +477,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -497,11 +537,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -564,11 +609,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -632,11 +682,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -702,11 +757,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -774,11 +834,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -848,11 +913,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -922,11 +992,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1001,11 +1076,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1081,11 +1161,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1189,11 +1274,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -357,6 +362,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -430,6 +436,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -483,6 +490,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -543,6 +551,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -615,6 +624,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -688,6 +698,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -763,6 +774,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -840,6 +852,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -919,6 +932,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -998,6 +1012,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1082,6 +1097,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1167,6 +1183,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1280,6 +1297,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -326,11 +351,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -394,11 +424,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -442,11 +477,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -497,11 +537,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -564,11 +609,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -632,11 +682,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -702,11 +757,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -774,11 +834,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -848,11 +913,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -922,11 +992,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1001,11 +1076,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1081,11 +1161,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1189,11 +1274,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -358,7 +358,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -431,7 +431,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -484,7 +484,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -544,7 +544,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -616,7 +616,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -689,7 +689,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -764,7 +764,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -841,7 +841,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -920,7 +920,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -999,7 +999,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1168,7 +1168,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1281,7 +1281,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -356,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -430,17 +364,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -484,17 +407,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -545,17 +457,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -618,17 +519,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -692,17 +582,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -768,17 +647,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -846,17 +714,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -926,17 +783,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1006,17 +852,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1091,17 +926,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1177,17 +1001,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1291,17 +1104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -361,12 +361,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -435,12 +435,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -489,12 +489,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -550,12 +550,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -623,12 +623,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -697,12 +697,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -773,12 +773,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -851,12 +851,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -931,12 +931,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1011,12 +1011,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1096,12 +1096,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1182,12 +1182,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1296,12 +1296,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -357,6 +362,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -430,6 +436,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -483,6 +490,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -543,6 +551,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -615,6 +624,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -688,6 +698,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -763,6 +774,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -840,6 +852,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -919,6 +932,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -998,6 +1012,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1082,6 +1097,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1167,6 +1183,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1280,6 +1297,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -361,12 +361,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -435,12 +435,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -489,12 +489,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -550,12 +550,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -623,12 +623,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -697,12 +697,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -773,12 +773,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -851,12 +851,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -931,12 +931,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1011,12 +1011,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1096,12 +1096,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1182,12 +1182,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1296,12 +1296,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -358,7 +358,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -431,7 +431,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -484,7 +484,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -544,7 +544,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -616,7 +616,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -689,7 +689,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -764,7 +764,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -841,7 +841,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -920,7 +920,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -999,7 +999,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1168,7 +1168,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1281,7 +1281,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -356,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -430,17 +364,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -484,17 +407,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -545,17 +457,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -618,17 +519,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -692,17 +582,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -768,17 +647,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -846,17 +714,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -926,17 +783,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1006,17 +852,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1091,17 +926,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1177,17 +1001,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1291,17 +1104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -326,11 +351,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -394,11 +424,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -442,11 +477,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -497,11 +537,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -564,11 +609,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -632,11 +682,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -702,11 +757,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -774,11 +834,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -848,11 +913,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -922,11 +992,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1001,11 +1076,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1081,11 +1161,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1189,11 +1274,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -357,6 +362,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -430,6 +436,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -483,6 +490,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -543,6 +551,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -615,6 +624,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -688,6 +698,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -763,6 +774,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -840,6 +852,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -919,6 +932,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -998,6 +1012,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1082,6 +1097,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1167,6 +1183,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1280,6 +1297,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -328,7 +328,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -396,7 +396,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -444,7 +444,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -499,7 +499,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -566,7 +566,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -634,7 +634,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -704,7 +704,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -776,7 +776,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -850,7 +850,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -924,7 +924,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1003,7 +1003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1083,7 +1083,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1191,7 +1191,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -284,7 +284,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -347,7 +347,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -388,7 +388,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -436,7 +436,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -496,7 +496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -557,7 +557,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -620,7 +620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -685,7 +685,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -752,7 +752,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -819,7 +819,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -891,7 +891,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -964,7 +964,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1039,7 +1039,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1216,7 +1216,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1287,7 +1287,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1356,7 +1356,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1425,7 +1425,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1496,7 +1496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1567,7 +1567,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1638,7 +1638,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1709,7 +1709,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1778,7 +1778,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1849,7 +1849,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1920,7 +1920,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1989,7 +1989,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2058,7 +2058,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2127,7 +2127,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2195,7 +2195,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2263,7 +2263,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2331,7 +2331,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2399,7 +2399,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2467,7 +2467,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2535,7 +2535,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2603,7 +2603,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2768,7 +2768,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -284,7 +284,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -347,7 +347,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -388,7 +388,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -436,7 +436,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -496,7 +496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -557,7 +557,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -620,7 +620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -685,7 +685,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -752,7 +752,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -819,7 +819,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -891,7 +891,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -964,7 +964,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1039,7 +1039,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1216,7 +1216,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1287,7 +1287,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1356,7 +1356,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1425,7 +1425,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1496,7 +1496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1567,7 +1567,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1638,7 +1638,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1709,7 +1709,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1778,7 +1778,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1849,7 +1849,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1920,7 +1920,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1989,7 +1989,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2058,7 +2058,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2127,7 +2127,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2195,7 +2195,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2263,7 +2263,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2331,7 +2331,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2399,7 +2399,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2467,7 +2467,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2535,7 +2535,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2603,7 +2603,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2768,7 +2768,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -40,6 +40,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -88,6 +89,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -138,6 +140,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -199,6 +202,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -253,6 +257,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -313,6 +318,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -381,6 +387,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -427,6 +434,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -480,6 +488,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -545,6 +554,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -611,6 +621,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -679,6 +690,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -749,6 +761,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -821,6 +834,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -893,6 +907,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -970,6 +985,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1048,6 +1064,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1128,6 +1145,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1244,6 +1262,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1315,6 +1334,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1391,6 +1411,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1465,6 +1486,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1539,6 +1561,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1615,6 +1638,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1691,6 +1715,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1767,6 +1792,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1843,6 +1869,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1917,6 +1944,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1993,6 +2021,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2069,6 +2098,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2143,6 +2173,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2217,6 +2248,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2291,6 +2323,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2364,6 +2397,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2437,6 +2471,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2510,6 +2545,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2583,6 +2619,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2656,6 +2693,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2729,6 +2767,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2802,6 +2841,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2878,6 +2918,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2977,6 +3018,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -34,11 +34,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -77,11 +82,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -122,11 +132,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -178,11 +193,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -227,11 +247,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -282,11 +307,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -345,11 +375,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -386,11 +421,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -434,11 +474,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -494,11 +539,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -555,11 +605,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -618,11 +673,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -683,11 +743,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -750,11 +815,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -817,11 +887,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -889,11 +964,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -962,11 +1042,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1037,11 +1122,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1148,11 +1238,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1214,11 +1309,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1285,11 +1385,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1354,11 +1459,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1423,11 +1533,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1494,11 +1609,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1565,11 +1685,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1636,11 +1761,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1707,11 +1837,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1776,11 +1911,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1847,11 +1987,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1918,11 +2063,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1987,11 +2137,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2056,11 +2211,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2125,11 +2285,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2193,11 +2358,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2261,11 +2431,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2329,11 +2504,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2397,11 +2577,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2465,11 +2650,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2533,11 +2723,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2601,11 +2796,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2672,11 +2872,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2766,11 +2971,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -34,17 +34,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -83,17 +72,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -134,17 +112,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -196,17 +163,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -251,17 +207,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -312,17 +257,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -381,17 +315,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -428,17 +351,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -482,17 +394,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -548,17 +449,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -615,17 +505,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -684,17 +563,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -755,17 +623,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -828,17 +685,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -901,17 +747,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -979,17 +814,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1058,17 +882,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1139,17 +952,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1256,17 +1058,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1328,17 +1119,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1405,17 +1185,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1480,17 +1249,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1555,17 +1313,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1632,17 +1379,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1709,17 +1445,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1786,17 +1511,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1863,17 +1577,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1938,17 +1641,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2015,17 +1707,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2092,17 +1773,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2167,17 +1837,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2242,17 +1901,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2317,17 +1965,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2391,17 +2028,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2465,17 +2091,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2539,17 +2154,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2613,17 +2217,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2687,17 +2280,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2761,17 +2343,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2835,17 +2406,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2912,17 +2472,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3012,17 +2561,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -41,7 +41,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -89,7 +89,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -139,7 +139,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -200,7 +200,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -254,7 +254,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -314,7 +314,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -382,7 +382,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -428,7 +428,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -481,7 +481,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -546,7 +546,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -612,7 +612,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -680,7 +680,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -750,7 +750,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -822,7 +822,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -894,7 +894,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -971,7 +971,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1049,7 +1049,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1245,7 +1245,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1316,7 +1316,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1392,7 +1392,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1466,7 +1466,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1540,7 +1540,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1616,7 +1616,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1692,7 +1692,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1768,7 +1768,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1844,7 +1844,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1918,7 +1918,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1994,7 +1994,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2070,7 +2070,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2144,7 +2144,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2218,7 +2218,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2292,7 +2292,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2365,7 +2365,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2438,7 +2438,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2511,7 +2511,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2584,7 +2584,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2657,7 +2657,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2730,7 +2730,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2803,7 +2803,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2879,7 +2879,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2978,7 +2978,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -39,12 +39,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -88,12 +88,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -139,12 +139,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -201,12 +201,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -256,12 +256,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -317,12 +317,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -386,12 +386,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -433,12 +433,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -487,12 +487,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -553,12 +553,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -620,12 +620,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -689,12 +689,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -760,12 +760,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -833,12 +833,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -906,12 +906,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -984,12 +984,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1063,12 +1063,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1144,12 +1144,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1261,12 +1261,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1333,12 +1333,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1410,12 +1410,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1485,12 +1485,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1560,12 +1560,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1637,12 +1637,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1714,12 +1714,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1791,12 +1791,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1868,12 +1868,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1943,12 +1943,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2020,12 +2020,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2097,12 +2097,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2172,12 +2172,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2247,12 +2247,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2322,12 +2322,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2396,12 +2396,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2470,12 +2470,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2544,12 +2544,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2618,12 +2618,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2692,12 +2692,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2766,12 +2766,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2840,12 +2840,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2917,12 +2917,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3017,12 +3017,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -284,7 +284,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -347,7 +347,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -388,7 +388,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -436,7 +436,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -496,7 +496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -557,7 +557,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -620,7 +620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -685,7 +685,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -752,7 +752,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -819,7 +819,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -891,7 +891,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -964,7 +964,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1039,7 +1039,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1216,7 +1216,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1287,7 +1287,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1356,7 +1356,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1425,7 +1425,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1496,7 +1496,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1567,7 +1567,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1638,7 +1638,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1709,7 +1709,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1778,7 +1778,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1849,7 +1849,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1920,7 +1920,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1989,7 +1989,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2058,7 +2058,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2127,7 +2127,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2195,7 +2195,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2263,7 +2263,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2331,7 +2331,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2399,7 +2399,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2467,7 +2467,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2535,7 +2535,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2603,7 +2603,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2768,7 +2768,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -154,11 +164,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -210,11 +225,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -272,11 +292,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -341,11 +366,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -389,11 +419,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -444,11 +479,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -511,11 +551,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -579,11 +624,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -649,11 +699,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -721,11 +776,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -795,11 +855,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -869,11 +934,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -948,11 +1018,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1028,11 +1103,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1136,11 +1216,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -171,7 +171,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -232,7 +232,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -299,7 +299,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -373,7 +373,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -426,7 +426,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -486,7 +486,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -558,7 +558,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -631,7 +631,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -706,7 +706,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -783,7 +783,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -862,7 +862,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -941,7 +941,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1025,7 +1025,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1110,7 +1110,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1223,7 +1223,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -170,6 +172,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -231,6 +234,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -298,6 +302,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -372,6 +377,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -425,6 +431,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -485,6 +492,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -557,6 +565,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -630,6 +639,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -705,6 +715,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -782,6 +793,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -861,6 +873,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -940,6 +953,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1024,6 +1038,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1109,6 +1124,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1222,6 +1238,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -166,17 +144,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,17 +195,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -296,17 +252,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -371,17 +316,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -425,17 +359,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -486,17 +409,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -559,17 +471,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -633,17 +534,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -709,17 +599,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -787,17 +666,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -867,17 +735,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -947,17 +804,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1032,17 +878,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1118,17 +953,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1232,17 +1056,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -171,12 +171,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -233,12 +233,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -301,12 +301,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -376,12 +376,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -430,12 +430,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -491,12 +491,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -564,12 +564,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -638,12 +638,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -714,12 +714,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -792,12 +792,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -872,12 +872,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -952,12 +952,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1037,12 +1037,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1123,12 +1123,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1237,12 +1237,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -274,7 +274,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -343,7 +343,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -391,7 +391,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -446,7 +446,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -581,7 +581,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -651,7 +651,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -723,7 +723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -797,7 +797,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -871,7 +871,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -950,7 +950,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1030,7 +1030,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1138,7 +1138,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -274,7 +274,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -343,7 +343,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -391,7 +391,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -446,7 +446,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -581,7 +581,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -651,7 +651,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -723,7 +723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -797,7 +797,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -871,7 +871,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -950,7 +950,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1030,7 +1030,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1138,7 +1138,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -274,7 +274,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -343,7 +343,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -391,7 +391,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -446,7 +446,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -581,7 +581,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -651,7 +651,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -723,7 +723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -797,7 +797,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -871,7 +871,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -950,7 +950,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1030,7 +1030,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1138,7 +1138,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -363,6 +368,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -416,6 +422,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -476,6 +483,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -548,6 +556,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -621,6 +630,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -696,6 +706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -773,6 +784,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -852,6 +864,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -931,6 +944,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1015,6 +1029,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1100,6 +1115,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1213,6 +1229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -364,7 +364,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -417,7 +417,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -477,7 +477,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -549,7 +549,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -622,7 +622,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -697,7 +697,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -774,7 +774,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -853,7 +853,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -932,7 +932,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1016,7 +1016,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1101,7 +1101,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1214,7 +1214,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -367,12 +367,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -421,12 +421,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -482,12 +482,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -555,12 +555,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -629,12 +629,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -705,12 +705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -783,12 +783,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -863,12 +863,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -943,12 +943,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1028,12 +1028,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1114,12 +1114,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1228,12 +1228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -362,17 +307,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -416,17 +350,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -477,17 +400,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -550,17 +462,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -624,17 +525,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -700,17 +590,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -778,17 +657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -858,17 +726,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -938,17 +795,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1023,17 +869,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1109,17 +944,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1223,17 +1047,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: bob-prometheus/cluster-autoscaler-bob/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -332,11 +357,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -380,11 +410,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -435,11 +470,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -502,11 +542,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -570,11 +615,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -640,11 +690,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -712,11 +767,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -786,11 +846,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -860,11 +925,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -939,11 +1009,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1019,11 +1094,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1127,11 +1207,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -363,6 +368,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -416,6 +422,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -476,6 +483,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -548,6 +556,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -621,6 +630,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -696,6 +706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -773,6 +784,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -852,6 +864,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -931,6 +944,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1015,6 +1029,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1100,6 +1115,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1213,6 +1229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -364,7 +364,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -417,7 +417,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -477,7 +477,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -549,7 +549,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -622,7 +622,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -697,7 +697,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -774,7 +774,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -853,7 +853,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -932,7 +932,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1016,7 +1016,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1101,7 +1101,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1214,7 +1214,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -362,17 +307,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -416,17 +350,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -477,17 +400,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -550,17 +462,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -624,17 +525,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -700,17 +590,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -778,17 +657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -858,17 +726,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -938,17 +795,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1023,17 +869,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1109,17 +944,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1223,17 +1047,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -332,11 +357,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -380,11 +410,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -435,11 +470,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -502,11 +542,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -570,11 +615,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -640,11 +690,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -712,11 +767,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -786,11 +846,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -860,11 +925,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -939,11 +1009,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1019,11 +1094,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1127,11 +1207,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: alice-prometheus/cluster-autoscaler-alice/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -367,12 +367,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -421,12 +421,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -482,12 +482,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -555,12 +555,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -629,12 +629,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -705,12 +705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -783,12 +783,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -863,12 +863,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -943,12 +943,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1028,12 +1028,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1114,12 +1114,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1228,12 +1228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -332,11 +357,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -380,11 +410,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -435,11 +470,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -502,11 +542,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -570,11 +615,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -640,11 +690,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -712,11 +767,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -786,11 +846,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -860,11 +925,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -939,11 +1009,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1019,11 +1094,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1127,11 +1207,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -363,6 +368,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -416,6 +422,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -476,6 +483,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -548,6 +556,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -621,6 +630,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -696,6 +706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -773,6 +784,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -852,6 +864,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -931,6 +944,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1015,6 +1029,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1100,6 +1115,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1213,6 +1229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -364,7 +364,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -417,7 +417,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -477,7 +477,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -549,7 +549,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -622,7 +622,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -697,7 +697,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -774,7 +774,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -853,7 +853,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -932,7 +932,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1016,7 +1016,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1101,7 +1101,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1214,7 +1214,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -362,17 +307,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -416,17 +350,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -477,17 +400,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -550,17 +462,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -624,17 +525,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -700,17 +590,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -778,17 +657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -858,17 +726,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -938,17 +795,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1023,17 +869,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1109,17 +944,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1223,17 +1047,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: foo-prometheus/cluster-autoscaler-foo/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -367,12 +367,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -421,12 +421,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -482,12 +482,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -555,12 +555,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -629,12 +629,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -705,12 +705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -783,12 +783,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -863,12 +863,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -943,12 +943,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1028,12 +1028,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1114,12 +1114,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1228,12 +1228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -168,6 +170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -229,6 +232,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -290,6 +294,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -363,6 +368,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -416,6 +422,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -476,6 +483,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -548,6 +556,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -621,6 +630,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -696,6 +706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -773,6 +784,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -852,6 +864,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -931,6 +944,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1015,6 +1029,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1100,6 +1115,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1213,6 +1229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -169,7 +169,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -230,7 +230,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -291,7 +291,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -364,7 +364,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -417,7 +417,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -477,7 +477,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -549,7 +549,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -622,7 +622,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -697,7 +697,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -774,7 +774,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -853,7 +853,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -932,7 +932,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1016,7 +1016,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1101,7 +1101,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1214,7 +1214,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for docker
@@ -152,11 +162,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -208,11 +223,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -264,11 +284,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -332,11 +357,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -380,11 +410,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -435,11 +470,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -502,11 +542,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -570,11 +615,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -640,11 +690,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -712,11 +767,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -786,11 +846,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -860,11 +925,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -939,11 +1009,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1019,11 +1094,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1127,11 +1207,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -154,7 +154,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -210,7 +210,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -266,7 +266,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -334,7 +334,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -382,7 +382,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -437,7 +437,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -504,7 +504,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -572,7 +572,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -642,7 +642,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -714,7 +714,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -788,7 +788,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -862,7 +862,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -941,7 +941,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1021,7 +1021,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1129,7 +1129,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -169,12 +169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -231,12 +231,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -293,12 +293,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -367,12 +367,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -421,12 +421,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -482,12 +482,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -555,12 +555,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -629,12 +629,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -705,12 +705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -783,12 +783,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -863,12 +863,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -943,12 +943,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1028,12 +1028,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1114,12 +1114,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1228,12 +1228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: bar-prometheus/cluster-autoscaler-bar/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for docker
@@ -164,17 +142,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -226,17 +193,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -288,17 +244,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -362,17 +307,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -416,17 +350,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -477,17 +400,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -550,17 +462,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -624,17 +525,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -700,17 +590,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -778,17 +657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -858,17 +726,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -938,17 +795,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1023,17 +869,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1109,17 +944,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1223,17 +1047,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -34,17 +34,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -83,17 +72,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -134,17 +112,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -196,17 +163,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -251,17 +207,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -320,17 +265,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -367,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -421,17 +344,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -487,17 +399,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -554,17 +455,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -623,17 +513,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -694,17 +573,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -767,17 +635,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -840,17 +697,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -918,17 +764,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -997,17 +832,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1078,17 +902,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1195,17 +1008,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1267,17 +1069,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1344,17 +1135,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1419,17 +1199,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1494,17 +1263,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1571,17 +1329,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1648,17 +1395,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1725,17 +1461,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1802,17 +1527,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1877,17 +1591,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1954,17 +1657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2031,17 +1723,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2106,17 +1787,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2181,17 +1851,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2256,17 +1915,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2330,17 +1978,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2404,17 +2041,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2478,17 +2104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2552,17 +2167,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2626,17 +2230,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2700,17 +2293,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2774,17 +2356,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2852,17 +2423,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2912,17 +2472,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3011,17 +2560,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -40,6 +40,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -88,6 +89,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -138,6 +140,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -199,6 +202,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -253,6 +257,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -321,6 +326,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -367,6 +373,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -420,6 +427,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -485,6 +493,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -551,6 +560,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -619,6 +629,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -689,6 +700,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -761,6 +773,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -833,6 +846,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -910,6 +924,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -988,6 +1003,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1068,6 +1084,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1184,6 +1201,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1255,6 +1273,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1331,6 +1350,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1405,6 +1425,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1479,6 +1500,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1555,6 +1577,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1631,6 +1654,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1707,6 +1731,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1783,6 +1808,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1857,6 +1883,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1933,6 +1960,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2009,6 +2037,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2083,6 +2112,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2157,6 +2187,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2231,6 +2262,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2304,6 +2336,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2377,6 +2410,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2450,6 +2484,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2523,6 +2558,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2596,6 +2632,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2669,6 +2706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2742,6 +2780,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2819,6 +2858,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2878,6 +2918,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2976,6 +3017,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -39,12 +39,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -88,12 +88,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -139,12 +139,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -201,12 +201,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -256,12 +256,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -325,12 +325,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -372,12 +372,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -426,12 +426,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -492,12 +492,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -559,12 +559,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -628,12 +628,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -699,12 +699,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -772,12 +772,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -845,12 +845,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -923,12 +923,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1002,12 +1002,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1083,12 +1083,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1200,12 +1200,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1272,12 +1272,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1349,12 +1349,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1424,12 +1424,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1499,12 +1499,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1576,12 +1576,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1653,12 +1653,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1730,12 +1730,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1807,12 +1807,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1882,12 +1882,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1959,12 +1959,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2036,12 +2036,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2111,12 +2111,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2186,12 +2186,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2261,12 +2261,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2335,12 +2335,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2409,12 +2409,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2483,12 +2483,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2557,12 +2557,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2631,12 +2631,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2705,12 +2705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2779,12 +2779,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2857,12 +2857,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2917,12 +2917,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3016,12 +3016,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2620,7 +2620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2767,7 +2767,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2620,7 +2620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2767,7 +2767,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -41,7 +41,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -89,7 +89,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -139,7 +139,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -200,7 +200,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -254,7 +254,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -322,7 +322,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -368,7 +368,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -421,7 +421,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -486,7 +486,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -552,7 +552,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -620,7 +620,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -690,7 +690,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -762,7 +762,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -834,7 +834,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -911,7 +911,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -989,7 +989,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1069,7 +1069,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1185,7 +1185,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1256,7 +1256,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1332,7 +1332,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1406,7 +1406,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1480,7 +1480,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1556,7 +1556,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1632,7 +1632,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1708,7 +1708,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1784,7 +1784,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1858,7 +1858,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2010,7 +2010,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2084,7 +2084,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2158,7 +2158,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2232,7 +2232,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2305,7 +2305,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2378,7 +2378,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2451,7 +2451,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2524,7 +2524,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2597,7 +2597,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2670,7 +2670,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2743,7 +2743,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2820,7 +2820,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2879,7 +2879,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2977,7 +2977,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2620,7 +2620,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2674,7 +2674,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2767,7 +2767,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -34,11 +34,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -77,11 +82,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -122,11 +132,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -178,11 +193,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -227,11 +247,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -290,11 +315,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -331,11 +361,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -379,11 +414,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -439,11 +479,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -500,11 +545,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -563,11 +613,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -628,11 +683,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -695,11 +755,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -762,11 +827,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -834,11 +904,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -907,11 +982,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -982,11 +1062,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1093,11 +1178,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1159,11 +1249,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1230,11 +1325,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1299,11 +1399,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1368,11 +1473,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1439,11 +1549,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1510,11 +1625,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1581,11 +1701,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1652,11 +1777,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1721,11 +1851,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1792,11 +1927,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1863,11 +2003,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1932,11 +2077,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2001,11 +2151,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2070,11 +2225,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2138,11 +2298,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2206,11 +2371,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2274,11 +2444,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2342,11 +2517,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2410,11 +2590,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2478,11 +2663,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2546,11 +2736,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2618,11 +2813,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2672,11 +2872,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2765,11 +2970,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -281,7 +281,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -329,7 +329,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -384,7 +384,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -451,7 +451,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -519,7 +519,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -589,7 +589,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -661,7 +661,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -735,7 +735,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -809,7 +809,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -888,7 +888,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -968,7 +968,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1076,7 +1076,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -281,7 +281,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -329,7 +329,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -384,7 +384,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -451,7 +451,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -519,7 +519,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -589,7 +589,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -661,7 +661,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -735,7 +735,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -809,7 +809,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -888,7 +888,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -968,7 +968,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1076,7 +1076,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -107,17 +96,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -166,17 +144,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,17 +195,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -303,17 +259,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -357,17 +302,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -418,17 +352,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -491,17 +414,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -565,17 +477,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -641,17 +542,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -719,17 +609,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -799,17 +678,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -879,17 +747,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -964,17 +821,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1050,17 +896,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1164,17 +999,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -101,11 +106,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -154,11 +164,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -210,11 +225,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -279,11 +299,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -327,11 +352,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -382,11 +412,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -449,11 +484,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -517,11 +557,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -587,11 +632,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -659,11 +709,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -733,11 +788,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -807,11 +867,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -886,11 +951,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -966,11 +1036,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1074,11 +1149,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -103,7 +103,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -156,7 +156,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -212,7 +212,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -281,7 +281,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -329,7 +329,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -384,7 +384,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -451,7 +451,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -519,7 +519,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -589,7 +589,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -661,7 +661,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -735,7 +735,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -809,7 +809,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -888,7 +888,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -968,7 +968,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1076,7 +1076,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -113,7 +113,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -171,7 +171,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -232,7 +232,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -306,7 +306,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -359,7 +359,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -419,7 +419,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -491,7 +491,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -564,7 +564,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -639,7 +639,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -716,7 +716,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -795,7 +795,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -874,7 +874,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -958,7 +958,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1043,7 +1043,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1156,7 +1156,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -112,6 +113,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -170,6 +172,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -231,6 +234,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -305,6 +309,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -358,6 +363,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -418,6 +424,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -490,6 +497,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -563,6 +571,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -638,6 +647,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -715,6 +725,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -794,6 +805,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -873,6 +885,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -957,6 +970,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1042,6 +1056,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1155,6 +1170,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 - job_name: baz-prometheus/cluster-autoscaler-baz/0
@@ -112,12 +112,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 # Add scrape configuration for cadvisor
@@ -171,12 +171,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -233,12 +233,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -308,12 +308,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -362,12 +362,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -423,12 +423,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -496,12 +496,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -570,12 +570,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -646,12 +646,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -724,12 +724,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -804,12 +804,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -884,12 +884,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -969,12 +969,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1055,12 +1055,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1169,12 +1169,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 
@@ -99,17 +88,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -161,17 +139,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -223,17 +190,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -297,17 +253,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -351,17 +296,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -412,17 +346,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -485,17 +408,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -559,17 +471,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -635,17 +536,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -713,17 +603,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -793,17 +672,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -873,17 +741,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -958,17 +815,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1044,17 +890,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1158,17 +993,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 
@@ -104,12 +104,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -166,12 +166,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,12 +228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -302,12 +302,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -356,12 +356,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -417,12 +417,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -490,12 +490,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -564,12 +564,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -640,12 +640,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -718,12 +718,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -798,12 +798,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -878,12 +878,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -963,12 +963,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1049,12 +1049,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1163,12 +1163,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 
@@ -93,11 +98,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -149,11 +159,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -205,11 +220,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -273,11 +293,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bob-prometheus/kubelet-bob/0
   honor_labels: true
@@ -321,11 +346,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bob-prometheus/kubernetes-controller-manager-bob/0
   honor_labels: true
@@ -376,11 +406,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -443,11 +478,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -511,11 +551,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -581,11 +626,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -653,11 +703,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -727,11 +782,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -801,11 +861,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -880,11 +945,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -960,11 +1030,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob
@@ -1068,11 +1143,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bob

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -105,7 +105,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -166,7 +166,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -227,7 +227,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -300,7 +300,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -353,7 +353,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -413,7 +413,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -485,7 +485,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -558,7 +558,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -633,7 +633,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -710,7 +710,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -789,7 +789,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -868,7 +868,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -952,7 +952,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1037,7 +1037,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -104,6 +105,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -165,6 +167,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -226,6 +229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -299,6 +303,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -352,6 +357,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -412,6 +418,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -484,6 +491,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -557,6 +565,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -632,6 +641,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -709,6 +719,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -788,6 +799,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -867,6 +879,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -951,6 +964,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1036,6 +1050,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1149,6 +1164,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 
@@ -93,11 +98,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -149,11 +159,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -205,11 +220,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -273,11 +293,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -321,11 +346,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -376,11 +406,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -443,11 +478,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -511,11 +551,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -581,11 +626,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -653,11 +703,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -727,11 +782,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -801,11 +861,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -880,11 +945,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -960,11 +1030,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1068,11 +1143,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -105,7 +105,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -166,7 +166,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -227,7 +227,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -300,7 +300,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -353,7 +353,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -413,7 +413,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -485,7 +485,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -558,7 +558,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -633,7 +633,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -710,7 +710,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -789,7 +789,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -868,7 +868,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -952,7 +952,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1037,7 +1037,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 
@@ -104,12 +104,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -166,12 +166,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,12 +228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -302,12 +302,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -356,12 +356,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -417,12 +417,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -490,12 +490,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -564,12 +564,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -640,12 +640,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -718,12 +718,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -798,12 +798,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -878,12 +878,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -963,12 +963,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1049,12 +1049,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1163,12 +1163,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -104,6 +105,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -165,6 +167,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -226,6 +229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -299,6 +303,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -352,6 +357,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -412,6 +418,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -484,6 +491,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -557,6 +565,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -632,6 +641,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -709,6 +719,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -788,6 +799,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -867,6 +879,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -951,6 +964,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1036,6 +1050,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1149,6 +1164,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 
@@ -99,17 +88,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -161,17 +139,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -223,17 +190,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -297,17 +253,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: alice-prometheus/kubelet-alice/0
   honor_labels: true
@@ -351,17 +296,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: alice-prometheus/kubernetes-controller-manager-alice/0
   honor_labels: true
@@ -412,17 +346,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -485,17 +408,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -559,17 +471,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -635,17 +536,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -713,17 +603,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -793,17 +672,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -873,17 +741,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -958,17 +815,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1044,17 +890,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -1158,17 +993,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 
@@ -99,17 +88,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -161,17 +139,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -223,17 +190,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -297,17 +253,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -351,17 +296,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -412,17 +346,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -485,17 +408,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -559,17 +471,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -635,17 +536,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -713,17 +603,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -793,17 +672,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -873,17 +741,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -958,17 +815,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1044,17 +890,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1158,17 +993,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 
@@ -104,12 +104,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -166,12 +166,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,12 +228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -302,12 +302,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -356,12 +356,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -417,12 +417,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -490,12 +490,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -564,12 +564,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -640,12 +640,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -718,12 +718,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -798,12 +798,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -878,12 +878,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -963,12 +963,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1049,12 +1049,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1163,12 +1163,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 
@@ -93,11 +98,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -149,11 +159,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -205,11 +220,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -273,11 +293,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: foo-prometheus/kubelet-foo/0
   honor_labels: true
@@ -321,11 +346,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: foo-prometheus/kubernetes-controller-manager-foo/0
   honor_labels: true
@@ -376,11 +406,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -443,11 +478,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -511,11 +551,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -581,11 +626,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -653,11 +703,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -727,11 +782,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -801,11 +861,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -880,11 +945,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -960,11 +1030,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -1068,11 +1143,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -105,7 +105,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -166,7 +166,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -227,7 +227,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -300,7 +300,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -353,7 +353,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -413,7 +413,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -485,7 +485,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -558,7 +558,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -633,7 +633,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -710,7 +710,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -789,7 +789,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -868,7 +868,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -952,7 +952,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1037,7 +1037,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -104,6 +105,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -165,6 +167,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -226,6 +229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -299,6 +303,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -352,6 +357,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -412,6 +418,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -484,6 +491,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -557,6 +565,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -632,6 +641,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -709,6 +719,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -788,6 +799,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -867,6 +879,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -951,6 +964,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1036,6 +1050,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1149,6 +1164,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -105,7 +105,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -166,7 +166,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -227,7 +227,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -300,7 +300,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -353,7 +353,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -413,7 +413,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -485,7 +485,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -558,7 +558,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -633,7 +633,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -710,7 +710,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -789,7 +789,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -868,7 +868,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -952,7 +952,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1037,7 +1037,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1150,7 +1150,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 
@@ -93,11 +98,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -149,11 +159,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -205,11 +220,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -273,11 +293,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -321,11 +346,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -376,11 +406,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -443,11 +478,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -511,11 +551,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -581,11 +626,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -653,11 +703,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -727,11 +782,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -801,11 +861,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -880,11 +945,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -960,11 +1030,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1068,11 +1143,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -95,7 +95,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -151,7 +151,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -207,7 +207,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -275,7 +275,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -323,7 +323,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -378,7 +378,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -445,7 +445,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -513,7 +513,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -583,7 +583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -655,7 +655,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -729,7 +729,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -803,7 +803,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -882,7 +882,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -962,7 +962,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1070,7 +1070,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -104,6 +105,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -165,6 +167,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -226,6 +229,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -299,6 +303,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -352,6 +357,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -412,6 +418,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -484,6 +491,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -557,6 +565,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -632,6 +641,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -709,6 +719,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -788,6 +799,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -867,6 +879,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -951,6 +964,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1036,6 +1050,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1149,6 +1164,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 
@@ -99,17 +88,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -161,17 +139,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -223,17 +190,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -297,17 +253,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -351,17 +296,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -412,17 +346,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -485,17 +408,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -559,17 +471,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -635,17 +536,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -713,17 +603,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -793,17 +672,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -873,17 +741,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -958,17 +815,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1044,17 +890,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1158,17 +993,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 
@@ -104,12 +104,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -166,12 +166,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -228,12 +228,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -302,12 +302,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: bar-prometheus/kubelet-bar/0
   honor_labels: true
@@ -356,12 +356,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: bar-prometheus/kubernetes-controller-manager-bar/0
   honor_labels: true
@@ -417,12 +417,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -490,12 +490,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -564,12 +564,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -640,12 +640,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -718,12 +718,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -798,12 +798,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -878,12 +878,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -963,12 +963,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1049,12 +1049,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -1163,12 +1163,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -40,6 +40,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -88,6 +89,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -138,6 +140,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -199,6 +202,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -253,6 +257,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -321,6 +326,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -367,6 +373,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -420,6 +427,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -485,6 +493,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -551,6 +560,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -619,6 +629,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -689,6 +700,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -761,6 +773,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -833,6 +846,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -910,6 +924,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -988,6 +1003,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1068,6 +1084,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1184,6 +1201,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1255,6 +1273,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1331,6 +1350,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1405,6 +1425,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1479,6 +1500,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1555,6 +1577,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1631,6 +1654,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1707,6 +1731,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1783,6 +1808,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1857,6 +1883,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1933,6 +1960,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2009,6 +2037,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2083,6 +2112,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2157,6 +2187,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2231,6 +2262,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2304,6 +2336,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2377,6 +2410,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2450,6 +2484,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2523,6 +2558,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2596,6 +2632,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2669,6 +2706,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2742,6 +2780,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2835,6 +2874,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2894,6 +2934,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -2953,6 +2994,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -3012,6 +3054,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -3135,6 +3178,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -34,17 +34,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -83,17 +72,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -134,17 +112,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -196,17 +163,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -251,17 +207,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -320,17 +265,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -367,17 +301,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -421,17 +344,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -487,17 +399,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -554,17 +455,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -623,17 +513,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -694,17 +573,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -767,17 +635,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -840,17 +697,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -918,17 +764,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -997,17 +832,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1078,17 +902,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1195,17 +1008,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1267,17 +1069,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1344,17 +1135,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1419,17 +1199,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1494,17 +1263,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1571,17 +1329,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1648,17 +1395,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1725,17 +1461,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1802,17 +1527,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1877,17 +1591,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1954,17 +1657,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2031,17 +1723,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2106,17 +1787,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2181,17 +1851,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2256,17 +1915,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2330,17 +1978,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2404,17 +2041,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2478,17 +2104,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2552,17 +2167,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2626,17 +2230,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2700,17 +2293,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2774,17 +2356,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2868,17 +2439,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2928,17 +2488,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2988,17 +2537,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3048,17 +2586,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3172,17 +2699,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2636,7 +2636,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2690,7 +2690,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2744,7 +2744,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2798,7 +2798,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2916,7 +2916,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2636,7 +2636,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2690,7 +2690,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2744,7 +2744,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2798,7 +2798,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2916,7 +2916,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -36,7 +36,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -79,7 +79,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -124,7 +124,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -180,7 +180,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -229,7 +229,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -292,7 +292,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -333,7 +333,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -381,7 +381,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -441,7 +441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -502,7 +502,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -565,7 +565,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -630,7 +630,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -697,7 +697,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -764,7 +764,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -836,7 +836,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -984,7 +984,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1095,7 +1095,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1161,7 +1161,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1232,7 +1232,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1301,7 +1301,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1370,7 +1370,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1441,7 +1441,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1512,7 +1512,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1583,7 +1583,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1654,7 +1654,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1723,7 +1723,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1794,7 +1794,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1865,7 +1865,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2003,7 +2003,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2072,7 +2072,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2140,7 +2140,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2208,7 +2208,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2276,7 +2276,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2344,7 +2344,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2412,7 +2412,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2480,7 +2480,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2548,7 +2548,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2636,7 +2636,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2690,7 +2690,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2744,7 +2744,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2798,7 +2798,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -2916,7 +2916,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -41,7 +41,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -89,7 +89,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -139,7 +139,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -200,7 +200,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -254,7 +254,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -322,7 +322,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -368,7 +368,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -421,7 +421,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -486,7 +486,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -552,7 +552,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -620,7 +620,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -690,7 +690,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -762,7 +762,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -834,7 +834,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -911,7 +911,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -989,7 +989,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1069,7 +1069,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1185,7 +1185,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1256,7 +1256,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1332,7 +1332,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1406,7 +1406,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1480,7 +1480,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1556,7 +1556,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1632,7 +1632,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1708,7 +1708,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1784,7 +1784,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1858,7 +1858,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1934,7 +1934,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2010,7 +2010,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2084,7 +2084,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2158,7 +2158,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2232,7 +2232,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2305,7 +2305,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2378,7 +2378,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2451,7 +2451,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2524,7 +2524,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2597,7 +2597,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2670,7 +2670,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2743,7 +2743,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2836,7 +2836,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2895,7 +2895,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -2954,7 +2954,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -3013,7 +3013,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -3136,7 +3136,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -34,11 +34,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -77,11 +82,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -122,11 +132,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -178,11 +193,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -227,11 +247,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -290,11 +315,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -331,11 +361,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -379,11 +414,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -439,11 +479,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -500,11 +545,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -563,11 +613,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -628,11 +683,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -695,11 +755,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -762,11 +827,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -834,11 +904,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -907,11 +982,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -982,11 +1062,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1093,11 +1178,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1159,11 +1249,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1230,11 +1325,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1299,11 +1399,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1368,11 +1473,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1439,11 +1549,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1510,11 +1625,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1581,11 +1701,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1652,11 +1777,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1721,11 +1851,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1792,11 +1927,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1863,11 +2003,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1932,11 +2077,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2001,11 +2151,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2070,11 +2225,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2138,11 +2298,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2206,11 +2371,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2274,11 +2444,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2342,11 +2517,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2410,11 +2590,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2478,11 +2663,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2546,11 +2736,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2634,11 +2829,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2688,11 +2888,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2742,11 +2947,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2796,11 +3006,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2914,11 +3129,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -39,12 +39,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # Add scrape configuration for docker
 - job_name: kubernetes-prometheus/docker-kubernetes/0
@@ -88,12 +88,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [__name__]
     regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
@@ -139,12 +139,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -201,12 +201,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
@@ -256,12 +256,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -325,12 +325,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: kubernetes-prometheus/kubelet-kubernetes/0
   honor_labels: true
@@ -372,12 +372,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
   honor_labels: true
@@ -426,12 +426,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -492,12 +492,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -559,12 +559,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -628,12 +628,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -699,12 +699,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -772,12 +772,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -845,12 +845,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -923,12 +923,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1002,12 +1002,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1083,12 +1083,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1200,12 +1200,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1272,12 +1272,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1349,12 +1349,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1424,12 +1424,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1499,12 +1499,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1576,12 +1576,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1653,12 +1653,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1730,12 +1730,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1807,12 +1807,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1882,12 +1882,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -1959,12 +1959,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2036,12 +2036,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2111,12 +2111,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2186,12 +2186,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2261,12 +2261,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2335,12 +2335,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2409,12 +2409,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2483,12 +2483,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2557,12 +2557,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2631,12 +2631,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2705,12 +2705,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2779,12 +2779,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2873,12 +2873,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2933,12 +2933,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -2993,12 +2993,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3053,12 +3053,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -3177,12 +3177,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -46,12 +46,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 
 
 
@@ -106,12 +106,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -168,12 +168,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -243,12 +243,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -297,12 +297,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -358,12 +358,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -431,12 +431,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -505,12 +505,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -581,12 +581,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -659,12 +659,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -739,12 +739,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -819,12 +819,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -904,12 +904,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -990,12 +990,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1104,12 +1104,12 @@
     target_label: default_role
     replacement: worker
   # If role is empty, we default to worker
-  - source_labels: [role, default_role]
-    action: replace
-    separator: ;
-    regex: ;(.*)
-    target_label: role
-    replacement: $1
+  #- source_labels: [role, default_role]
+  #  action: replace
+  #  separator: ;
+  #  regex: ;(.*)
+  #  target_label: role
+  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 
@@ -97,7 +97,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -153,7 +153,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -222,7 +222,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -270,7 +270,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -325,7 +325,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -392,7 +392,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -460,7 +460,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -530,7 +530,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -602,7 +602,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -676,7 +676,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -750,7 +750,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -829,7 +829,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1017,7 +1017,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: null
+    regex: ^$
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -47,6 +47,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -106,6 +107,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -167,6 +169,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -241,6 +244,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -294,6 +298,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -354,6 +359,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -426,6 +432,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -499,6 +506,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -574,6 +582,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -651,6 +660,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -730,6 +740,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -809,6 +820,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -893,6 +905,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -978,6 +991,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role
@@ -1091,6 +1105,7 @@
     replacement: worker
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
+    action: replace
     separator: ;
     regex: ;(.*)
     target_label: role

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -41,11 +41,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 
 
 
@@ -95,11 +100,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -151,11 +161,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -220,11 +235,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -268,11 +288,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &#39;&#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &#39;;(.*)&#39;
+    target_label: role
+    replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -323,11 +348,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -390,11 +420,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -458,11 +493,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -528,11 +568,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -600,11 +645,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -674,11 +724,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -748,11 +803,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -827,11 +887,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -907,11 +972,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1015,11 +1085,16 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # If role is empty, we default to worker
-  - source_labels: [__meta_kubernetes_node_label_role]
-    regex: &amp;#39;&amp;#39;
-    target_label: role
+  # Add a temporary label.
+  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
+    target_label: default_role
     replacement: worker
+  # If role is empty, we default to worker
+  - source_labels: [role, default_role]
+    separator: ;
+    regex: &amp;#39;;(.*)&amp;#39;
+    target_label: role
+    replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -48,7 +48,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 
@@ -107,7 +107,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   metric_relabel_configs:
@@ -168,7 +168,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -242,7 +242,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # Add kubelet configuration
@@ -295,7 +295,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &#39;;(.*)&#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
 # kube-controller-manager
@@ -355,7 +355,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -427,7 +427,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -500,7 +500,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -575,7 +575,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -652,7 +652,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -731,7 +731,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -810,7 +810,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -894,7 +894,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -979,7 +979,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.
@@ -1092,7 +1092,7 @@
   # If role is empty, we default to worker
   - source_labels: [role, default_role]
     separator: ;
-    regex: &amp;#39;;(.*)&amp;#39;
+    regex: ;(.*)
     target_label: role
     replacement: $1
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 
@@ -97,7 +97,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -153,7 +153,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -222,7 +222,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -270,7 +270,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &#39;&#39;
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -325,7 +325,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -392,7 +392,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -460,7 +460,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -530,7 +530,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -602,7 +602,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -676,7 +676,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -750,7 +750,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -829,7 +829,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1017,7 +1017,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ''
+    regex: &amp;#39;&amp;#39;
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -43,7 +43,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 
@@ -97,7 +97,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   metric_relabel_configs:
@@ -153,7 +153,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -222,7 +222,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # Add kubelet configuration
@@ -270,7 +270,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
 # kube-controller-manager
@@ -325,7 +325,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -392,7 +392,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -460,7 +460,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -530,7 +530,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -602,7 +602,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -676,7 +676,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -750,7 +750,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -829,7 +829,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -909,7 +909,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.
@@ -1017,7 +1017,7 @@
     target_label: role
   # If role is empty, we default to worker
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: ^$
+    regex: ''
     target_label: role
     replacement: worker
   # Add cluster_id label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -41,17 +41,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 
 
 
@@ -101,17 +90,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   metric_relabel_configs:
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*)
@@ -163,17 +141,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -238,17 +205,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # Add kubelet configuration
 - job_name: baz-prometheus/kubelet-baz/0
   honor_labels: true
@@ -292,17 +248,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
 # kube-controller-manager
 - job_name: baz-prometheus/kubernetes-controller-manager-baz/0
   honor_labels: true
@@ -353,17 +298,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -426,17 +360,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -500,17 +423,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -576,17 +488,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -654,17 +555,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -734,17 +624,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -814,17 +693,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -899,17 +767,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -985,17 +842,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -1099,17 +945,6 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
-  # Add a temporary label.
-  - source_labels: [ __address__ ] # using address because I need this replacement to always happen.
-    target_label: default_role
-    replacement: worker
-  # If role is empty, we default to worker
-  #- source_labels: [role, default_role]
-  #  action: replace
-  #  separator: ;
-  #  regex: ;(.*)
-  #  target_label: role
-  #  replacement: $1
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/18779

Among all exporters that are discovered using the prometheus' `kubernetes` discovery plugin, only the ones using the `node` role have the node's labels available.
We rely on the nodes' "role" label to detect the role of the k8s node so we can't reliably detect this information.

This PR removes the defaulting feature to avoid the wrong default.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
