### PR TITLE
scrape-configs: Replace region & zone labels.

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -33,3 +33,7 @@ sonatype-2021-1485 until=2022-11-01
 # - sigs.k8s.io/cluster-api@v1.0.5
 # - sigs.k8s.io/controller-runtime@v0.10.3
 CVE-2021-20329 until=2022-11-01
+
+# pkg:golang/github.com/labstack/echo/v4@v4.5.0
+# imported from: github.com/giantswarm/operatorkit/v7@v7.1.0
+sonatype-2022-5436 until=2022-11-01

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Relabeling for labels `label_topology_kubernetes_io_region` & `label_topology_kubernetes_io_zone` to `region` & `zone`.
+
 ## [4.5.1] - 2022-08-24
 
 ### Fixed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -527,6 +527,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -923,6 +923,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -923,6 +923,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -923,6 +923,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -943,6 +943,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -923,6 +923,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -885,6 +885,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -885,6 +885,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -885,6 +885,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -858,6 +858,18 @@
     target_label: workload_name
     replacement: ${1}
     action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)


### PR DESCRIPTION
Relabels the recently added labels `label_topology_kubernetes_io_region` &  `label_topology_kubernetes_io_zone` to `region` & `zone`.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
