### PR TITLE
Implement sync RemoteWrite Secrets logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement remotewrite CR logic, in order to configure Prometheus remotewrite config.
 - Add HTTP_PROXY in remotewrite config
 - Add unit tests for remotewrite resource
+- Add Secrets field in the RemoteWrite CR
+- Implement sync RemoteWrite Secrets logic
+
+### Fixed 
+
+- Fix API server discovery.
 
 ### Removed
 

--- a/api/v1alpha1/remoteWrite_types.go
+++ b/api/v1alpha1/remoteWrite_types.go
@@ -15,7 +15,8 @@ type RemoteWrite struct {
 }
 
 type RemoteWriteSpec struct {
-	RemoteWrite     pov1.RemoteWriteSpec `json:"remoteWrite"`
+	RemoteWrite pov1.RemoteWriteSpec `json:"remoteWrite"`
+	// +immutable
 	ClusterSelector metav1.LabelSelector `json:"clusterSelector"`
 
 	// Secrets data to be created along with the configured Prometheus resource.

--- a/config/crd/monitoring.giantswarm.io_remotewrites.yaml
+++ b/config/crd/monitoring.giantswarm.io_remotewrites.yaml
@@ -559,8 +559,10 @@ spec:
                 - url
                 type: object
               secrets:
-                description: Secrets that will be created in the relevant Prometheus
-                  namespace
+                description: Secrets data to be created along with the configured
+                  Prometheus resource. This provides the data for any v1.SecretKeySelector
+                  used in the subsequent RemoteWrite field. Provided name and keys
+                  should match values in v1.SecretKeySelector fields.
                 items:
                   properties:
                     data:

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -35,6 +35,7 @@ rules:
       - create
       - update # Needed to update the additionalScrapeConfigs
       - delete
+      - deletecollection
       - get
       - list
   - apiGroups:

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -36,6 +36,7 @@ rules:
       - update # Needed to update the additionalScrapeConfigs
       - delete
       - get
+      - list
   - apiGroups:
       - apiextensions.k8s.io
     resources:

--- a/pkg/remotewriteutils/error.go
+++ b/pkg/remotewriteutils/error.go
@@ -1,0 +1,11 @@
+package remotewriteutils
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+var errorFetchingPrometheus = &microerror.Error{
+	Kind: "errorFetchingPrometheus",
+}

--- a/pkg/remotewriteutils/util.go
+++ b/pkg/remotewriteutils/util.go
@@ -1,0 +1,45 @@
+package remotewriteutils
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
+)
+
+type ResourceWrapper struct {
+	K8sClient        k8sclient.Interface
+	Logger           micrologger.Logger
+	PrometheusClient promclient.Interface
+}
+
+func ToRemoteWrite(obj interface{}) (*pmov1alpha1.RemoteWrite, error) {
+	remotewrite, ok := obj.(*pmov1alpha1.RemoteWrite)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "'%T' is not a 'pmov1alpha1.RemoteWrite'", obj)
+	}
+
+	return remotewrite, nil
+}
+
+func FetchPrometheusList(ctx context.Context, r *ResourceWrapper, rw *pmov1alpha1.RemoteWrite) (*promv1.PrometheusList, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&rw.Spec.ClusterSelector)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	prometheusList, err := r.PrometheusClient.
+		MonitoringV1().
+		Prometheuses(metav1.NamespaceAll).
+		List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, microerror.Maskf(errorFetchingPrometheus, "Could not fetch Prometheus with label selector %#q", rw.Spec.ClusterSelector.String())
+	}
+
+	return prometheusList, nil
+}

--- a/pkg/remotewriteutils/util_test.go
+++ b/pkg/remotewriteutils/util_test.go
@@ -1,0 +1,89 @@
+package remotewriteutils
+
+import (
+	"testing"
+
+	"github.com/giantswarm/microerror"
+	"github.com/google/go-cmp/cmp"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
+	"github.com/giantswarm/prometheus-meta-operator/pkg/unittest"
+)
+
+const (
+	name      = "simple-remotewrite"
+	namespace = "default"
+)
+
+func TestToRemoteWrite(t *testing.T) {
+
+	type args struct {
+		obj interface{}
+	}
+
+	type want struct {
+		rw  *pmov1alpha1.RemoteWrite
+		err error
+	}
+
+	successObj := pmov1alpha1.RemoteWrite{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: pmov1alpha1.RemoteWriteSpec{},
+	}
+
+	cases := map[string]struct {
+		reason string
+		args   args
+		want   want
+	}{
+		"ConvertSuccess": {
+			reason: "Convert an object to RemoteWrite",
+			args: args{
+				obj: &pmov1alpha1.RemoteWrite{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: pmov1alpha1.RemoteWriteSpec{},
+				},
+			},
+			want: want{
+				err: nil,
+				rw:  &successObj,
+			},
+		},
+		"ConvertFailed": {
+			reason: "Convert an object to RemoteWrite Failed",
+			args: args{
+				obj: promv1.Prometheus{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+					},
+					Spec: promv1.PrometheusSpec{},
+				},
+			},
+			want: want{
+				err: microerror.Maskf(wrongTypeError, "'%T' is not a 'pmov1alpha1.RemoteWrite'", promv1.Prometheus{}),
+				rw:  nil,
+			},
+		},
+	}
+
+	for n, tc := range cases {
+		t.Run(n, func(t *testing.T) {
+			got, err := ToRemoteWrite(tc.args.obj)
+			if diff := cmp.Diff(tc.want.err, err, unittest.EquateErrors()); diff != "" {
+				t.Errorf("\n%s\nExpand(...): -want, +got:\n%s", tc.reason, diff)
+			}
+			if diff := cmp.Diff(tc.want.rw, got); diff != "" {
+				t.Errorf("\n%s\nExpand(...): -want, +got:\n%s", tc.reason, diff)
+			}
+		})
+	}
+}

--- a/service/controller/remotewrite/resource.go
+++ b/service/controller/remotewrite/resource.go
@@ -44,8 +44,8 @@ func newResources(config ControllerConfig) ([]resource.Interface, error) {
 	}
 
 	resources := []resource.Interface{
-		prometheusRemoteWrite,
 		rwSecretResource,
+		prometheusRemoteWrite,
 	}
 
 	return resources, nil

--- a/service/controller/remotewrite/resource.go
+++ b/service/controller/remotewrite/resource.go
@@ -5,6 +5,7 @@ import (
 	"github.com/giantswarm/operatorkit/v7/pkg/resource"
 
 	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/prometheusremotewrite"
+	"github.com/giantswarm/prometheus-meta-operator/service/controller/resource/remotewritesecret"
 )
 
 func newResources(config ControllerConfig) ([]resource.Interface, error) {
@@ -28,8 +29,23 @@ func newResources(config ControllerConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var rwSecretResource resource.Interface
+	{
+		c := remotewritesecret.Config{
+			K8sClient:        config.K8sClient,
+			Logger:           config.Logger,
+			PrometheusClient: config.PrometheusClient,
+		}
+
+		rwSecretResource, err = remotewritesecret.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		prometheusRemoteWrite,
+		rwSecretResource,
 	}
 
 	return resources, nil

--- a/service/controller/resource/prometheusremotewrite/create.go
+++ b/service/controller/resource/prometheusremotewrite/create.go
@@ -7,18 +7,20 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/pkg/remotewriteutils"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	r.logger.Debugf(ctx, "ensuring prometheus remoteWrite config")
 	{
-		remoteWrite, err := ToRemoteWrite(obj)
+		remoteWrite, err := remotewriteutils.ToRemoteWrite(obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		// fetch current prometheus using the selector provided in remoteWrite resource.
-		prometheusList, err := fetchPrometheusList(ctx, r, remoteWrite)
+		prometheusList, err := remotewriteutils.FetchPrometheusList(ctx, toResourceWrapper(r), remoteWrite)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/prometheusremotewrite/delete.go
+++ b/service/controller/resource/prometheusremotewrite/delete.go
@@ -7,18 +7,20 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/pkg/remotewriteutils"
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 	r.logger.Debugf(ctx, "deleting prometheus remoteWrite config")
 	{
-		remoteWrite, err := ToRemoteWrite(obj)
+		remoteWrite, err := remotewriteutils.ToRemoteWrite(obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		// fetch current prometheus using the selector provided in remoteWrite resource.
-		prometheusList, err := fetchPrometheusList(ctx, r, remoteWrite)
+		prometheusList, err := remotewriteutils.FetchPrometheusList(ctx, toResourceWrapper(r), remoteWrite)
 		if err != nil {
 			return microerror.Mask(err)
 		}

--- a/service/controller/resource/prometheusremotewrite/error.go
+++ b/service/controller/resource/prometheusremotewrite/error.go
@@ -2,10 +2,6 @@ package prometheusremotewrite
 
 import "github.com/giantswarm/microerror"
 
-var errorFetchingPrometheus = &microerror.Error{
-	Kind: "errorFetchingPrometheus",
-}
-
 var noSuchPrometheusForLabel = &microerror.Error{
 	Kind: "noSuchPrometheusForLabel",
 }

--- a/service/controller/resource/prometheusremotewrite/resource_test.go
+++ b/service/controller/resource/prometheusremotewrite/resource_test.go
@@ -3,14 +3,12 @@ package prometheusremotewrite
 import (
 	"testing"
 
-	"github.com/giantswarm/microerror"
 	"github.com/google/go-cmp/cmp"
 	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
-	"github.com/giantswarm/prometheus-meta-operator/pkg/unittest"
 )
 
 const (
@@ -18,77 +16,6 @@ const (
 	namespace       = "default"
 	clusterSelector = "giant-cluster"
 )
-
-func TestToRemoteWrite(t *testing.T) {
-
-	type args struct {
-		obj interface{}
-	}
-
-	type want struct {
-		rw  *pmov1alpha1.RemoteWrite
-		err error
-	}
-
-	successObj := pmov1alpha1.RemoteWrite{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Spec: pmov1alpha1.RemoteWriteSpec{},
-	}
-
-	cases := map[string]struct {
-		reason string
-		args   args
-		want   want
-	}{
-		"ConvertSuccess": {
-			reason: "Convert an object to RemoteWrite",
-			args: args{
-				obj: &pmov1alpha1.RemoteWrite{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: namespace,
-					},
-					Spec: pmov1alpha1.RemoteWriteSpec{},
-				},
-			},
-			want: want{
-				err: nil,
-				rw:  &successObj,
-			},
-		},
-		"ConvertFailed": {
-			reason: "Convert an object to RemoteWrite Failed",
-			args: args{
-				obj: promv1.Prometheus{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      name,
-						Namespace: namespace,
-					},
-					Spec: promv1.PrometheusSpec{},
-				},
-			},
-			want: want{
-				err: microerror.Maskf(wrongTypeError, "'%T' is not a 'pmov1alpha1.RemoteWrite'", promv1.Prometheus{}),
-				rw:  nil,
-			},
-		},
-	}
-
-	for n, tc := range cases {
-		t.Run(n, func(t *testing.T) {
-			got, err := ToRemoteWrite(tc.args.obj)
-			if diff := cmp.Diff(tc.want.err, err, unittest.EquateErrors()); diff != "" {
-				t.Errorf("\n%s\nExpand(...): -want, +got:\n%s", tc.reason, diff)
-			}
-			if diff := cmp.Diff(tc.want.rw, got); diff != "" {
-				t.Errorf("\n%s\nExpand(...): -want, +got:\n%s", tc.reason, diff)
-			}
-		})
-	}
-}
 
 func TestEnsurePrometheusRemoteWrite(t *testing.T) {
 

--- a/service/controller/resource/remotewritesecret/create.go
+++ b/service/controller/resource/remotewritesecret/create.go
@@ -1,0 +1,59 @@
+package remotewritesecret
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	r.logger.Debugf(ctx, "ensuring prometheus remotewrite secret")
+	{
+		remoteWrite, err := ToRemoteWrite(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// fetch current prometheus using the selector provided in remoteWrite resource.
+		prometheusList, err := fetchPrometheusList(ctx, r, remoteWrite)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if prometheusList == nil || len(prometheusList.Items) == 0 {
+			r.logger.Debugf(ctx, "no prometheus found, cancel reconciliation")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil
+		}
+
+		for _, current := range prometheusList.Items {
+
+			// Loop over remote write secrets
+			for _, item := range remoteWrite.Spec.Secrets {
+				desired := r.ensureRemoteWriteSecret(item, remoteWrite.ObjectMeta, current.GetNamespace())
+				secret, err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Get(ctx, item.Name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					r.logger.Debugf(ctx, fmt.Sprintf("creating Secret %#q in namespace %#q", desired.Name, desired.Namespace))
+
+					//if err := r.k8sClient.K8sClient().SetControllerReference(p, &desiredSa, r.Scheme); err != nil {
+					//	return err
+					//}
+					secret, err = r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Create(ctx, &desired, metav1.CreateOptions{})
+				}
+				if err != nil {
+					return microerror.Mask(err)
+				}
+				r.logger.Debugf(ctx, fmt.Sprintf("Secret %#q in namespace %#q created", secret.Name, secret.Namespace))
+
+			}
+		}
+
+	}
+
+	r.logger.Debugf(ctx, "ensured prometheus remotewrite secret")
+
+	return nil
+}

--- a/service/controller/resource/remotewritesecret/create.go
+++ b/service/controller/resource/remotewritesecret/create.go
@@ -57,7 +57,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			  Cleanup deleted secrets from RemoteWrite CR
 			*/
 			l := labels.SelectorFromSet(labels.Set(map[string]string{
-				label:          Name,
 				labelName:      remoteWrite.GetName(),
 				labelNamespace: remoteWrite.GetNamespace(),
 			}))

--- a/service/controller/resource/remotewritesecret/create.go
+++ b/service/controller/resource/remotewritesecret/create.go
@@ -39,7 +39,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// Loop over remote write secrets
 			for _, item := range remoteWrite.Spec.Secrets {
 				desired := r.ensureRemoteWriteSecret(item, remoteWrite.ObjectMeta, current.GetNamespace())
-				fmt.Println("Debug:", desired)
 				secret, err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Get(ctx, item.Name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					r.logger.Debugf(ctx, fmt.Sprintf("creating Secret %#q in namespace %#q", desired.Name, desired.Namespace))

--- a/service/controller/resource/remotewritesecret/create.go
+++ b/service/controller/resource/remotewritesecret/create.go
@@ -39,6 +39,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			// Loop over remote write secrets
 			for _, item := range remoteWrite.Spec.Secrets {
 				desired := r.ensureRemoteWriteSecret(item, remoteWrite.ObjectMeta, current.GetNamespace())
+				fmt.Println("Debug:", desired)
 				secret, err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Get(ctx, item.Name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					r.logger.Debugf(ctx, fmt.Sprintf("creating Secret %#q in namespace %#q", desired.Name, desired.Namespace))

--- a/service/controller/resource/remotewritesecret/create.go
+++ b/service/controller/resource/remotewritesecret/create.go
@@ -6,20 +6,24 @@ import (
 
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/giantswarm/prometheus-meta-operator/pkg/remotewriteutils"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 	r.logger.Debugf(ctx, "ensuring prometheus remotewrite secret")
 	{
-		remoteWrite, err := ToRemoteWrite(obj)
+		remoteWrite, err := remotewriteutils.ToRemoteWrite(obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
 		// fetch current prometheus using the selector provided in remoteWrite resource.
-		prometheusList, err := fetchPrometheusList(ctx, r, remoteWrite)
+		prometheusList, err := remotewriteutils.FetchPrometheusList(ctx, toResourceWrapper(r), remoteWrite)
 		if err != nil {
 			return microerror.Mask(err)
 		}
@@ -31,24 +35,46 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		for _, current := range prometheusList.Items {
 
+			installedSecrets := make([]corev1.Secret, 0)
 			// Loop over remote write secrets
 			for _, item := range remoteWrite.Spec.Secrets {
 				desired := r.ensureRemoteWriteSecret(item, remoteWrite.ObjectMeta, current.GetNamespace())
 				secret, err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Get(ctx, item.Name, metav1.GetOptions{})
 				if apierrors.IsNotFound(err) {
 					r.logger.Debugf(ctx, fmt.Sprintf("creating Secret %#q in namespace %#q", desired.Name, desired.Namespace))
-
-					//if err := r.k8sClient.K8sClient().SetControllerReference(p, &desiredSa, r.Scheme); err != nil {
-					//	return err
-					//}
 					secret, err = r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Create(ctx, &desired, metav1.CreateOptions{})
 				}
 				if err != nil {
 					return microerror.Mask(err)
 				}
+				installedSecrets = append(installedSecrets, *secret)
 				r.logger.Debugf(ctx, fmt.Sprintf("Secret %#q in namespace %#q created", secret.Name, secret.Namespace))
 
 			}
+
+			/*
+			  Cleanup deleted secrets from RemoteWrite CR
+			*/
+			l := labels.SelectorFromSet(labels.Set(map[string]string{label: Name}))
+			options := metav1.ListOptions{
+				LabelSelector: l.String(),
+			}
+			secrets, err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).List(ctx, options)
+			if err != nil {
+				return microerror.Mask(err)
+			}
+			if secrets != nil && len(secrets.Items) > 0 {
+				for _, secret := range secrets.Items {
+					// delete secret if it doesn't exist in the remotewrite secrets field
+					if !secretInstalled(secret, installedSecrets) {
+						err := r.performDelete(ctx, secret.GetName(), secret.GetNamespace())
+						if err != nil {
+							return microerror.Mask(err)
+						}
+					}
+				}
+			}
+
 		}
 
 	}

--- a/service/controller/resource/remotewritesecret/delete.go
+++ b/service/controller/resource/remotewritesecret/delete.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/giantswarm/microerror"
-	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
@@ -25,8 +24,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 		if len(prometheusList.Items) == 0 {
-			r.logger.Debugf(ctx, "no prometheus found, cancel reconciliation")
-			resourcecanceledcontext.SetCanceled(ctx)
+			r.logger.Debugf(ctx, "no prometheus found, stop reconciliation")
 			return nil
 		}
 
@@ -36,7 +34,6 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			  Cleanup deleted secrets from RemoteWrite CR
 			*/
 			l := labels.SelectorFromSet(labels.Set(map[string]string{
-				label:          Name,
 				labelName:      remoteWrite.GetName(),
 				labelNamespace: remoteWrite.GetNamespace(),
 			}))

--- a/service/controller/resource/remotewritesecret/delete.go
+++ b/service/controller/resource/remotewritesecret/delete.go
@@ -1,0 +1,45 @@
+package remotewritesecret
+
+import (
+	"context"
+
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/operatorkit/v7/pkg/controller/context/resourcecanceledcontext"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	r.logger.Debugf(ctx, "deleting prometheus remoteWrite secret")
+	{
+		remoteWrite, err := ToRemoteWrite(obj)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+
+		// fetch current prometheus using the selector provided in remoteWrite resource.
+		prometheusList, err := fetchPrometheusList(ctx, r, remoteWrite)
+		if err != nil {
+			return microerror.Mask(err)
+		}
+		if prometheusList == nil && len(prometheusList.Items) == 0 {
+			r.logger.Debugf(ctx, "no prometheus found, cancel reconciliation")
+			resourcecanceledcontext.SetCanceled(ctx)
+			return nil
+		}
+
+		for _, current := range prometheusList.Items {
+
+			// Loop over remote write secrets
+			for _, item := range remoteWrite.Spec.Secrets {
+				err := r.k8sClient.K8sClient().CoreV1().Secrets(current.GetNamespace()).Delete(ctx, item.Name, metav1.DeleteOptions{})
+				if err != nil {
+					return microerror.Mask(err)
+				}
+			}
+		}
+
+	}
+	r.logger.Debugf(ctx, "deleted prometheus remoteWrite secret")
+
+	return nil
+}

--- a/service/controller/resource/remotewritesecret/error.go
+++ b/service/controller/resource/remotewritesecret/error.go
@@ -1,0 +1,11 @@
+package remotewritesecret
+
+import "github.com/giantswarm/microerror"
+
+var wrongTypeError = &microerror.Error{
+	Kind: "wrongTypeError",
+}
+
+var errorFetchingPrometheus = &microerror.Error{
+	Kind: "errorFetchingPrometheus",
+}

--- a/service/controller/resource/remotewritesecret/error.go
+++ b/service/controller/resource/remotewritesecret/error.go
@@ -1,11 +1,1 @@
 package remotewritesecret
-
-import "github.com/giantswarm/microerror"
-
-var wrongTypeError = &microerror.Error{
-	Kind: "wrongTypeError",
-}
-
-var errorFetchingPrometheus = &microerror.Error{
-	Kind: "errorFetchingPrometheus",
-}

--- a/service/controller/resource/remotewritesecret/resource.go
+++ b/service/controller/resource/remotewritesecret/resource.go
@@ -14,6 +14,10 @@ import (
 	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
 )
 
+const (
+	Name = "remotewrite"
+)
+
 type Config struct {
 	K8sClient        k8sclient.Interface
 	Logger           micrologger.Logger
@@ -34,6 +38,10 @@ func New(config Config) (*Resource, error) {
 	}
 
 	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
 }
 
 func ToRemoteWrite(obj interface{}) (*pmov1alpha1.RemoteWrite, error) {

--- a/service/controller/resource/remotewritesecret/resource.go
+++ b/service/controller/resource/remotewritesecret/resource.go
@@ -53,9 +53,9 @@ func (r *Resource) ensureRemoteWriteSecret(scSpec pmov1alpha1.RemoteWriteSecretS
 		labels[labelNamespace] = meta.GetNamespace()
 	} else {
 		labels = map[string]string{
-			label:                  Name,
-			labelName:              meta.GetName(),
-			labels[labelNamespace]: meta.GetNamespace(),
+			label:          Name,
+			labelName:      meta.GetName(),
+			labelNamespace: meta.GetNamespace(),
 		}
 	}
 

--- a/service/controller/resource/remotewritesecret/resource.go
+++ b/service/controller/resource/remotewritesecret/resource.go
@@ -13,7 +13,6 @@ import (
 
 const (
 	Name           = "remotewrite"
-	label          = "giantswarm.io/resource"
 	labelName      = "remotewrite/name"
 	labelNamespace = "remotewrite/namespace"
 )
@@ -48,12 +47,10 @@ func (r *Resource) ensureRemoteWriteSecret(scSpec pmov1alpha1.RemoteWriteSecretS
 
 	labels := meta.GetLabels()
 	if labels != nil {
-		labels[label] = Name
 		labels[labelName] = meta.GetName()
 		labels[labelNamespace] = meta.GetNamespace()
 	} else {
 		labels = map[string]string{
-			label:          Name,
 			labelName:      meta.GetName(),
 			labelNamespace: meta.GetNamespace(),
 		}

--- a/service/controller/resource/remotewritesecret/resource.go
+++ b/service/controller/resource/remotewritesecret/resource.go
@@ -1,0 +1,75 @@
+package remotewritesecret
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/api/v1alpha1"
+)
+
+type Config struct {
+	K8sClient        k8sclient.Interface
+	Logger           micrologger.Logger
+	PrometheusClient promclient.Interface
+}
+
+type Resource struct {
+	k8sClient        k8sclient.Interface
+	logger           micrologger.Logger
+	prometheusClient promclient.Interface
+}
+
+func New(config Config) (*Resource, error) {
+	r := &Resource{
+		k8sClient:        config.K8sClient,
+		logger:           config.Logger,
+		prometheusClient: config.PrometheusClient,
+	}
+
+	return r, nil
+}
+
+func ToRemoteWrite(obj interface{}) (*pmov1alpha1.RemoteWrite, error) {
+	remotewrite, ok := obj.(*pmov1alpha1.RemoteWrite)
+	if !ok {
+		return nil, microerror.Maskf(wrongTypeError, "'%T' is not a 'pmov1alpha1.RemoteWrite'", obj)
+	}
+
+	return remotewrite, nil
+}
+
+func fetchPrometheusList(ctx context.Context, r *Resource, rw *pmov1alpha1.RemoteWrite) (*promv1.PrometheusList, error) {
+	selector, err := metav1.LabelSelectorAsSelector(&rw.Spec.ClusterSelector)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	prometheusList, err := r.prometheusClient.
+		MonitoringV1().
+		Prometheuses(metav1.NamespaceAll).
+		List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, microerror.Maskf(errorFetchingPrometheus, "Could not fetch Prometheus with label selector %#q", rw.Spec.ClusterSelector.String())
+	}
+
+	return prometheusList, nil
+}
+
+func (r *Resource) ensureRemoteWriteSecret(scSpec pmov1alpha1.RemoteWriteSecretSpec, meta metav1.ObjectMeta, ns string) corev1.Secret {
+
+	return corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        scSpec.Name,
+			Namespace:   ns,
+			Labels:      meta.GetLabels(),
+			Annotations: meta.GetAnnotations(),
+		},
+		Data: scSpec.Data,
+	}
+}

--- a/service/controller/resource/remotewritesecret/resource.go
+++ b/service/controller/resource/remotewritesecret/resource.go
@@ -1,8 +1,6 @@
 package remotewritesecret
 
 import (
-	"context"
-
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/micrologger"
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
@@ -14,8 +12,10 @@ import (
 )
 
 const (
-	Name  = "remotewrite"
-	label = "monitoring.giantswarm.io/remotewrite"
+	Name           = "remotewrite"
+	label          = "giantswarm.io/resource"
+	labelName      = "remotewrite/name"
+	labelNamespace = "remotewrite/namespace"
 )
 
 type Config struct {
@@ -49,8 +49,14 @@ func (r *Resource) ensureRemoteWriteSecret(scSpec pmov1alpha1.RemoteWriteSecretS
 	labels := meta.GetLabels()
 	if labels != nil {
 		labels[label] = Name
+		labels[labelName] = meta.GetName()
+		labels[labelNamespace] = meta.GetNamespace()
 	} else {
-		labels = map[string]string{label: Name}
+		labels = map[string]string{
+			label:                  Name,
+			labelName:              meta.GetName(),
+			labels[labelNamespace]: meta.GetNamespace(),
+		}
 	}
 
 	return corev1.Secret{
@@ -62,10 +68,6 @@ func (r *Resource) ensureRemoteWriteSecret(scSpec pmov1alpha1.RemoteWriteSecretS
 		},
 		Data: scSpec.Data,
 	}
-}
-
-func (r *Resource) performDelete(ctx context.Context, name, ns string) error {
-	return r.k8sClient.K8sClient().CoreV1().Secrets(ns).Delete(ctx, name, metav1.DeleteOptions{})
 }
 
 func toResourceWrapper(r *Resource) *remotewriteutils.ResourceWrapper {


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1180

After adding https://github.com/giantswarm/prometheus-meta-operator/pull/928 
In this PR, I added the logic of the sync.
By adding a new resource `remotewritesecret`.
and implementing `EnsureCreated()` and `EnsureDeleted`


## Checklist

I have:

- [X] Described why this change is being introduced
- [X] Separated out refactoring/reformatting in a dedicated PR
- [X] Updated changelog in `CHANGELOG.md`
