### PR TITLE
Prevent panic when user in kubeconfig is not matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Prevent panic when encountering a different user in the CAPI kubeconfig.
+
+
 ## [2.1.0] - 2022-01-10
 
 ## Added

--- a/service/controller/resource/certificates/resource.go
+++ b/service/controller/resource/certificates/resource.go
@@ -2,6 +2,7 @@ package certificates
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -111,8 +112,12 @@ func (r *Resource) getDesiredObject(v interface{}) (*corev1.Secret, error) {
 			}
 			kubeconfigAdminUser := fmt.Sprintf("%s-admin", cluster.GetName())
 			secretData["ca"] = capiKubeconfig.Clusters[cluster.GetName()].CertificateAuthorityData
-			secretData["crt"] = capiKubeconfig.AuthInfos[kubeconfigAdminUser].ClientCertificateData
-			secretData["key"] = capiKubeconfig.AuthInfos[kubeconfigAdminUser].ClientKeyData
+			if _, ok := capiKubeconfig.AuthInfos[kubeconfigAdminUser]; ok {
+				secretData["crt"] = capiKubeconfig.AuthInfos[kubeconfigAdminUser].ClientCertificateData
+				secretData["key"] = capiKubeconfig.AuthInfos[kubeconfigAdminUser].ClientKeyData
+			} else {
+				return nil, errors.New("no supported user found in the CAPI secret")
+			}
 		}
 	}
 


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/20257

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
