### PR TITLE
Replaced firecracker and celestial routing with phoenix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support ingress v1 by default.
 - Scrape node-exporter trough apiserver proxy.
 
+### Fixed
+
+- Old references to Firecracker and Celestial replaced with Phoenix
+
 ## [2.2.1] - 2022-02-24
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -36,10 +36,8 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  [[ if eq .Provider "aws" ]]
-  - receiver: team_firecracker_slack
-  [[ else if eq .Provider "azure" ]]
-  - receiver: team_celestial_slack
+  [[ if or (eq .Provider "aws") (eq .Provider "azure") ]]
+  - receiver: team_phoenix_slack
   [[ else ]]
   - receiver: team_rocket_slack
   [[ end ]]
@@ -69,17 +67,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -201,39 +206,12 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
   [[- if eq .Pipeline "stable" ]]
-  - channel: '#alert-celestial'
+  - channel: '#alertphoenix'
   [[- else ]]
-  - channel: '#alert-celestial-test'
-  [[- end ]]
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  [[- if eq .Pipeline "stable" ]]
-  - channel: '#alert-firecracker'
-  [[- else ]]
-  - channel: '#alert-firecracker-test'
+  - channel: '#alertphoenix-test'
   [[- end ]]
     send_resolved: true
     actions:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -36,11 +36,11 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  [[ if or (eq .Provider "aws") (eq .Provider "azure") ]]
+  [[- if or (eq .Provider "aws") (eq .Provider "azure") ]]
   - receiver: team_phoenix_slack
-  [[ else ]]
+  [[- else ]]
   - receiver: team_rocket_slack
-  [[ end ]]
+  [[- end ]]
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -209,9 +209,9 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   [[- if eq .Pipeline "stable" ]]
-  - channel: '#alertphoenix'
+  - channel: '#alert-phoenix'
   [[- else ]]
-  - channel: '#alertphoenix-test'
+  - channel: '#alert-phoenix-test'
   [[- end ]]
     send_resolved: true
     actions:

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-0-cluster-api.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-1-awsconfig.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-2-azureconfig.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-3-kvmconfig.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-4-control-plane.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfigsecret/test/case-5-cluster-api-v1alpha3.golden
@@ -32,9 +32,7 @@ route:
     continue: false
 
   # Service Level slack -- chooses the slack channel based on the provider
-  
-  - receiver: team_firecracker_slack
-  
+  - receiver: team_phoenix_slack
     match:
       alertname: ServiceLevelBurnRateTooHigh
     continue: false
@@ -61,17 +59,24 @@ route:
     continue: false
 
   # Team Celestial Slack (team)
-  - receiver: team_celestial_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: celestial
     continue: false
 
   # Team Firecracker Slack (team)
-  - receiver: team_firecracker_slack
+  - receiver: team_phoenix_slack
     match_re:
       severity: page|notify
       team: firecracker
+    continue: false
+
+  # Team Phoenix Slack (team)
+  - receiver: team_phoenix_slack
+    match_re:
+      severity: page|notify
+      team: phoenix
     continue: false
 
   # Team Ludacris Slack (team)
@@ -189,32 +194,9 @@ receivers:
       url: '{{`{{ template "__alert_silence_link" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
 
-- name: team_celestial_slack
+- name: team_phoenix_slack
   slack_configs:
-  - channel: '#alert-celestial-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{`{{ (index .Alerts 0).Annotations.opsrecipe }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{`{{ (index .Alerts 0).GeneratorURL }}`}}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/{{`{{ (index .Alerts 0).Annotations.dashboard }}`}}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{`{{ template "__alert_silence_link" . }}`}}'
-      style: '{{`{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}`}}'
-
-- name: team_firecracker_slack
-  slack_configs:
-  - channel: '#alert-firecracker-test'
+  - channel: '#alert-phoenix-test'
     send_resolved: true
     actions:
     - type: button


### PR DESCRIPTION
Firecracker and Celestial alerts still routing to old slack recievers

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
