### PR TITLE
Upgrade rbac to v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Migrate to rbac/v1 from rbac/v1beta1.
+
 ## [2.3.0] - 2022-03-04
 
 ### Changed

--- a/service/controller/resource/rbac/create.go
+++ b/service/controller/resource/rbac/create.go
@@ -16,9 +16,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		current, err := r.k8sClient.K8sClient().RbacV1beta1().ClusterRoles().Get(ctx, desired.GetName(), metav1.GetOptions{})
+		current, err := r.k8sClient.K8sClient().RbacV1().ClusterRoles().Get(ctx, desired.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			current, err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoles().Create(ctx, desired, metav1.CreateOptions{})
+			current, err = r.k8sClient.K8sClient().RbacV1().ClusterRoles().Create(ctx, desired, metav1.CreateOptions{})
 		}
 		if err != nil {
 			return microerror.Mask(err)
@@ -26,7 +26,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		if hasClusterRoleChanged(current, desired) {
 			updateMeta(current, desired)
-			_, err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoles().Update(ctx, desired, metav1.UpdateOptions{})
+			_, err = r.k8sClient.K8sClient().RbacV1().ClusterRoles().Update(ctx, desired, metav1.UpdateOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -40,9 +40,9 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		current, err := r.k8sClient.K8sClient().RbacV1beta1().ClusterRoleBindings().Get(ctx, desired.GetName(), metav1.GetOptions{})
+		current, err := r.k8sClient.K8sClient().RbacV1().ClusterRoleBindings().Get(ctx, desired.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			current, err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoleBindings().Create(ctx, desired, metav1.CreateOptions{})
+			current, err = r.k8sClient.K8sClient().RbacV1().ClusterRoleBindings().Create(ctx, desired, metav1.CreateOptions{})
 		}
 		if err != nil {
 			return microerror.Mask(err)
@@ -50,7 +50,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		if hasClusterRoleBindingChanged(current, desired) {
 			updateMeta(current, desired)
-			_, err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoleBindings().Update(ctx, desired, metav1.UpdateOptions{})
+			_, err = r.k8sClient.K8sClient().RbacV1().ClusterRoleBindings().Update(ctx, desired, metav1.UpdateOptions{})
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/rbac/delete.go
+++ b/service/controller/resource/rbac/delete.go
@@ -16,7 +16,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoles().Delete(ctx, desired.GetName(), metav1.DeleteOptions{})
+		err = r.k8sClient.K8sClient().RbacV1().ClusterRoles().Delete(ctx, desired.GetName(), metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			// fall through
 		} else if err != nil {
@@ -30,7 +30,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		err = r.k8sClient.K8sClient().RbacV1beta1().ClusterRoleBindings().Delete(ctx, desired.GetName(), metav1.DeleteOptions{})
+		err = r.k8sClient.K8sClient().RbacV1().ClusterRoleBindings().Delete(ctx, desired.GetName(), metav1.DeleteOptions{})
 		if apierrors.IsNotFound(err) {
 			// fall through
 		} else if err != nil {

--- a/service/controller/resource/rbac/resource.go
+++ b/service/controller/resource/rbac/resource.go
@@ -6,7 +6,7 @@ import (
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	"k8s.io/api/rbac/v1beta1"
+	v1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/key"
@@ -39,7 +39,7 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-func toClusterRole(v interface{}) (*v1beta1.ClusterRole, error) {
+func toClusterRole(v interface{}) (*v1.ClusterRole, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -47,11 +47,11 @@ func toClusterRole(v interface{}) (*v1beta1.ClusterRole, error) {
 
 	name := cluster.GetName()
 
-	clusterRole := &v1beta1.ClusterRole{
+	clusterRole := &v1.ClusterRole{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Rules: []v1beta1.PolicyRule{
+		Rules: []v1.PolicyRule{
 			{
 				APIGroups: []string{
 					"",
@@ -96,7 +96,7 @@ func toClusterRole(v interface{}) (*v1beta1.ClusterRole, error) {
 	return clusterRole, nil
 }
 
-func toClusterRoleBinding(v interface{}) (*v1beta1.ClusterRoleBinding, error) {
+func toClusterRoleBinding(v interface{}) (*v1.ClusterRoleBinding, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -104,16 +104,16 @@ func toClusterRoleBinding(v interface{}) (*v1beta1.ClusterRoleBinding, error) {
 
 	name := cluster.GetName()
 
-	clusterRoleBinding := &v1beta1.ClusterRoleBinding{
+	clusterRoleBinding := &v1.ClusterRoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		RoleRef: v1beta1.RoleRef{
-			APIGroup: v1beta1.SchemeGroupVersion.Group,
+		RoleRef: v1.RoleRef{
+			APIGroup: v1.SchemeGroupVersion.Group,
 			Kind:     "ClusterRole",
 			Name:     name,
 		},
-		Subjects: []v1beta1.Subject{
+		Subjects: []v1.Subject{
 			{
 				Kind:      "ServiceAccount",
 				Name:      "default",
@@ -125,10 +125,10 @@ func toClusterRoleBinding(v interface{}) (*v1beta1.ClusterRoleBinding, error) {
 	return clusterRoleBinding, nil
 }
 
-func hasClusterRoleChanged(current, desired *v1beta1.ClusterRole) bool {
+func hasClusterRoleChanged(current, desired *v1.ClusterRole) bool {
 	return !reflect.DeepEqual(current.Rules, desired.Rules)
 }
 
-func hasClusterRoleBindingChanged(current, desired *v1beta1.ClusterRoleBinding) bool {
+func hasClusterRoleBindingChanged(current, desired *v1.ClusterRoleBinding) bool {
 	return !reflect.DeepEqual(current.RoleRef, desired.RoleRef) || !reflect.DeepEqual(current.Subjects, desired.Subjects)
 }


### PR DESCRIPTION
Rbac v1 has beed suported since kubernetes 1.8 and v1beta1 is removed in 1.22

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
