### PR TITLE
do no trail right whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Migrate to rbac/v1 from rbac/v1beta1.
 
+### Fixed
+
+- Do not trail right whitespaces in config.
+
 ## [2.3.0] - 2022-03-04
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -82,7 +82,7 @@ data:
         registry: {{ .Values.registry.domain }}
         {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
         ingressAPIVersion: networking.k8s.io/v1
-        {{- else -}}
+        {{- else }}
         ingressAPIVersion: networking.k8s.io/v1beta1
         {{- end }}
       vault:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21294

Removing trailing right whitespaces result in invalid/broken config and crashlooping PMO.