### PR TITLE
Adding  support for updating app label based on monitoring annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new inhibition for clusters without workers.
-- Relabeling for `__meta_kubernetes_annotation_giantswarm_io_monitoring_app_label` 
+- Add relabeling for `__meta_kubernetes_annotation_giantswarm_io_monitoring_app_label`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new inhibition for clusters without workers.
+- Relabeling for `__meta_kubernetes_annotation_giantswarm_io_monitoring_app_label` 
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add new inhibition for clusters without workers.
-- Add relabeling for `__meta_kubernetes_annotation_giantswarm_io_monitoring_app_label`
+- Add relabeling for `__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label`
 
 ### Changed
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -648,9 +648,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -648,6 +648,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -1089,9 +1089,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -1089,6 +1089,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1089,9 +1089,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1089,6 +1089,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1089,9 +1089,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1089,6 +1089,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1089,9 +1089,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1089,6 +1089,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -937,6 +937,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -937,9 +937,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1041,9 +1041,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1041,6 +1041,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -1032,6 +1032,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -1032,9 +1032,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1032,6 +1032,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1032,9 +1032,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1032,6 +1032,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1032,9 +1032,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1032,6 +1032,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1032,9 +1032,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -887,9 +887,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -887,6 +887,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -984,6 +984,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -984,9 +984,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -978,6 +978,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -978,9 +978,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -978,6 +978,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -978,9 +978,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -978,6 +978,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -978,9 +978,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -978,6 +978,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -978,9 +978,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -887,9 +887,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -887,6 +887,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -930,9 +930,9 @@
     regex: (.*)
     target_label: app
     action: replace
-  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
     regex: (.*)
-    target_label: helm_chart
+    target_label: app
     action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -930,6 +930,10 @@
     regex: (.*)
     target_label: app
     action: replace
+  - source_labels: [__meta_kubernetes_endpoints_label_helm_sh_chart]
+    regex: (.*)
+    target_label: helm_chart
+    action: replace
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace


### PR DESCRIPTION
## Change description
- Towards https://github.com/giantswarm/giantswarm/issues/20083
- Adds relabel config for app that copies app name annotation to prometheus app label, towards helping managed app monitoring

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
- [x] tested on gauss