### PR TITLE
Copy BasicAuth secrets to prometheus namespace

### DIFF
--- a/service/controller/resource/prometheusremotewrite/create.go
+++ b/service/controller/resource/prometheusremotewrite/create.go
@@ -30,6 +30,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		for _, current := range prometheusList.Items {
 
+			// Copy BasicAuth Secrets to Prometheus namespace:
+			err := r.copyBasicAuthSecret(ctx, remoteWrite, current.GetNamespace())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
 			desired, ok := r.ensurePrometheusRemoteWrite(*remoteWrite, *current)
 			if !ok {
 				r.logger.Debugf(ctx, fmt.Sprintf("no update required for Prometheus CR %#q in namespace %#q", desired.Name, desired.Namespace))

--- a/service/controller/resource/prometheusremotewrite/error.go
+++ b/service/controller/resource/prometheusremotewrite/error.go
@@ -6,6 +6,14 @@ var errorFetchingPrometheus = &microerror.Error{
 	Kind: "errorFetchingPrometheus",
 }
 
+var errorRetrievingSecret = &microerror.Error{
+	Kind: "errorRetrievingSecret",
+}
+
+var errorCreatingSecret = &microerror.Error{
+	Kind: "errorCreatingSecret",
+}
+
 var noSuchPrometheusForLabel = &microerror.Error{
 	Kind: "noSuchPrometheusForLabel",
 }

--- a/service/controller/resource/prometheusremotewrite/secrets.go
+++ b/service/controller/resource/prometheusremotewrite/secrets.go
@@ -2,10 +2,12 @@ package prometheusremotewrite
 
 import (
 	"context"
+
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
 )
 
 func (r *Resource) copyBasicAuthSecret(ctx context.Context, rw *v1alpha1.RemoteWrite, ns string) error {

--- a/service/controller/resource/prometheusremotewrite/secrets.go
+++ b/service/controller/resource/prometheusremotewrite/secrets.go
@@ -1,0 +1,71 @@
+package prometheusremotewrite
+
+import (
+	"context"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) copyBasicAuthSecret(ctx context.Context, rw *v1alpha1.RemoteWrite, ns string) error {
+
+	if rw.Spec.RemoteWrite.BasicAuth != nil {
+
+		if rw.Spec.RemoteWrite.BasicAuth.Username.Name == rw.Spec.RemoteWrite.BasicAuth.Password.Name {
+
+			sc, err := r.fetchSecret(ctx, rw.Spec.RemoteWrite.BasicAuth.Username.Name, rw.GetNamespace())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			// creating the new secret in the prometheus namespace
+			_, err = r.createSecret(ctx, sc, ns)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+		} else {
+
+			scUsername, err := r.fetchSecret(ctx, rw.Spec.RemoteWrite.BasicAuth.Username.Name, rw.GetNamespace())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			_, err = r.createSecret(ctx, scUsername, ns)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+			scPassword, err := r.fetchSecret(ctx, rw.Spec.RemoteWrite.BasicAuth.Password.Name, rw.GetNamespace())
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			_, err = r.createSecret(ctx, scPassword, ns)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+
+		}
+
+	}
+	return nil
+}
+
+func (r *Resource) fetchSecret(ctx context.Context, name, namespace string) (*corev1.Secret, error) {
+
+	sc, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return nil, microerror.Maskf(errorRetrievingSecret, "Could not fetch Secret with name %#s in namespace %#s", name, namespace)
+	}
+	return sc, nil
+}
+
+func (r *Resource) createSecret(ctx context.Context, sc *corev1.Secret, namespace string) (*corev1.Secret, error) {
+	sc.SetNamespace(namespace)
+
+	newSc, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Create(ctx, sc, metav1.CreateOptions{})
+	if err != nil {
+		return nil, microerror.Maskf(errorCreatingSecret, "Could not create Secret with name %#s in namespace %#s", newSc.GetName(), namespace)
+	}
+	return newSc, nil
+}

--- a/service/controller/resource/prometheusremotewrite/secrets.go
+++ b/service/controller/resource/prometheusremotewrite/secrets.go
@@ -57,7 +57,7 @@ func (r *Resource) fetchSecret(ctx context.Context, name, namespace string) (*co
 
 	sc, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
-		return nil, microerror.Maskf(errorRetrievingSecret, "Could not fetch Secret with name %#s in namespace %#s", name, namespace)
+		return nil, microerror.Maskf(errorRetrievingSecret, "Could not fetch Secret with name %s in namespace %s", name, namespace)
 	}
 	return sc, nil
 }
@@ -67,7 +67,7 @@ func (r *Resource) createSecret(ctx context.Context, sc *corev1.Secret, namespac
 
 	newSc, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Create(ctx, sc, metav1.CreateOptions{})
 	if err != nil {
-		return nil, microerror.Maskf(errorCreatingSecret, "Could not create Secret with name %#s in namespace %#s", newSc.GetName(), namespace)
+		return nil, microerror.Maskf(errorCreatingSecret, "Could not create Secret with name %s in namespace %s", newSc.GetName(), namespace)
 	}
 	return newSc, nil
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1180

## Checklist

In This PR, We make remotewrite controller able to copy BasicAuth secrets to Prometheus namespace.
In the reconciliation loop, the controller fetches the secrets and create them in Prometheus namespace.


I have:

- [X] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
