### PR TITLE
add remoteWrite CRD to helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add remotewrite controller.
+- Deployment of remoteWrite CRD in Helm chart
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ The actual CRDs are in `config/crd/monitoring.giantswarm.io_remotewrites.yaml`
 
 To generate the CRDs from code, just use `make generate`.
 
+## Deployment
+
+CRDs deployment is managed within the helm chart.
+The remoteWrite CRD is located under the chart's templates directory as a symbolic link to the generated yaml file. 
 
 [operatorkit]: https://github.com/giantswarm/operatorkit
 [prometheus-operator]: https://github.com/prometheus-operator/prometheus-operator

--- a/helm/prometheus-meta-operator/templates/remoteWrites_crd.yaml
+++ b/helm/prometheus-meta-operator/templates/remoteWrites_crd.yaml
@@ -1,0 +1,1 @@
+../../../config/crd/monitoring.giantswarm.io_remotewrites.yaml


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1109

Deploy remoteWrite CRD with Helm chart.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
