### PR TITLE
Inhibition no workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new inhibition for clusters without workers.
+
 ### Changed
 
 - Upgrade alertmanager to v0.23.0

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -454,3 +454,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
@@ -422,3 +422,8 @@ inhibit_rules:
     outside_working_hours: true
   target_match:
     cancel_if_outside_working_hours: true
+- source_match:
+    has_worker_nodes: false
+  target_match:
+    cancel_if_has_no_workers: true
+  equal: [cluster_id]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/546

This PR enables a new inhibition leveraging https://github.com/giantswarm/prometheus-rules/blob/0b1f77f8b1b5a840ad47ff7bb0599b929c737283/helm/prometheus-rules/templates/alerting-rules/inhibit.all.rules.yml#L32 and silencing any alerts labeled `cancel_if_has_no_workers` when the cluster has no worker nodes


## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
