### PR TITLE
Cadvisor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add scrape config for standalone cadvisor.
+
 ## [3.4.3] - 2022-05-10
 
 ### Fixed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -159,17 +159,16 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
 [[ include "_labelingschema" . | indent 2 ]]
-[[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
 [[- if eq .ClusterType "management_cluster" ]]
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 [[- else ]]
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 [[- end ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -100,8 +100,8 @@
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
 [[- end ]]
-# Add scrape configuration for cadvisor
-- job_name: [[ .ClusterID ]]-prometheus/cadvisor-[[ .ClusterID ]]/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: [[ .ClusterID ]]-prometheus/cadvisor-[[ .ClusterID ]]-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -116,6 +116,39 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+[[ include "_labelingschema" . | indent 2 ]]
+[[ include "_node_role" . | indent 2 ]]
+  metric_relabel_configs:
+[[- if eq .ClusterType "management_cluster" ]]
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+[[- else ]]
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+[[- end ]]
+# cadvisor standalone deployed as a managed app
+- job_name: [[ .ClusterID ]]-prometheus/cadvisor-[[ .ClusterID ]]-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+[[ include "_apiserver" . ]]
+[[ include "_tlsconfig" . | indent 2 ]]
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: [[ .APIServerURL ]]
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -163,8 +163,14 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
 [[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -161,10 +161,12 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
 [[- if eq .ClusterType "management_cluster" ]]
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 [[- else ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -111,11 +111,20 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: [[ .APIServerURL ]]
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  [[ if eq .ClusterType "management_cluster" ]]
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+  [[- end ]]
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -146,7 +146,8 @@
 - job_name: [[ .ClusterID ]]-prometheus/cadvisor-[[ .ClusterID ]]-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 [[ include "_apiserver" . ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -152,7 +152,7 @@
 [[ include "_tlsconfig" . | indent 2 ]]
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: [[ .APIServerURL ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -163,9 +163,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -169,7 +169,7 @@
     target_label: container
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
 [[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -161,16 +161,16 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+[[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
   - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
   - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
   - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
-[[ include "_labelingschema" . | indent 2 ]]
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  - regex: container_label_.*
+    action: labeldrop
 #[[- if eq .ClusterType "management_cluster" ]]
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -111,20 +111,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  [[ if eq .ClusterType "management_cluster" ]]
-  # if the 'ip' label is present, use the value
-  - source_labels: [__meta_kubernetes_node_label_ip]
-    regex: (.+)
-    target_label: __address__
-    replacement: ${1}:2379
-    action: replace
-  [[- end ]]
+  - target_label: __address__
+    replacement: [[ .APIServerURL ]]
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -147,17 +147,22 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 [[ include "_apiserver" . ]]
 [[ include "_tlsconfig" . | indent 2 ]]
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: [[ .APIServerURL ]]
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -171,15 +171,15 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#[[- if eq .ClusterType "management_cluster" ]]
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-#    action: keep
-#[[- else ]]
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#[[- end ]]
+[[- if eq .ClusterType "management_cluster" ]]
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+[[- else ]]
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+[[- end ]]
 # calico-node
 - job_name: [[ .ClusterID ]]-prometheus/calico-node-[[ .ClusterID ]]/0
   honor_labels: true

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -161,11 +161,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
@@ -176,7 +176,7 @@
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 [[- else ]]
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 [[- end ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -146,6 +146,7 @@
 - job_name: [[ .ClusterID ]]-prometheus/cadvisor-[[ .ClusterID ]]-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 [[ include "_apiserver" . ]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -168,18 +168,18 @@
   - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
 [[ include "_labelingschema" . | indent 2 ]]
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-[[- if eq .ClusterType "management_cluster" ]]
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-    action: keep
-[[- else ]]
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
-[[- end ]]
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#[[- if eq .ClusterType "management_cluster" ]]
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+#    action: keep
+#[[- else ]]
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#[[- end ]]
 # calico-node
 - job_name: [[ .ClusterID ]]-prometheus/calico-node-[[ .ClusterID ]]/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -154,7 +154,8 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: alice-prometheus/cadvisor-alice/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: alice-prometheus/cadvisor-alice-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: aws
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: alice-prometheus/cadvisor-alice-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.alice:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -154,6 +154,7 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.foo:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -154,6 +154,7 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -154,7 +154,8 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: foo-prometheus/cadvisor-foo/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: foo-prometheus/cadvisor-foo-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: aws
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: foo-prometheus/cadvisor-foo-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.bar:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: bar-prometheus/cadvisor-bar/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: bar-prometheus/cadvisor-bar-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: aws
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: bar-prometheus/cadvisor-bar-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -154,7 +154,8 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -154,6 +154,7 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -198,11 +198,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -138,19 +138,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
-  # if the 'ip' label is present, use the value
-  - source_labels: [__meta_kubernetes_node_label_ip]
-    regex: (.+)
-    target_label: __address__
-    replacement: ${1}:2379
-    action: replace
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -180,7 +180,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
@@ -188,12 +188,17 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -138,11 +138,19 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -196,7 +196,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -210,11 +210,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -216,12 +216,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+#    action: keep
+#
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -198,12 +198,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -216,9 +210,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -179,6 +179,7 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -219,11 +219,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -200,9 +200,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -124,8 +124,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-# Add scrape configuration for cadvisor
-- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -143,6 +143,49 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: aws
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -217,7 +217,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -200,6 +200,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -213,6 +217,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -188,7 +188,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -198,6 +198,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -211,7 +213,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -179,7 +179,8 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.baz:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: baz-prometheus/cadvisor-baz/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: baz-prometheus/cadvisor-baz-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: aws
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: baz-prometheus/cadvisor-baz-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -154,7 +154,8 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -154,6 +154,7 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -154,7 +154,8 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: alice-prometheus/cadvisor-alice/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: alice-prometheus/cadvisor-alice-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: azure
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: alice-prometheus/cadvisor-alice-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.alice:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -154,6 +154,7 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: foo-prometheus/cadvisor-foo/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: foo-prometheus/cadvisor-foo-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: azure
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: foo-prometheus/cadvisor-foo-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.foo:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -154,6 +154,7 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -154,7 +154,8 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: bar-prometheus/cadvisor-bar/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: bar-prometheus/cadvisor-bar-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: azure
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: bar-prometheus/cadvisor-bar-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.bar:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -154,7 +154,8 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -154,6 +154,7 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -198,11 +198,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -138,19 +138,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
-  # if the 'ip' label is present, use the value
-  - source_labels: [__meta_kubernetes_node_label_ip]
-    regex: (.+)
-    target_label: __address__
-    replacement: ${1}:2379
-    action: replace
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -180,7 +180,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
@@ -188,12 +188,17 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -138,11 +138,19 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -196,7 +196,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -210,11 +210,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -216,12 +216,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+#    action: keep
+#
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -198,12 +198,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -216,9 +210,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -179,6 +179,7 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -219,11 +219,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -200,9 +200,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -217,7 +217,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -200,6 +200,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -213,6 +217,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -124,8 +124,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-# Add scrape configuration for cadvisor
-- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -143,6 +143,49 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: azure
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -188,7 +188,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -198,6 +198,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -211,7 +213,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -179,7 +179,8 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -207,11 +207,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -186,12 +186,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -204,9 +198,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -204,12 +204,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -119,13 +119,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -155,7 +155,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.baz:443
     tls_config:
@@ -170,12 +170,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -119,11 +119,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -170,7 +170,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -186,6 +186,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -98,8 +98,8 @@
     target_label: role
 
 
-# Add scrape configuration for cadvisor
-- job_name: baz-prometheus/cadvisor-baz/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: baz-prometheus/cadvisor-baz-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -124,6 +124,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: azure
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: baz-prometheus/cadvisor-baz-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -188,6 +188,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -201,6 +205,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -184,7 +184,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -198,11 +198,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -154,7 +154,8 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -188,9 +188,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -205,7 +205,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -186,11 +186,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -207,7 +207,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -154,6 +154,7 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -100,6 +100,7 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -100,7 +100,8 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: alice-prometheus/cadvisor-alice/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: alice-prometheus/cadvisor-alice-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: alice-prometheus/cadvisor-alice-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.alice:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -100,6 +100,7 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -100,7 +100,8 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.foo:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: foo-prometheus/cadvisor-foo/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: foo-prometheus/cadvisor-foo-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: foo-prometheus/cadvisor-foo-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -100,7 +100,8 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.bar:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: bar-prometheus/cadvisor-bar/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: bar-prometheus/cadvisor-bar-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: bar-prometheus/cadvisor-bar-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -100,6 +100,7 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -198,11 +198,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -138,19 +138,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
-  # if the 'ip' label is present, use the value
-  - source_labels: [__meta_kubernetes_node_label_ip]
-    regex: (.+)
-    target_label: __address__
-    replacement: ${1}:2379
-    action: replace
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -180,7 +180,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
@@ -188,12 +188,17 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -124,8 +124,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-# Add scrape configuration for cadvisor
-- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -143,6 +143,49 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -138,11 +138,19 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -196,7 +196,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -210,11 +210,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -216,12 +216,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+#    action: keep
+#
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -198,12 +198,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -216,9 +210,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -179,6 +179,7 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -219,11 +219,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -200,9 +200,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -217,7 +217,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -200,6 +200,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -213,6 +217,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -188,7 +188,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -198,6 +198,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -211,7 +213,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -179,7 +179,8 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: baz-prometheus/cadvisor-baz/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: baz-prometheus/cadvisor-baz-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: baz-prometheus/cadvisor-baz-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -100,6 +100,7 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -100,7 +100,8 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.baz:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: alice-prometheus/cadvisor-alice/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: alice-prometheus/cadvisor-alice-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: alice-prometheus/cadvisor-alice-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -100,6 +100,7 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -100,7 +100,8 @@
 - job_name: alice-prometheus/cadvisor-alice-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.alice:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.alice:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: alice
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -100,6 +100,7 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -100,7 +100,8 @@
 - job_name: foo-prometheus/cadvisor-foo-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.foo:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.foo:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: foo
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: foo-prometheus/cadvisor-foo/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: foo-prometheus/cadvisor-foo-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: foo-prometheus/cadvisor-foo-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.foo:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -100,7 +100,8 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.bar:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -100,6 +100,7 @@
 - job_name: bar-prometheus/cadvisor-bar-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.bar:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: bar
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: bar-prometheus/cadvisor-bar/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: bar-prometheus/cadvisor-bar-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: bar-prometheus/cadvisor-bar-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -198,11 +198,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -138,19 +138,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
-  # if the 'ip' label is present, use the value
-  - source_labels: [__meta_kubernetes_node_label_ip]
-    regex: (.+)
-    target_label: __address__
-    replacement: ${1}:2379
-    action: replace
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -180,7 +180,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
   tls_config:
@@ -188,12 +188,17 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -138,11 +138,19 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: 127.0.0.1:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -196,7 +196,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -210,11 +210,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -216,12 +216,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+#    action: keep
+#
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -198,12 +198,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -216,9 +210,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -124,8 +124,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-# Add scrape configuration for cadvisor
-- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -143,6 +143,49 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: 127.0.0.1:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -179,6 +179,7 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -219,11 +219,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -200,9 +200,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -217,7 +217,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -200,6 +200,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -213,6 +217,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -188,7 +188,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: 127.0.0.1:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -198,6 +198,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: kubernetes
@@ -211,7 +213,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -179,7 +179,8 @@
 - job_name: kubernetes-prometheus/cadvisor-kubernetes-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -132,12 +132,6 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [container_label_io_kubernetes_pod_namespace]
-    target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
-    target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
-    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -150,9 +144,15 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-#  metric_relabel_configs:
-#  - regex: container_label_.*
-#    action: labeldrop
+  metric_relabel_configs:
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
+    target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
+  - regex: container_label_.*
+    action: labeldrop
 #
 #  - source_labels: [namespace]
 #    regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -65,13 +65,11 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  # by default use node address
-  - source_labels: [__address__]
-    regex: (.*):10260
-    target_label: __address__
-    replacement: ${1}:10260
-    action: replace
-  
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -150,12 +150,14 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  metric_relabel_configs:
-  - regex: container_label_.*
-    action: labeldrop
-  - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
-    action: keep
+#  metric_relabel_configs:
+#  - regex: container_label_.*
+#    action: labeldrop
+#
+#  - source_labels: [namespace]
+#    regex: (kube-system|giantswarm.*|kong.*)
+#    action: keep
+#
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -44,8 +44,8 @@
 
 
 
-# Add scrape configuration for cadvisor
-- job_name: baz-prometheus/cadvisor-baz/0
+# cadvisor embedded in kubelet - deprecated and to be removed
+- job_name: baz-prometheus/cadvisor-baz-kubelet/0
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
@@ -70,6 +70,56 @@
   - source_labels: [__meta_kubernetes_node_name]
     target_label: __metrics_path__
     replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# cadvisor standalone deployed as a managed app
+- job_name: baz-prometheus/cadvisor-baz-daemonset/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10260/metrics
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -153,11 +153,9 @@
     target_label: container
   - regex: container_label_.*
     action: labeldrop
-#
-#  - source_labels: [namespace]
-#    regex: (kube-system|giantswarm.*|kong.*)
-#    action: keep
-#
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -116,7 +116,7 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
-    replacement: ${1}:10260
+    replacement: ${1}
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -100,6 +100,7 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
+  scrape_timeout: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -100,7 +100,8 @@
 - job_name: baz-prometheus/cadvisor-baz-daemonset/0
   honor_labels: true
   scheme: https
-  scrape_timeout: 60s
+  scrape_timeout: 30s
+  scrape_interval: 60s
   kubernetes_sd_configs:
   - role: pod
 

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -134,9 +134,9 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
-  - source_labels: [container_label_io_kubernetes_pod_name]
+  - source_labels: [__meta_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [container_label_io_kubernetes_container_name]
+  - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -134,6 +134,10 @@
     target_label: node
   - source_labels: [__meta_kubernetes_namespace]
     target_label: namespace
+  - source_labels: [container_label_io_kubernetes_pod_name]
+    target_label: pod
+  - source_labels: [container_label_io_kubernetes_container_name]
+    target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz
@@ -147,6 +151,8 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
+  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+    action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -151,7 +151,7 @@
   - target_label: installation
     replacement: test-installation
   metric_relabel_configs:
-  - source_labels: [container_label_annotation_io_kubernetes_container_hash,container_label_annotation_io_kubernetes_container_ports,container_label_annotation_io_kubernetes_container_restartCount,container_label_annotation_io_kubernetes_container_terminationMessagePath,container_label_annotation_io_kubernetes_container_terminationMessagePolicy,container_label_annotation_io_kubernetes_pod_terminationGracePeriod,container_label_io_kubernetes_container_logpath, container_label_io_kubernetes_docker_type,container_label_io_kubernetes_pod_namespace,container_label_io_kubernetes_pod_uid,container_label_io_kubernetes_sandbox_id]
+  - regex: container_label_.*
     action: labeldrop
   - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -132,6 +132,8 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
   # Add cluster_id label.
   - target_label: cluster_id
     replacement: baz

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -130,7 +130,7 @@
   - target_label: app
     replacement: cadvisor
   # Add node name.
-  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+  - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
   # Add cluster_id label.
   - target_label: cluster_id
@@ -144,11 +144,8 @@
   # Add installation label.
   - target_label: installation
     replacement: test-installation
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
   metric_relabel_configs:
-  - source_labels: [namespace]
+  - source_labels: [__meta_kubernetes_namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -65,11 +65,13 @@
   relabel_configs:
   - source_labels: [__address__]
     target_label: instance
-  - target_label: __address__
-    replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
-    target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10260
+    target_label: __address__
+    replacement: ${1}:10260
+    action: replace
+  
   - target_label: app
     replacement: cadvisor
   # Add node name.

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -132,11 +132,11 @@
   # Add node name.
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [container_label_io_kubernetes_pod_namespace]
     target_label: namespace
-  - source_labels: [__meta_kubernetes_pod_name]
+  - source_labels: [container_label_io_kubernetes_pod_name]
     target_label: pod
-  - source_labels: [__meta_kubernetes_pod_container_name]
+  - source_labels: [container_label_io_kubernetes_container_name]
     target_label: container
   # Add cluster_id label.
   - target_label: cluster_id
@@ -153,7 +153,7 @@
   metric_relabel_configs:
   - regex: container_label_.*
     action: labeldrop
-  - source_labels: [__meta_kubernetes_namespace]
+  - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -101,7 +101,7 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  - role: node
+  - role: pod
 
     api_server: https://master.baz:443
     tls_config:
@@ -116,12 +116,17 @@
     insecure_skip_verify: false
   relabel_configs:
   - source_labels: [__address__]
+    replacement: ${1}:10260
     target_label: instance
   - target_label: __address__
     replacement: master.baz:443
-  - source_labels: [__meta_kubernetes_node_name]
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cadvisor.*)
     target_label: __metrics_path__
-    replacement: /api/v1/nodes/${1}:10260/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10260/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;cadvisor.*
+    action: keep
   - target_label: app
     replacement: cadvisor
   # Add node name.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1094

This PR adds a new scraping config to scrape standalone cadvisor alongside kubelet-embedded one.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
