### PR TITLE
grant remoteWrite patch permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove duplicate scrape config targets.
 
+### Fixed
+
+- Add `patch` verb for `remoteWrite` resources.
+
 ## [3.7.0] - 2022-06-20
 
 This release was created on release-v3.5.x branch to fix release 3.6.0 see PR#992

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -152,6 +152,7 @@ rules:
     verbs:
       - get
       - list
+      - patch
       - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/1140

Add the `patch` verb for `remoteWrite` resources needed by operatorkit to add finalizers.