### PR TITLE
Use pod ip for scrapping etcd on CAPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Added `pod_name` as a label to distinguish between multiple etcd pods when running in-cluster (e.g. CAPI).
+
 ## [4.1.0] - 2022-07-20
 
 ### Changed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -180,7 +180,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: [[ .APIServerURL ]]
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -180,11 +180,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: [[ .APIServerURL ]]
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
 [[- else ]]
   - source_labels: [__meta_kubernetes_node_label_role]
     regex: master

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -271,11 +271,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -271,7 +271,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.alice:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -271,7 +271,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.foo:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -271,11 +271,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -271,11 +271,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -271,7 +271,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.bar:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -271,11 +271,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -271,7 +271,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.baz:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.alice:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.foo:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.bar:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.baz:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.alice:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.foo:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.bar:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.baz:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.alice:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.alice:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.foo:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.foo:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.bar:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.bar:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -206,11 +206,13 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: __meta_kubernetes_pod_ip
+    replacement: master.baz:443
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
     action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
   - target_label: app
     replacement: etcd
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -206,7 +206,7 @@
     regex: (etcd)
     action: keep
   - target_label: __address__
-    replacement: master.baz:443
+    replacement: __meta_kubernetes_pod_ip
   - source_labels: [__meta_kubernetes_pod_name]
     target_label: __metrics_path__
     replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics


### PR DESCRIPTION
Added `pod_name` as a label to distinguish between multiple etcd pods when running in-cluster (e.g. CAPI)

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
