### PR TITLE
Update node-exporter and cert-exporter namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set node-exporter namespace to `kube-system` for CAPI MCs and all WC, and to `monitoring` for vintage MCs.
+- Set cert-exporter namespace to `kube-system` for CAPI MCs and all WC, and to `monitoring` for vintage MCs.
+
 ### Fixed
 
 - Added `pod_name` as a label to distinguish between multiple etcd pods when running in-cluster (e.g. CAPI).

--- a/files/templates/scrapeconfigs/_cert_exporter_namespace.yaml
+++ b/files/templates/scrapeconfigs/_cert_exporter_namespace.yaml
@@ -1,4 +1,4 @@
-[[- define "_node_exporter_namespace" -]]
+[[- define "_cert_exporter_namespace" -]]
 [[- if or (and (eq .ClusterType "management_cluster") (.CAPIManagementCluster)) (eq .ClusterType "workload_cluster") -]]
 kube-system
 [[- else -]]

--- a/files/templates/scrapeconfigs/_cert_exporter_namespace.yaml
+++ b/files/templates/scrapeconfigs/_cert_exporter_namespace.yaml
@@ -1,7 +1,7 @@
 [[- define "_cert_exporter_namespace" -]]
-[[- if or (and (eq .ClusterType "management_cluster") (.CAPIManagementCluster)) (eq .ClusterType "workload_cluster") -]]
-kube-system
-[[- else -]]
+[[- if and (eq .ClusterType "management_cluster") (.VintageManagementCluster) -]]
 monitoring
+[[- else -]]
+kube-system
 [[- end -]]
 [[- end -]]

--- a/files/templates/scrapeconfigs/_node_exporter_namespace.yaml
+++ b/files/templates/scrapeconfigs/_node_exporter_namespace.yaml
@@ -1,7 +1,7 @@
 [[- define "_node_exporter_namespace" -]]
-[[- if or (and (eq .ClusterType "management_cluster") (.CAPIManagementCluster)) (eq .ClusterType "workload_cluster") -]]
-kube-system
-[[- else -]]
+[[- if and (eq .ClusterType "management_cluster") (.VintageManagementCluster) -]]
 monitoring
+[[- else -]]
+kube-system
 [[- end -]]
 [[- end -]]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -395,11 +395,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-[[ if eq .ClusterType "management_cluster" ]]
-    replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
-[[ else ]]
-    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-[[ end ]]
+    replacement: /api/v1/namespaces/[[ include "_cert_exporter_namespace" . ]]/pods/${1}:9005/proxy/metrics
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -56,6 +56,7 @@ type TemplateData struct {
 	Vault                     string
 	WorkloadClusterETCDDomain string
 	CAPICluster               bool
+	CAPIManagementCluster     bool
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -187,6 +188,7 @@ func getTemplateData(cluster metav1.Object, config Config) (*TemplateData, error
 		Mayu:                      config.Mayu,
 		WorkloadClusterETCDDomain: config.WorkloadClusterETCDDomain,
 		CAPICluster:               key.IsCAPICluster(cluster),
+		CAPIManagementCluster:     key.IsCAPIManagementCluster(config.Provider),
 	}
 
 	return d, nil

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -57,6 +57,7 @@ type TemplateData struct {
 	WorkloadClusterETCDDomain string
 	CAPICluster               bool
 	CAPIManagementCluster     bool
+	VintageManagementCluster  bool
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -189,6 +190,7 @@ func getTemplateData(cluster metav1.Object, config Config) (*TemplateData, error
 		WorkloadClusterETCDDomain: config.WorkloadClusterETCDDomain,
 		CAPICluster:               key.IsCAPICluster(cluster),
 		CAPIManagementCluster:     key.IsCAPIManagementCluster(config.Provider),
+		VintageManagementCluster:  !key.IsCAPIManagementCluster(config.Provider),
 	}
 
 	return d, nil

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-0-cluster-api.golden
@@ -830,9 +830,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -683,9 +683,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -683,9 +683,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -683,9 +683,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -717,9 +717,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -683,9 +683,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-0-cluster-api.golden
@@ -772,9 +772,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -659,9 +659,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-0-cluster-api.golden
@@ -718,9 +718,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -659,9 +659,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-0-cluster-api.golden
@@ -718,9 +718,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -659,9 +659,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -659,7 +659,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/monitoring/pods/${1}:9005/proxy/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
@@ -718,9 +718,9 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (node-exporter.*)
     target_label: __metrics_path__
-    replacement: /api/v1/namespaces/monitoring/pods/${1}:10300/proxy/metrics
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
   - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
-    regex: monitoring;node-exporter.*
+    regex: kube-system;node-exporter.*
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -618,9 +618,7 @@
   - source_labels: [__meta_kubernetes_pod_name]
     regex: (cert-exporter.*)
     target_label: __metrics_path__
-
     replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
-
   - source_labels: [__meta_kubernetes_service_label_app]
     target_label: app
   - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]


### PR DESCRIPTION
Closes https://github.com/giantswarm/roadmap/issues/1265

In WCs and the new MCs created for CAPI we deploy `node-exporter` and `cert-exporter` to the `kube-system` namespace. That way WCs and MCs are more similar between them.

But in the vintage product, `node-exporter` and `cert-exporter` are deployed to the `monitoring` namespace for MCs.

This PR changes the logic for `node-exporter` and `cert-exporter` namespaces:
- Use `kube-system` for CAPI MCs and all WC
- Use `monitoring` for vintage MCs
- Assume `aws` and `azure` MCs are vintage (`CAPIManagementCluster` check that is used is checking if the provider is one of cloud-director, gcp, openstack or vsphere, see here https://github.com/giantswarm/prometheus-meta-operator/blob/master/service/key/key.go#L79)

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
