### PR TITLE
disable legacy controller on aws and azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Disable cluster-api controller on KVM instllations.
+- Disable cluster-api controller on KVM installations.
+- Disable legacy controller on AWS and Azure installations.
 - Upgrade to Go 1.17
 - Upgrade github.com/giantswarm/microkit v0.2.2 to v1.0.0
 - Upgrade github.com/giantswarm/versionbundle v0.2.0 to v1.0.0


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20186

For each cluster there are both an `AzureConfig` and a `Cluster` CR, since PMO watches both it does reconcile both at the same time. Release `15.1.3`

```
D 12/21 15:04:45 org-giantswarm/qs9d8 namespace creating | prometheus-meta-operator/service/controller/resource/generic/create.go:17 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=16 | version=130980581
D 12/21 15:04:45 org-giantswarm/qs9d8 namespace created | prometheus-meta-operator/service/controller/resource/generic/create.go:35 | controller=prometheus-meta-operator-cluster-api-controller | event=update | loop=16 | version=130980581

D 12/21 15:04:46 default/qs9d8 namespace creating | prometheus-meta-operator/service/controller/resource/generic/create.go:17 | controller=prometheus-meta-operator-legacy-controller | event=update | loop=11 | version=130980594
D 12/21 15:04:46 default/qs9d8 namespace created | prometheus-meta-operator/service/controller/resource/generic/create.go:35 | controller=prometheus-meta-operator-legacy-controller | event=update | loop=11 | version=130980594
```

Could not test on AWS as there are no old enough release, and I only see Cluster CRs being created with release `13.1.0` ([discussion](https://gigantic.slack.com/archives/C2MS2VB37/p1640099345026600))

This PR disable legacy controller for both Azure and AWS to avoid this issue.