### PR TITLE
Supply HTTP proxy in remotewrite config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Implement remotewrite CR logic, in order to configure Prometheus remotewrite config.
+- Add HTTP_PROXY in remotewrite config
 
 ## [3.6.0] - 2022-06-08
 

--- a/service/controller/remotewrite/controller.go
+++ b/service/controller/remotewrite/controller.go
@@ -18,6 +18,10 @@ type ControllerConfig struct {
 	K8sClient        k8sclient.Interface
 	Logger           micrologger.Logger
 	PrometheusClient promclient.Interface
+
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
 }
 
 type Controller struct {

--- a/service/controller/remotewrite/resource.go
+++ b/service/controller/remotewrite/resource.go
@@ -16,6 +16,10 @@ func newResources(config ControllerConfig) ([]resource.Interface, error) {
 			K8sClient:        config.K8sClient,
 			Logger:           config.Logger,
 			PrometheusClient: config.PrometheusClient,
+
+			HTTPProxy:  config.HTTPProxy,
+			HTTPSProxy: config.HTTPSProxy,
+			NoProxy:    config.NoProxy,
 		}
 
 		prometheusRemoteWrite, err = prometheusremotewrite.New(c)

--- a/service/controller/resource/prometheusremotewrite/create.go
+++ b/service/controller/resource/prometheusremotewrite/create.go
@@ -30,7 +30,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		for _, current := range prometheusList.Items {
 
-			desired, ok := ensurePrometheusRemoteWrite(r, *remoteWrite, *current)
+			desired, ok := r.ensurePrometheusRemoteWrite(*remoteWrite, *current)
 			if !ok {
 				r.logger.Debugf(ctx, fmt.Sprintf("no update required for Prometheus CR %#q in namespace %#q", desired.Name, desired.Namespace))
 				continue

--- a/service/controller/resource/prometheusremotewrite/create.go
+++ b/service/controller/resource/prometheusremotewrite/create.go
@@ -30,7 +30,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		for _, current := range prometheusList.Items {
 
-			desired, ok := ensurePrometheusRemoteWrite(*remoteWrite, *current)
+			desired, ok := ensurePrometheusRemoteWrite(r, *remoteWrite, *current)
 			if !ok {
 				r.logger.Debugf(ctx, fmt.Sprintf("no update required for Prometheus CR %#q in namespace %#q", desired.Name, desired.Namespace))
 				continue

--- a/service/controller/resource/prometheusremotewrite/resource.go
+++ b/service/controller/resource/prometheusremotewrite/resource.go
@@ -82,7 +82,7 @@ func fetchPrometheusList(ctx context.Context, r *Resource, rw *pmov1alpha1.Remot
 	return prometheusList, nil
 }
 
-func ensurePrometheusRemoteWrite(r *Resource, rw pmov1alpha1.RemoteWrite, p promv1.Prometheus) (*promv1.Prometheus, bool) {
+func (r *Resource) ensurePrometheusRemoteWrite(rw pmov1alpha1.RemoteWrite, p promv1.Prometheus) (*promv1.Prometheus, bool) {
 	rw.Spec.RemoteWrite.Name = rw.GetName()
 
 	if !strings.Contains(r.NoProxy, rw.Spec.RemoteWrite.URL) {

--- a/service/controller/resource/prometheusremotewrite/resource.go
+++ b/service/controller/resource/prometheusremotewrite/resource.go
@@ -2,6 +2,7 @@ package prometheusremotewrite
 
 import (
 	"context"
+	"strings"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -22,12 +23,20 @@ type Config struct {
 	K8sClient        k8sclient.Interface
 	Logger           micrologger.Logger
 	PrometheusClient promclient.Interface
+
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
 }
 
 type Resource struct {
 	k8sClient        k8sclient.Interface
 	logger           micrologger.Logger
 	prometheusClient promclient.Interface
+
+	HTTPProxy  string
+	HTTPSProxy string
+	NoProxy    string
 }
 
 func New(config Config) (*Resource, error) {
@@ -35,6 +44,10 @@ func New(config Config) (*Resource, error) {
 		k8sClient:        config.K8sClient,
 		logger:           config.Logger,
 		prometheusClient: config.PrometheusClient,
+
+		HTTPProxy:  config.HTTPProxy,
+		HTTPSProxy: config.HTTPSProxy,
+		NoProxy:    config.NoProxy,
 	}
 
 	return r, nil
@@ -69,21 +82,30 @@ func fetchPrometheusList(ctx context.Context, r *Resource, rw *pmov1alpha1.Remot
 	return prometheusList, nil
 }
 
-func ensurePrometheusRemoteWrite(r pmov1alpha1.RemoteWrite, p promv1.Prometheus) (*promv1.Prometheus, bool) {
-	r.Spec.RemoteWrite.Name = r.GetName()
+func ensurePrometheusRemoteWrite(r *Resource, rw pmov1alpha1.RemoteWrite, p promv1.Prometheus) (*promv1.Prometheus, bool) {
+	rw.Spec.RemoteWrite.Name = rw.GetName()
+
+	if !strings.Contains(r.NoProxy, rw.Spec.RemoteWrite.URL) {
+		if len(r.HTTPSProxy) > 0 {
+			rw.Spec.RemoteWrite.ProxyURL = r.HTTPSProxy
+		} else if len(r.HTTPProxy) > 0 {
+			rw.Spec.RemoteWrite.ProxyURL = r.HTTPProxy
+		}
+	}
+
 	if p.Spec.RemoteWrite != nil {
-		if rwIndex, ok := remoteWriteExists(r.GetName(), p.Spec.RemoteWrite); !ok { // item not found
-			p.Spec.RemoteWrite = append(p.Spec.RemoteWrite, r.Spec.RemoteWrite)
+		if rwIndex, ok := remoteWriteExists(rw.GetName(), p.Spec.RemoteWrite); !ok { // item not found
+			p.Spec.RemoteWrite = append(p.Spec.RemoteWrite, rw.Spec.RemoteWrite)
 			return &p, true
-		} else if !cmp.Equal(r.Spec.RemoteWrite, p.Spec.RemoteWrite[rwIndex]) { //  item found
-			p.Spec.RemoteWrite[rwIndex] = r.Spec.RemoteWrite
+		} else if !cmp.Equal(rw.Spec.RemoteWrite, p.Spec.RemoteWrite[rwIndex]) { //  item found
+			p.Spec.RemoteWrite[rwIndex] = rw.Spec.RemoteWrite
 			return &p, true
 		} else {
 			// no update!!
 			return &p, false
 		}
 	} else {
-		p.Spec.RemoteWrite = []promv1.RemoteWriteSpec{r.Spec.RemoteWrite}
+		p.Spec.RemoteWrite = []promv1.RemoteWriteSpec{rw.Spec.RemoteWrite}
 		return &p, true
 	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -290,6 +290,10 @@ func New(config Config) (*Service, error) {
 			K8sClient:        k8sClient,
 			Logger:           config.Logger,
 			PrometheusClient: prometheusClient,
+
+			HTTPProxy:  os.Getenv("HTTP_PROXY"),
+			HTTPSProxy: os.Getenv("HTTPS_PROXY"),
+			NoProxy:    os.Getenv("NO_PROXY"),
 		}
 		remotewriteController, err = remotewrite.NewController(c)
 		if err != nil {


### PR DESCRIPTION
Issue: https://github.com/giantswarm/roadmap/issues/1169

Adding `HTTP_PROXY` If needed, once set up in the controller. 

## Checklist

I have:

- [X] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [X] Updated changelog in `CHANGELOG.md`
