### PR TITLE
Allow overriding protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Allow overriding the scraping protocol
+
 ### Fixed
 
 - Set ingress class name in ingress spec instead of annotation to prepare supporting ingress v1.

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -631,14 +631,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1072,14 +1072,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1072,14 +1072,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1072,14 +1072,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -920,14 +920,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1024,14 +1024,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1015,14 +1015,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1015,14 +1015,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1015,14 +1015,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -870,14 +870,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -967,14 +967,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -961,14 +961,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -961,14 +961,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -961,14 +961,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -870,14 +870,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -913,14 +913,20 @@
     target_label: __address__
     regex: ([^:]+):(\d+);(\d+)
     replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
   - source_labels: [__meta_kubernetes_pod_ip, __address__]
     regex: (.*);([^:]+):(\d+)
     replacement: $1:$3
     target_label: instance
-  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
-    regex: (.*);(.*);(.+:)(\d+);(.*)
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
     action: replace
   - regex: (.*)
     target_label: __address__


### PR DESCRIPTION
## Checklist

Allow overriding protocol in scrape config to be able to scrape prometheus operator

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
