### PR TITLE
scrape-config: Drop original region & zone labels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Drop original `label_topology_kubernetes_io_region` & `label_topology_kubernetes_io_zone` labels.
+
 ## [4.6.0] - 2022-09-12
 
 ### Added

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -539,6 +539,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -935,6 +935,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -935,6 +935,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -935,6 +935,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -955,6 +955,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -935,6 +935,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -897,6 +897,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -897,6 +897,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -897,6 +897,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -870,6 +870,8 @@
     target_label: zone
     replacement: ${1}
     action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
   # Override with label for AWS clusters if exists.
   - source_labels: [app,label_giantswarm_io_machine_deployment]
     regex: kube-state-metrics;(.+)


### PR DESCRIPTION
## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
