### PR TITLE
generic resource context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add context to generic resources.
+
 ## [3.0.0] - 2022-03-28
 
 ### Added

--- a/service/controller/resource/alerting/alertmanager/resource.go
+++ b/service/controller/resource/alerting/alertmanager/resource.go
@@ -8,6 +8,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1client "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,8 +45,8 @@ func New(config Config) (*generic.Resource, error) {
 		Logger:        config.Logger,
 		Name:          Name,
 		GetObjectMeta: getObjectMeta,
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
-			return toAlertmanager(v, config)
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
+			return toAlertmanager(ctx, v, config)
 		},
 		HasChangedFunc: hasChanged,
 	}
@@ -57,7 +58,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	return metav1.ObjectMeta{
 		Name:      "alertmanager",
 		Namespace: key.NamespaceMonitoring(),
@@ -65,12 +66,12 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}, nil
 }
 
-func toAlertmanager(v interface{}, config Config) (metav1.Object, error) {
+func toAlertmanager(ctx context.Context, v interface{}, config Config) (metav1.Object, error) {
 	if v == nil {
 		return nil, nil
 	}
 
-	objectMeta, err := getObjectMeta(v)
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/alerting/alertmanager/resource_test.go
+++ b/service/controller/resource/alerting/alertmanager/resource_test.go
@@ -1,6 +1,7 @@
 package alertmanager
 
 import (
+	"context"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -27,7 +28,7 @@ func TestAlertmanager(t *testing.T) {
 		OutputDir: outputDir,
 		T:         t,
 		TestFunc: func(v interface{}) (interface{}, error) {
-			return toAlertmanager(v, config)
+			return toAlertmanager(context.TODO(), v, config)
 		},
 		Update: *update,
 	}

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -1,6 +1,7 @@
 package alertmanagerconfig
 
 import (
+	"context"
 	"io/ioutil"
 	"path"
 	"reflect"
@@ -67,10 +68,10 @@ func New(config Config) (*generic.Resource, error) {
 		ClientFunc: clientFunc,
 		Logger:     config.Logger,
 		Name:       Name,
-		GetObjectMeta: func(v interface{}) (metav1.ObjectMeta, error) {
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 			return getObjectMeta(v, config)
 		},
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
 			return toSecret(v, config)
 		},
 		HasChangedFunc: hasChanged,

--- a/service/controller/resource/alerting/alertmanagerwiring/resource.go
+++ b/service/controller/resource/alerting/alertmanagerwiring/resource.go
@@ -1,6 +1,7 @@
 package alertmanagerwiring
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -60,7 +61,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -76,8 +77,8 @@ func toData(v interface{}) []byte {
 	return []byte(alertmanagerConfig)
 }
 
-func toSecret(v interface{}) (metav1.Object, error) {
-	objectMeta, err := getObjectMeta(v)
+func toSecret(ctx context.Context, v interface{}) (metav1.Object, error) {
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
@@ -10,6 +10,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	monitoringv1alpha1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1alpha1"
 	monitoringclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -41,10 +42,10 @@ func New(config Config) (*generic.Resource, error) {
 		ClientFunc: clientFunc,
 		Logger:     config.Logger,
 		Name:       Name,
-		GetObjectMeta: func(v interface{}) (metav1.ObjectMeta, error) {
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 			return getObjectMeta(v, config)
 		},
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
 			return toAlertmanagerConfig(v, config)
 		},
 		HasChangedFunc: hasChanged,

--- a/service/controller/resource/etcd-certificates/resource.go
+++ b/service/controller/resource/etcd-certificates/resource.go
@@ -61,7 +61,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -73,13 +73,13 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}, nil
 }
 
-func (sc *secretCopier) ToCR(v interface{}) (metav1.Object, error) {
-	objectMeta, err := getObjectMeta(v)
+func (sc *secretCopier) ToCR(ctx context.Context, v interface{}) (metav1.Object, error) {
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	data, err := sc.getSource(context.TODO(), v)
+	data, err := sc.getSource(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/generic/create.go
+++ b/service/controller/resource/generic/create.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	desired, err := r.getDesiredObject(obj)
+	desired, err := r.getDesiredObject(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/generic/delete.go
+++ b/service/controller/resource/generic/delete.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	object, err := r.getObjectMeta(obj)
+	object, err := r.getObjectMeta(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/service/controller/resource/generic/resource.go
+++ b/service/controller/resource/generic/resource.go
@@ -31,11 +31,11 @@ type Config struct {
 	// GetObjectMeta is a function that takes a resource object, casts it to
 	// appropriate type and returns the metadata of that object, i.e. its
 	// metav1.ObjectMeta part (name, namespace, labels, annotations, etc.).
-	GetObjectMeta func(interface{}) (metav1.ObjectMeta, error)
+	GetObjectMeta func(context.Context, interface{}) (metav1.ObjectMeta, error)
 
 	// GetDesiredObject is a function that takes a resource object and returns the
 	// object populated with the desired state.
-	GetDesiredObject func(interface{}) (metav1.Object, error)
+	GetDesiredObject func(context.Context, interface{}) (metav1.Object, error)
 
 	// HasChangedFunc is a function that takes two copies of an object - first
 	// with existing state in the cluster and second with the desired state for
@@ -48,8 +48,8 @@ type Resource struct {
 	clientFunc       func(string) Interface
 	logger           micrologger.Logger
 	name             string
-	getObjectMeta    func(interface{}) (metav1.ObjectMeta, error)
-	getDesiredObject func(interface{}) (metav1.Object, error)
+	getObjectMeta    func(context.Context, interface{}) (metav1.ObjectMeta, error)
+	getDesiredObject func(context.Context, interface{}) (metav1.Object, error)
 	hasChangedFunc   func(metav1.Object, metav1.Object) bool
 }
 

--- a/service/controller/resource/monitoring/ingress/v1/resource.go
+++ b/service/controller/resource/monitoring/ingress/v1/resource.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -36,10 +37,10 @@ func New(config Config) (*generic.Resource, error) {
 		ClientFunc: clientFunc,
 		Logger:     config.Logger,
 		Name:       Name,
-		GetObjectMeta: func(v interface{}) (metav1.ObjectMeta, error) {
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 			return getObjectMeta(v, config)
 		},
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
 			return toIngress(v, config)
 		},
 		HasChangedFunc: hasChanged,

--- a/service/controller/resource/monitoring/ingress/v1beta1/resource.go
+++ b/service/controller/resource/monitoring/ingress/v1beta1/resource.go
@@ -1,6 +1,7 @@
 package v1beta1
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 
@@ -37,10 +38,10 @@ func New(config Config) (*generic.Resource, error) {
 		ClientFunc: clientFunc,
 		Logger:     config.Logger,
 		Name:       Name,
-		GetObjectMeta: func(v interface{}) (metav1.ObjectMeta, error) {
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 			return getObjectMeta(v, config)
 		},
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
 			return toIngress(v, config)
 		},
 		HasChangedFunc: hasChanged,

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -10,6 +10,7 @@ import (
 	"github.com/giantswarm/micrologger"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	"golang.org/x/net/context"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,8 +59,8 @@ func New(config Config) (*generic.Resource, error) {
 		Logger:        config.Logger,
 		Name:          Name,
 		GetObjectMeta: getObjectMeta,
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
-			return toPrometheus(v, config)
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
+			return toPrometheus(ctx, v, config)
 		},
 		HasChangedFunc: hasChanged,
 	}
@@ -71,7 +72,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -84,12 +85,12 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}, nil
 }
 
-func toPrometheus(v interface{}, config Config) (metav1.Object, error) {
+func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Object, error) {
 	if v == nil {
 		return nil, nil
 	}
 
-	objectMeta, err := getObjectMeta(v)
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/monitoring/prometheus/resource_test.go
+++ b/service/controller/resource/monitoring/prometheus/resource_test.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"context"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -37,7 +38,7 @@ func TestPrometheus(t *testing.T) {
 		OutputDir: outputDir,
 		T:         t,
 		TestFunc: func(v interface{}) (interface{}, error) {
-			return toPrometheus(v, config)
+			return toPrometheus(context.TODO(), v, config)
 		},
 		Update: *update,
 	}

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -1,6 +1,7 @@
 package remotewriteconfig
 
 import (
+	"context"
 	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -35,8 +36,8 @@ func New(config Config) (*generic.Resource, error) {
 		Logger:        config.Logger,
 		Name:          Name,
 		GetObjectMeta: getObjectMeta,
-		GetDesiredObject: func(v interface{}) (metav1.Object, error) {
-			return toSecret(v, config)
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
+			return toSecret(ctx, v, config)
 		},
 		HasChangedFunc: hasChanged,
 	}
@@ -48,7 +49,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -60,8 +61,8 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}, nil
 }
 
-func toSecret(v interface{}, config Config) (*corev1.Secret, error) {
-	objectMeta, err := getObjectMeta(v)
+func toSecret(ctx context.Context, v interface{}, config Config) (*corev1.Secret, error) {
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/monitoring/remotewriteconfig/resource_test.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource_test.go
@@ -1,6 +1,7 @@
 package remotewriteconfig
 
 import (
+	"context"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func TestRemoteWriteSecret(t *testing.T) {
 		OutputDir: outputDir,
 		T:         t,
 		TestFunc: func(v interface{}) (interface{}, error) {
-			return toSecret(v, Config{
+			return toSecret(context.TODO(), v, Config{
 				RemoteWriteUsername: "test",
 				RemoteWritePassword: "test",
 			})

--- a/service/controller/resource/namespace/resource.go
+++ b/service/controller/resource/namespace/resource.go
@@ -1,6 +1,8 @@
 package namespace
 
 import (
+	"context"
+
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
@@ -42,7 +44,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -54,8 +56,8 @@ func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	}, nil
 }
 
-func toNamespace(v interface{}) (metav1.Object, error) {
-	objectMeta, err := getObjectMeta(v)
+func toNamespace(ctx context.Context, v interface{}) (metav1.Object, error) {
+	objectMeta, err := getObjectMeta(ctx, v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/namespace/resource_test.go
+++ b/service/controller/resource/namespace/resource_test.go
@@ -1,6 +1,7 @@
 package namespace
 
 import (
+	"context"
 	"flag"
 	"path/filepath"
 	"testing"
@@ -20,7 +21,7 @@ func TestNamespace(t *testing.T) {
 		OutputDir: outputDir,
 		T:         t,
 		TestFunc: func(v interface{}) (interface{}, error) {
-			return toNamespace(v)
+			return toNamespace(context.TODO(), v)
 		},
 		Update: *update,
 	}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21156

Add controller context to generic resource, so we can later re-use it for logging and other purposes.

- pass context from generic resource
- pass context around
- update CHANGELOG
