### PR TITLE
Update secrets once changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unit tests for remotewrite resource
 - Add Secrets field in the RemoteWrite CR
 - Implement sync RemoteWrite Secrets logic
+- Update Secrets Content once changed in RemoteWrite
 
 ### Fixed 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add unit tests for remotewrite resource
 - Add Secrets field in the RemoteWrite CR
 - Implement sync RemoteWrite Secrets logic
-- Update Secrets Content once changed in RemoteWrite
 
 ### Fixed 
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/1180

After https://github.com/giantswarm/prometheus-meta-operator/pull/930 gets merged

We also need to implement the logic of updating secrets once changed in remotewrite CR


## Checklist

I have:

- [X] Described why this change is being introduced
- [X] Separated out refactoring/reformatting in a dedicated PR
- [X] Updated changelog in `CHANGELOG.md`
