### PR TITLE
node-exporter namespace can be monitoring or kube-system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- node-exporter namespace can be `monitoring` orr `kube-system`.
+- node-exporter namespace can be `monitoring` or `kube-system`.
 
 ## [4.1.0] - 2022-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- node-exporter namespace can be `monitoring` orr `kube-system`.
+
 ## [4.1.0] - 2022-07-20
 
 ### Changed
@@ -42,10 +46,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Rename `vcd` to `cloud-director`
-
-### Fixed
-
-- Fix API server discovery.
 
 ### Removed
 

--- a/files/templates/scrapeconfigs/_node_exporter_namespace.yaml
+++ b/files/templates/scrapeconfigs/_node_exporter_namespace.yaml
@@ -1,7 +1,3 @@
 [[- define "_node_exporter_namespace" -]]
-[[- if eq .ClusterType "management_cluster" -]]
-monitoring
-[[- else -]]
-kube-system
-[[- end -]]
+monitoring|kube-system
 [[- end -]]


### PR DESCRIPTION
In WCs and the new MCs created for CAPI we deploy `node-exporter` on the `kube-system` namespace. That way WCs and MCs are more similar between them.

But in the vintage product, `node-exporter` is deployed to the `monitoring` namespace for MCs. It's hard to know which namespace would be used depending on the `provider` because `aws` and `azure` could be CAPI and vintage at the same time.

So instead, we relax the regex for `node-exporter` to include both namespaces.

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
