### PR TITLE
Changed scrape_interval to 180s and scrape_timeout to 60s for azure-collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Remove deprecated matcher types from alertmanager config.
+- Changed scrape_interval to 180s and scrape_timeout to 60s for azure-collector.
 
 ### Removed
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -1656,6 +1656,8 @@
 - job_name: [[ .ClusterID ]]-prometheus/azure-collector-[[ .ClusterID ]]/0
   honor_labels: true
   scheme: http
+  scrape_timeout: 60s
+  scrape_interval: 180s
   kubernetes_sd_configs:
   - role: endpoints
     namespaces:

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -2423,6 +2423,8 @@
 - job_name: kubernetes-prometheus/azure-collector-kubernetes/0
   honor_labels: true
   scheme: http
+  scrape_timeout: 60s
+  scrape_interval: 180s
   kubernetes_sd_configs:
   - role: endpoints
     namespaces:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20670

azure-collector takes longer than the default 10s to provide data and that makes it fail very often.
this PR changes the timeout value to a safer 60s and also decreases the interval.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
