### PR TITLE
Fix Team Hydra notification template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Team hydra config.
+
 ## [4.4.0] - 2022-08-17
 
 ### Added

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -172,8 +172,8 @@ receivers:
   [[- else ]]
   - channel: '#alert-hydra-test'
   [[- end ]]
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
@@ -154,8 +154,8 @@ receivers:
 - name: team_hydra_slack
   slack_configs:
   - channel: '#alert-hydra-test'
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
@@ -154,8 +154,8 @@ receivers:
 - name: team_hydra_slack
   slack_configs:
   - channel: '#alert-hydra-test'
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
@@ -154,8 +154,8 @@ receivers:
 - name: team_hydra_slack
   slack_configs:
   - channel: '#alert-hydra-test'
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
@@ -154,8 +154,8 @@ receivers:
 - name: team_hydra_slack
   slack_configs:
   - channel: '#alert-hydra-test'
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -154,8 +154,8 @@ receivers:
 - name: team_hydra_slack
   slack_configs:
   - channel: '#alert-hydra-test'
-  send_resolved: true
-  actions:
+    send_resolved: true
+    actions:
     - type: button
       text: ':green_book: OpsRecipe'
       url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'


### PR DESCRIPTION
I got alerted that a heartbeat was failing. This happened for a new cluster as the alertmanager config is missing the heartbeat configuration for the new cluster after team hydra was added with a misconfiguration.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`


Error in prometheus-operator:

`level=error ts=2022-08-18T13:40:10.373498114Z caller=klog.go:116 component=k8s_client_runtime func=ErrorDepth msg="Sync \"monitoring/alertmanager\" failed: provision alertmanager configuration: base config from Secret could not be parsed: yaml: unmarshal errors:\n  line 157: field send_resolved not found in type config.plain\n  line 158: field actions not found in type config.plain"`

