### PR TITLE
change remote write name to grafana-cloud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add remotewrite controller.
 - Deployment of remoteWrite CRD in Helm chart
 
+### Changed
+
+- Change remote write name to grafana-cloud.
+
 ### Fixed
 
 - dependencies updates

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -297,7 +297,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 				// We set it to 10 (default: 1) to prevent the initial shard scale up
 				MinShards: 10,
 			},
-			Name: key.ClusterID(cluster),
+			Name: "grafana-cloud",
 			WriteRelabelConfigs: []promv1.RelabelConfig{
 				{
 					SourceLabels: []string{"__name__"},

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -64,7 +64,7 @@ spec:
       username:
         key: username
         name: remote-write
-    name: alice
+    name: grafana-cloud
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -64,7 +64,7 @@ spec:
       username:
         key: username
         name: remote-write
-    name: foo
+    name: grafana-cloud
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -64,7 +64,7 @@ spec:
       username:
         key: username
         name: remote-write
-    name: bar
+    name: grafana-cloud
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -72,7 +72,7 @@ spec:
       username:
         key: username
         name: remote-write
-    name: kubernetes
+    name: grafana-cloud
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -64,7 +64,7 @@ spec:
       username:
         key: username
         name: remote-write
-    name: baz
+    name: grafana-cloud
     queueConfig:
       capacity: 10000
       maxSamplesPerSend: 1000


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1167

This PR changes the current name of the remote write config to match the upcoming resource name ([see](https://github.com/giantswarm/prometheus-remotewrite/pull/3/files#diff-5d9cb907ead68e48ad623375e437680d927f1572d02af17fd55963b5a169b2beR4)).