### PR TITLE
Kube state metrics nodepool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `nodepool` label to `kube-state-metrics` metrics.
+
 ## [3.2.0] - 2022-04-13
 
 ### Changed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -652,21 +652,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
@@ -708,6 +693,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 [[ if eq .ClusterType "management_cluster" ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -707,6 +707,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 [[ if eq .ClusterType "management_cluster" ]]
 # app-operator
 - job_name: [[ .ClusterID ]]-prometheus/app-operator-[[ .ClusterID ]]/0

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -576,17 +576,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
 [[ include "_common" . | indent 2 ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -576,19 +576,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
 [[ if eq .ClusterType "workload_cluster" ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -574,21 +574,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
 [[ if eq .ClusterType "workload_cluster" ]]
@@ -667,6 +652,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -695,13 +695,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -602,6 +602,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 [[ end ]]
 - job_name: [[ .ClusterID ]]-prometheus/workload-[[ .ClusterID ]]/0
   honor_labels: true

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -697,7 +697,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -574,6 +574,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
 [[ if eq .ClusterType "workload_cluster" ]]
@@ -601,21 +616,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 [[ end ]]
 - job_name: [[ .ClusterID ]]-prometheus/workload-[[ .ClusterID ]]/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1154,6 +1154,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: alice-prometheus/prometheus-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -961,6 +961,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1013,21 +1028,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -963,17 +963,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -961,21 +961,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1089,6 +1074,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1074,21 +1074,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1155,6 +1140,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -963,19 +963,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1014,6 +1014,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1144,7 +1144,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -1142,13 +1142,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -961,6 +961,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1013,21 +1028,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -963,17 +963,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -961,21 +961,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1089,6 +1074,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1154,6 +1154,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: foo-prometheus/prometheus-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1074,21 +1074,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1155,6 +1140,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1014,6 +1014,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -963,19 +963,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1144,7 +1144,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -1142,13 +1142,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -963,17 +963,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1014,6 +1014,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -961,21 +961,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1089,6 +1074,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1074,21 +1074,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1155,6 +1140,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -963,19 +963,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1144,7 +1144,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1142,13 +1142,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -1154,6 +1154,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: bar-prometheus/prometheus-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -961,6 +961,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1013,21 +1028,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -1002,6 +1002,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -842,21 +842,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -937,6 +922,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -844,17 +844,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -992,7 +992,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -922,21 +922,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1003,6 +988,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -990,13 +990,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -842,6 +842,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -844,19 +844,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -916,6 +916,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -968,21 +983,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -918,17 +918,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1097,13 +1097,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1029,21 +1029,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1110,6 +1095,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -918,19 +918,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1099,7 +1099,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -916,21 +916,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1044,6 +1029,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -969,6 +969,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -1109,6 +1109,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: baz-prometheus/prometheus-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1088,7 +1088,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -907,17 +907,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -905,21 +905,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1033,6 +1018,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -905,6 +905,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -957,21 +972,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -907,19 +907,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -958,6 +958,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1086,13 +1086,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1018,21 +1018,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1099,6 +1084,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -1098,6 +1098,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: alice-prometheus/prometheus-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1088,7 +1088,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -958,6 +958,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -907,17 +907,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -905,21 +905,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1033,6 +1018,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1098,6 +1098,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: foo-prometheus/prometheus-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -907,19 +907,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1086,13 +1086,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -1018,21 +1018,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1099,6 +1084,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -905,6 +905,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -957,21 +972,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1088,7 +1088,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -907,17 +907,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -958,6 +958,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -905,21 +905,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1033,6 +1018,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1098,6 +1098,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: bar-prometheus/prometheus-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -907,19 +907,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1086,13 +1086,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -1018,21 +1018,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1099,6 +1084,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -905,6 +905,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -957,21 +972,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -953,6 +953,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -873,21 +873,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -954,6 +939,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -793,6 +793,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -941,13 +941,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -795,19 +795,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -795,17 +795,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -793,21 +793,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -888,6 +873,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -943,7 +943,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -860,6 +860,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -912,21 +927,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -862,19 +862,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -1043,7 +1043,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -1053,6 +1053,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: baz-prometheus/prometheus-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -860,21 +860,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -988,6 +973,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -973,21 +973,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1054,6 +1039,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -913,6 +913,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -1041,13 +1041,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -862,17 +862,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: alice-prometheus/prometheus-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: foo-prometheus/prometheus-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: bar-prometheus/prometheus-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -953,6 +953,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -873,21 +873,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -954,6 +939,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -793,6 +793,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -941,13 +941,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -795,19 +795,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -795,17 +795,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -793,21 +793,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -888,6 +873,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -943,7 +943,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -987,13 +987,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -806,6 +806,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -858,21 +873,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -999,6 +999,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: baz-prometheus/prometheus-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -989,7 +989,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -808,19 +808,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -806,21 +806,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -934,6 +919,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -808,17 +808,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -919,21 +919,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1000,6 +985,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -859,6 +859,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: alice-prometheus/prometheus-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: foo-prometheus/prometheus-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -904,6 +904,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -1034,7 +1034,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -851,6 +851,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -903,21 +918,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: bar-prometheus/workload-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -1044,6 +1044,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: bar-prometheus/prometheus-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -851,21 +851,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -979,6 +964,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -853,19 +853,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -964,21 +964,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1045,6 +1030,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -853,17 +853,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -1032,13 +1032,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -953,6 +953,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # app-operator
 - job_name: kubernetes-prometheus/app-operator-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -873,21 +873,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -954,6 +939,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -793,6 +793,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -941,13 +941,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -795,19 +795,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -795,17 +795,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -793,21 +793,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -888,6 +873,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -943,7 +943,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -987,13 +987,6 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [app,cluster_id]
-    separator: ;
-    regex: kube-state-metrics;(.+)
-    target_label: nodepool
-    replacement: ${1}
-    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -806,6 +806,21 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -858,21 +873,6 @@
   - source_labels: [statefulset]
     regex: (.+)
     target_label: workload_name
-    replacement: ${1}
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: ${1}
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
     replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -999,6 +999,8 @@
     target_label: nodepool
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
 
 # prometheus
 - job_name: baz-prometheus/prometheus-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -989,7 +989,8 @@
     action: replace
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [app,cluster_id]
-    separator: kube-state-metrics;(.+)
+    separator: ;
+    regex: kube-state-metrics;(.+)
     target_label: nodepool
     replacement: ${1}
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -808,19 +808,19 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: .*
+    regex: (.*)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: .+
+    regex: (.+)
     target_label: nodepool
-    replacement: ${1}
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -806,21 +806,6 @@
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -934,6 +919,21 @@
     regex: (.+)
     target_label: app
     action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -808,17 +808,17 @@
     action: drop
   # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
   - source_labels: [cluster_id]
-    regex: (.*)
+    regex: .*
     target_label: nodepool
     replacement: ${1}
   # Override with label for AWS clusters if exists.
   - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Override with label for Azure clusters if exists.
   - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
+    regex: .+
     target_label: nodepool
     replacement: ${1}
   # Add namespace label.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -919,21 +919,6 @@
     regex: (.+)
     target_label: app
     action: replace
-  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
-  - source_labels: [cluster_id]
-    regex: (.*)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for AWS clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_deployment]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
-  # Override with label for Azure clusters if exists.
-  - source_labels: [label_giantswarm_io_machine_pool]
-    regex: (.+)
-    target_label: nodepool
-    replacement: $1
   # Add namespace label.
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
@@ -1000,6 +985,24 @@
     separator: ;
     regex: kube-state-metrics;(.+)
     target_label: workload_name
+    replacement: ${1}
+    action: replace
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [app,cluster_id]
+    separator: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
     replacement: ${1}
     action: replace
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -859,6 +859,21 @@
     regex: (.+)
     target_label: workload_name
     replacement: ${1}
+  # nodepool name. Defaults to the cluster name (to ensure there is always a value for management clusters that don't have node pools).
+  - source_labels: [cluster_id]
+    regex: (.*)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for AWS clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_deployment]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
+  # Override with label for Azure clusters if exists.
+  - source_labels: [label_giantswarm_io_machine_pool]
+    regex: (.+)
+    target_label: nodepool
+    replacement: ${1}
 
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/21428

after we merge https://github.com/giantswarm/kube-state-metrics-app/pull/132/files with this PR we rewrite the node pool name in `kube_node_info` metric as `nodepool` to make it uniform across providers.

This will be helpful to make SLO alerts nodepool-aware.


## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
