### PR TITLE
Clean up heartbeat receiver name

### DIFF
--- a/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
@@ -106,8 +106,9 @@ func toAlertmanagerConfig(v interface{}, config Config) (metav1.Object, error) {
 		}
 	}
 
+	// We define the receiver name as heartbeat as prometheus operator will add the monitoring-clusterId as a prefix
 	receiver := monitoringv1alpha1.Receiver{
-		Name: key.HeartbeatReceiverName(cluster, config.Installation),
+		Name: "heartbeat",
 		WebhookConfigs: []monitoringv1alpha1.WebhookConfig{
 			{
 				URL: &address,
@@ -132,7 +133,7 @@ func toAlertmanagerConfig(v interface{}, config Config) (metav1.Object, error) {
 		ObjectMeta: objectMeta,
 		Spec: monitoringv1alpha1.AlertmanagerConfigSpec{
 			Route: &monitoringv1alpha1.Route{
-				Receiver: key.HeartbeatReceiverName(cluster, config.Installation),
+				Receiver: "heartbeat",
 				Matchers: []monitoringv1alpha1.Matcher{
 					{Name: key.ClusterIDKey(), Value: key.ClusterID(cluster)},
 					{Name: key.InstallationKey(), Value: config.Installation},

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-1-awsconfig.golden
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   receivers:
-  - name: heartbeat_test-installation_alice
+  - name: heartbeat
     webhookConfigs:
     - httpConfig:
         authorization:
@@ -28,5 +28,5 @@ spec:
       value: test-installation
     - name: type
       value: heartbeat
-    receiver: heartbeat_test-installation_alice
+    receiver: heartbeat
     repeatInterval: 1m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-2-azureconfig.golden
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   receivers:
-  - name: heartbeat_test-installation_foo
+  - name: heartbeat
     webhookConfigs:
     - httpConfig:
         authorization:
@@ -28,5 +28,5 @@ spec:
       value: test-installation
     - name: type
       value: heartbeat
-    receiver: heartbeat_test-installation_foo
+    receiver: heartbeat
     repeatInterval: 1m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-3-kvmconfig.golden
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   receivers:
-  - name: heartbeat_test-installation_bar
+  - name: heartbeat
     webhookConfigs:
     - httpConfig:
         authorization:
@@ -28,5 +28,5 @@ spec:
       value: test-installation
     - name: type
       value: heartbeat
-    receiver: heartbeat_test-installation_bar
+    receiver: heartbeat
     repeatInterval: 1m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-4-control-plane.golden
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   receivers:
-  - name: heartbeat_test-installation_kubernetes
+  - name: heartbeat
     webhookConfigs:
     - httpConfig:
         authorization:
@@ -28,5 +28,5 @@ spec:
       value: test-installation
     - name: type
       value: heartbeat
-    receiver: heartbeat_test-installation_kubernetes
+    receiver: heartbeat
     repeatInterval: 1m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -8,7 +8,7 @@ metadata:
   namespace: monitoring
 spec:
   receivers:
-  - name: heartbeat_test-installation_baz
+  - name: heartbeat
     webhookConfigs:
     - httpConfig:
         authorization:
@@ -28,5 +28,5 @@ spec:
       value: test-installation
     - name: type
       value: heartbeat
-    receiver: heartbeat_test-installation_baz
+    receiver: heartbeat
     repeatInterval: 1m


### PR DESCRIPTION
Remove unecessary suffix in receiver names

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`


- name: monitoring-gorgoth-heartbeat
  webhook_configs:
  - send_resolved: false
    http_config:
      authorization:
        type: GenieKey
        credentials: <secret>
      follow_redirects: true
    url: https://api.opsgenie.com/v2/heartbeats/gorgoth-gorgoth/ping
    max_alerts: 0