### PR TITLE
Run PMO as non root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fix
+
+- Make PMO run as non root.
+
 ## [3.6.0] - 2022-06-08
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/deployment.yaml
+++ b/helm/prometheus-meta-operator/templates/deployment.yaml
@@ -46,6 +46,21 @@ spec:
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}
         runAsGroup: {{ .Values.pod.group.id }}
+        runAsNonRoot: true
+      initContainers:
+      - name: volume-mount-hack
+        image: busybox
+        command: ["sh", "-c", "chmod -R 644 /etcd-client-certs"]
+        securityContext:
+          runAsUser: 0
+          runAsNonRoot: false
+        volumeMounts:
+        - mountPath: /etcd-client-certs/ca.pem
+          name: etcd-client-ca
+        - mountPath: /etcd-client-certs/crt.pem
+          name: etcd-client-crt
+        - mountPath: /etcd-client-certs/key.pem
+          name: etcd-client-key
       containers:
       - name: {{ include "name" . }}
         image: "{{ .Values.registry.domain }}/{{ .Values.image.name }}:{{ .Values.image.tag }}"

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -9,7 +9,7 @@ registry:
 
 pod:
   user:
-    id: 0
+    id: 1000
   group:
     id: 1000
 


### PR DESCRIPTION
This PR adds an init container to change the permission of the etcd certs to non root so the PMO container can use them

## Checklist

I have:

- [x] Described why this change is being introduced Towards https://github.com/giantswarm/giantswarm/issues/22291
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
