### PR TITLE
Allow `cadvisor` to scrape customer workloads 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add service priority as a tag in opsgenie alerts.
+- Allow `cadvisor` to scrape customer workloads using `giantswarm.io/scrape-customer-workloads` annotation on the Cluster CR.
 
 ## [4.3.0] - 2022-08-02
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -93,9 +93,11 @@
     regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman)
     action: keep
 [[- else ]]
+[[- if not .ScrapeCustomerNamespaces ]]
   - source_labels: [namespace]
     regex: (kube-system|giantswarm.*|kong.*)
     action: keep
+[[- end ]]
 [[- end ]]
 # calico-node
 - job_name: [[ .ClusterID ]]-prometheus/calico-node-[[ .ClusterID ]]/0

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -58,6 +58,7 @@ type TemplateData struct {
 	CAPICluster               bool
 	CAPIManagementCluster     bool
 	VintageManagementCluster  bool
+	ScrapeCustomerNamespaces  bool
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -172,6 +173,8 @@ func getTemplateData(cluster metav1.Object, config Config) (*TemplateData, error
 		servicePriority = priority
 	}
 
+	_, scrapeCustomerNamespaces := cluster.GetAnnotations()["giantswarm.io/scrape-customer-workloads"]
+
 	d := &TemplateData{
 		AdditionalScrapeConfigs:   config.AdditionalScrapeConfigs,
 		APIServerURL:              key.APIUrl(cluster),
@@ -191,6 +194,7 @@ func getTemplateData(cluster metav1.Object, config Config) (*TemplateData, error
 		CAPICluster:               key.IsCAPICluster(cluster),
 		CAPIManagementCluster:     key.IsCAPIManagementCluster(config.Provider),
 		VintageManagementCluster:  !key.IsCAPIManagementCluster(config.Provider),
+		ScrapeCustomerNamespaces:  scrapeCustomerNamespaces,
 	}
 
 	return d, nil


### PR DESCRIPTION
Sometimes it is useful to know resource usage of customer workloads, to troubleshoot overloaded nodes problems.
See for example https://github.com/giantswarm/giantswarm/issues/22895

Currently cadvisor scraping is limited to the `giantswarm`, `kube-system` and `kong` namespaces, thus excluding all customer workloads.

This PR adds support to use the `giantswarm.io/scrape-customer-workloads` annotation on the Cluster CR for a workload cluster to enable ondemand scraping of all namespaces with cadvisor.

@giantswarm/team-atlas this is just a suggestion for improvement, if you're not ok with this no big deal.
We'll use this branch whenever needed.

Here the number of namespaces scraped by cadvisor per cluster, where only one cluster CR was annotated:

![cw](https://user-images.githubusercontent.com/868430/184123932-1916fcaf-a5e2-4faa-890d-bb8afdd85815.png)

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
