### PR TITLE
disable capi controller on kvm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Disable cluster-api controller on KVM instllations.
+
 ## [1.53.0] - 2021-12-17
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -43,7 +43,6 @@ require (
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920 // indirect
 	sigs.k8s.io/cluster-api v0.3.19
-	sigs.k8s.io/controller-runtime v0.6.4
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/pkg/unittest/input/case-0-cluster-api.golden
+++ b/pkg/unittest/input/case-0-cluster-api.golden
@@ -1,4 +1,0 @@
-apiVersion: cluster.x-k8s.io/v1alpha2
-kind: Cluster
-metadata:
-  name: bob

--- a/pkg/unittest/unittest.go
+++ b/pkg/unittest/unittest.go
@@ -15,7 +15,6 @@ import (
 	pkgruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/cluster-api/api/v1alpha2"
 	"sigs.k8s.io/cluster-api/api/v1alpha3"
 	"sigs.k8s.io/yaml"
 )
@@ -162,10 +161,6 @@ func inputValue(inputFile string) (pkgruntime.Object, error) {
 	// Giant Swarm objects.
 	s := pkgruntime.NewScheme()
 	err = scheme.AddToScheme(s)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-	err = v1alpha2.AddToScheme(s)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -1,20 +1,15 @@
 package clusterapi
 
 import (
-	"context"
-
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	"github.com/giantswarm/operatorkit/v4/pkg/controller"
 	"github.com/giantswarm/operatorkit/v4/pkg/resource"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/giantswarm/prometheus-meta-operator/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/service/controller/resource"
@@ -74,19 +69,16 @@ func NewController(config ControllerConfig) (*Controller, error) {
 		}
 	}
 
-	runtimeObjectFactoryFunc, err := getClusterFactoryFunc(config.K8sClient.CtrlClient())
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	var operatorkitController *controller.Controller
 	{
 		c := controller.Config{
-			K8sClient:            config.K8sClient,
-			Logger:               config.Logger,
-			Name:                 project.Name() + "-cluster-api-controller",
-			NewRuntimeObjectFunc: runtimeObjectFactoryFunc,
-			Resources:            resources,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
+			Name:      project.Name() + "-cluster-api-controller",
+			NewRuntimeObjectFunc: func() runtime.Object {
+				return new(capiv1alpha3.Cluster)
+			},
+			Resources: resources,
 		}
 
 		operatorkitController, err = controller.New(c)
@@ -100,34 +92,4 @@ func NewController(config ControllerConfig) (*Controller, error) {
 	}
 
 	return c, nil
-}
-
-func getClusterFactoryFunc(ctrlClient client.Client) (func() runtime.Object, error) {
-	var clusterCRD apiextensionsv1.CustomResourceDefinition
-	err := ctrlClient.Get(context.Background(), client.ObjectKey{
-		Name: "clusters.cluster.x-k8s.io",
-	}, &clusterCRD)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	var crdVersions []string
-	for _, v := range clusterCRD.Spec.Versions {
-		crdVersions = append(crdVersions, v.Name)
-	}
-
-	// Decide which object to construct based cluster CRD versions.
-	supportedVerions := map[string]func() runtime.Object{
-		"v1alpha3": func() runtime.Object { return new(capiv1alpha3.Cluster) },
-		"v1alpha2": func() runtime.Object { return new(capiv1alpha2.Cluster) },
-	}
-	for supportedVersion, versionFN := range supportedVerions {
-		for _, v := range crdVersions {
-			if v == supportedVersion {
-				return versionFN, nil
-			}
-		}
-	}
-
-	return nil, microerror.Maskf(unsupportedStorageVersionError, "implementation does not support storage version %q", crdVersions)
 }

--- a/service/service.go
+++ b/service/service.go
@@ -333,7 +333,7 @@ func shouldCreateLegacyController(clients k8sclient.Interface, provider string) 
 
 func shouldCreateCAPIController(provider string) bool {
 	// KVM installations do not currently support cluster-api clusters.
-	// This is being tracked here: https://github.com/giantswarm/roadmap/issues/319
+	// This is being tracked here: https://github.com/giantswarm/roadmap/issues/441
 	return provider != "kvm"
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -331,7 +331,7 @@ func shouldCreateLegacyController(clients k8sclient.Interface, provider string) 
 	return true, nil
 }
 
-func shouldCreateCAPIController(provider kind) bool {
+func shouldCreateCAPIController(provider string) bool {
 	// KVM installations do not currently support cluster-api clusters.
 	// This is being tracked here: https://github.com/giantswarm/roadmap/issues/319
 	if provider == "kvm" {

--- a/service/service.go
+++ b/service/service.go
@@ -331,7 +331,7 @@ func shouldCreateLegacyController(clients k8sclient.Interface, provider string) 
 	return true, nil
 }
 
-func shouldCreateCAPIController(provider kind) bool {
+func shouldCreateCAPIController(provider string) bool {
 	// KVM installations do not currently support cluster-api clusters.
 	// This is being tracked here: https://github.com/giantswarm/roadmap/issues/319
 	return provider != "kvm"

--- a/service/service.go
+++ b/service/service.go
@@ -21,7 +21,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 	"k8s.io/client-go/rest"
-	capiv1alpha2 "sigs.k8s.io/cluster-api/api/v1alpha2"
 	capiv1alpha3 "sigs.k8s.io/cluster-api/api/v1alpha3"
 
 	"github.com/giantswarm/prometheus-meta-operator/flag"
@@ -94,7 +93,6 @@ func New(config Config) (*Service, error) {
 			RestConfig: restConfig,
 			SchemeBuilder: k8sclient.SchemeBuilder{
 				apiextensionsv1.AddToScheme,
-				capiv1alpha2.AddToScheme,
 				capiv1alpha3.AddToScheme,
 				providerv1alpha1.AddToScheme,
 			},

--- a/service/service.go
+++ b/service/service.go
@@ -331,14 +331,10 @@ func shouldCreateLegacyController(clients k8sclient.Interface, provider string) 
 	return true, nil
 }
 
-func shouldCreateCAPIController(provider string) bool {
+func shouldCreateCAPIController(provider kind) bool {
 	// KVM installations do not currently support cluster-api clusters.
 	// This is being tracked here: https://github.com/giantswarm/roadmap/issues/319
-	if provider == "kvm" {
-		return false
-	}
-
-	return true
+	return provider != "kvm"
 }
 
 func (s *Service) Boot(ctx context.Context) {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20186

KVM installations do not officially support capi (even though Cluster CRD might be present).

This PR does the following :

- Remove `v1alpha2` capi support
- Disable capi controller on KVM installations