### PR TITLE
Use 'ip' node label as target to scrape etcd on MCs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Use 'ip' node label as target to scrape etcd on MCs.
+
 ## [3.4.1] - 2022-05-05
 
 ### Fixed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -225,11 +225,20 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master
     action: keep
+  # by default use node address
   - source_labels: [__address__]
     regex: (.*):10250
     target_label: __address__
     replacement: ${1}:2379
     action: replace
+[[ if eq .ClusterType "management_cluster" ]]
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+[[- end ]]
 [[- if and (eq .ClusterType "workload_cluster") (.WorkloadClusterETCDDomain) ]]
   - source_labels: [__address__]
     target_label: __address__

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -290,8 +290,16 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master
     action: keep
+  # by default use node address
   - source_labels: [__address__]
     regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
     target_label: __address__
     replacement: ${1}:2379
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -241,8 +241,16 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master
     action: keep
+  # by default use node address
   - source_labels: [__address__]
     regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
     target_label: __address__
     replacement: ${1}:2379
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -241,8 +241,16 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master
     action: keep
+  # by default use node address
   - source_labels: [__address__]
     regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
     target_label: __address__
     replacement: ${1}:2379
     action: replace

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -241,8 +241,16 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master
     action: keep
+  # by default use node address
   - source_labels: [__address__]
     regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
     target_label: __address__
     replacement: ${1}:2379
     action: replace


### PR DESCRIPTION
The main node IP as written by the kubelet in the `Node` status field, is unreliable.
In AWS MCs this can be a random POD cidr IP and when that's the case etcd scraping fails.

This PR looks for a label named "ip" in the Node resource and, if present, uses that label for scraping etcd.
The label is set by us on MCs with a well known correct ip address.
This makes scrape success much more likely.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
