### PR TITLE
prepare etcd certificates

### DIFF
--- a/service/controller/resource/etcd-certificates/doc.go
+++ b/service/controller/resource/etcd-certificates/doc.go
@@ -1,0 +1,4 @@
+package etcdcertificates
+
+// Package etcdcertificates implements a resource in charge of finding
+// necessary TLS certificates to communicate with Etcd endpoints.

--- a/service/controller/resource/etcd-certificates/resource.go
+++ b/service/controller/resource/etcd-certificates/resource.go
@@ -97,32 +97,6 @@ func (sc *secretCopier) ToCR(ctx context.Context, v interface{}) (metav1.Object,
 	return secret, nil
 }
 
-// getSource returns the Secret to be copied, i.e. default/$CLUSTER_ID-prometheus
-func (sc *secretCopier) getSource(ctx context.Context, v interface{}) (map[string]string, error) {
-	ca, err := ioutil.ReadFile("/etcd-client-certs/ca.pem")
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	crt, err := ioutil.ReadFile("/etcd-client-certs/crt.pem")
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	key, err := ioutil.ReadFile("/etcd-client-certs/key.pem")
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
-	data := map[string]string{
-		"ca":  string(ca),
-		"crt": string(crt),
-		"key": string(key),
-	}
-
-	return data, nil
-}
-
 func hasChanged(current, desired metav1.Object) bool {
 	c := current.(*corev1.Secret)
 	d := desired.(*corev1.Secret)

--- a/service/controller/resource/etcd-certificates/resource.go
+++ b/service/controller/resource/etcd-certificates/resource.go
@@ -2,7 +2,6 @@ package etcdcertificates
 
 import (
 	"context"
-	"io/ioutil"
 	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
@@ -27,7 +26,9 @@ type Config struct {
 // secretCopier provides a `ToCR` method which copies data from the source
 // cluster secret CR
 type secretCopier struct {
+	logger     micrologger.Logger
 	clientFunc func(string) generic.Interface
+	k8sClient  k8sclient.Interface
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -43,7 +44,11 @@ func New(config Config) (*generic.Resource, error) {
 		return wrappedClient{client: c}
 	}
 
-	sc := secretCopier{clientFunc: clientFunc}
+	sc := secretCopier{
+		logger:     config.Logger,
+		clientFunc: clientFunc,
+		k8sClient:  config.K8sClient,
+	}
 
 	c := generic.Config{
 		ClientFunc:       clientFunc,

--- a/service/controller/resource/etcd-certificates/source.go
+++ b/service/controller/resource/etcd-certificates/source.go
@@ -17,6 +17,7 @@ func (sc *secretCopier) getSource(ctx context.Context, v interface{}) (map[strin
 	return data, nil
 }
 
+// getSourceFromDisk retrieves etcd certificates from the filesystem.
 func (sc *secretCopier) getSourceFromDisk() (map[string]string, error) {
 	ca, err := ioutil.ReadFile("/etcd-client-certs/ca.pem")
 	if err != nil {

--- a/service/controller/resource/etcd-certificates/source.go
+++ b/service/controller/resource/etcd-certificates/source.go
@@ -1,0 +1,43 @@
+package etcdcertificates
+
+import (
+	"context"
+	"io/ioutil"
+
+	"github.com/giantswarm/microerror"
+)
+
+// getSource retrieve data for the desired Secret.
+func (sc *secretCopier) getSource(ctx context.Context, v interface{}) (map[string]string, error) {
+	data, err := sc.getSourceFromDisk()
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return data, nil
+}
+
+func (sc *secretCopier) getSourceFromDisk() (map[string]string, error) {
+	ca, err := ioutil.ReadFile("/etcd-client-certs/ca.pem")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	crt, err := ioutil.ReadFile("/etcd-client-certs/crt.pem")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	key, err := ioutil.ReadFile("/etcd-client-certs/key.pem")
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	data := map[string]string{
+		"ca":  string(ca),
+		"crt": string(crt),
+		"key": string(key),
+	}
+
+	return data, nil
+}

--- a/service/controller/resource/etcd-certificates/target.go
+++ b/service/controller/resource/etcd-certificates/target.go
@@ -1,0 +1,44 @@
+package etcdcertificates
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/service/key"
+)
+
+// getObjectMeta returns the target secret metadata.
+func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return metav1.ObjectMeta{}, microerror.Mask(err)
+	}
+
+	return metav1.ObjectMeta{
+		Name:      key.EtcdSecret(v),
+		Namespace: key.Namespace(cluster),
+	}, nil
+}
+
+// ToSecret returns the target secret by combining results of getObjectMeta and getSource.
+func (sc *secretCopier) ToSecret(ctx context.Context, v interface{}) (metav1.Object, error) {
+	objectMeta, err := getObjectMeta(ctx, v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	data, err := sc.getSource(ctx, v)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: objectMeta,
+		StringData: data,
+	}
+
+	return secret, nil
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21156

Move `etcd-certificate` code around and prepare to add openstack support.

- enrich secretCopier with logger and k8sClient
- move getSource to getSourceFromDisk
