### PR TITLE
Add remote write ingress boilerplate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Enable remote write receiver.
+
 ## [4.5.1] - 2022-08-24
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Enable remote write receiver.
+- Add prometheus remote write ingress boilerplate.
 
 ## [4.5.1] - 2022-08-24
 

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -177,8 +177,11 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 			PodMetadata: &promv1.EmbeddedObjectMetadata{
 				Labels: labels,
 			},
-			LogLevel: config.LogLevel,
-			Image:    &image,
+			// TODO will have to migrate to EnableRemoteWriteReceiver: true but need CRD changes
+			// https://github.com/prometheus-operator/prometheus-operator/pull/4633/files
+			EnableFeatures: []string{"remote-write-receiver"},
+			LogLevel:       config.LogLevel,
+			Image:          &image,
 			Web: &promv1.WebSpec{
 				PageTitle: &pageTitle,
 			},

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   externalLabels:
     cluster_id: alice
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   externalLabels:
     cluster_id: foo
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   externalLabels:
     cluster_id: bar
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   externalLabels:
     cluster_id: kubernetes
     cluster_type: management_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   externalLabels:
     cluster_id: baz
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/remotewriteingress/v1/client.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/client.go
@@ -1,0 +1,29 @@
+package v1
+
+import (
+	"context"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/client-go/kubernetes/typed/networking/v1"
+)
+
+type wrappedClient struct {
+	client v1.IngressInterface
+}
+
+func (c wrappedClient) Create(ctx context.Context, o metav1.Object, options metav1.CreateOptions) (metav1.Object, error) {
+	return c.client.Create(ctx, o.(*networkingv1.Ingress), options)
+}
+
+func (c wrappedClient) Update(ctx context.Context, o metav1.Object, options metav1.UpdateOptions) (metav1.Object, error) {
+	return c.client.Update(ctx, o.(*networkingv1.Ingress), options)
+}
+
+func (c wrappedClient) Get(ctx context.Context, name string, options metav1.GetOptions) (metav1.Object, error) {
+	return c.client.Get(ctx, name, options)
+}
+
+func (c wrappedClient) Delete(ctx context.Context, name string, options *metav1.DeleteOptions) error {
+	return c.client.Delete(ctx, name, *options)
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/resource.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/resource.go
@@ -1,0 +1,80 @@
+package v1
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const (
+	Name = "monitoringremotewriteingress"
+)
+
+type Config struct {
+	K8sClient  k8sclient.Interface
+	Logger     micrologger.Logger
+	BaseDomain string
+}
+
+func New(config Config) (*generic.Resource, error) {
+	clientFunc := func(namespace string) generic.Interface {
+		c := config.K8sClient.K8sClient().NetworkingV1().Ingresses(namespace)
+		return wrappedClient{client: c}
+	}
+
+	c := generic.Config{
+		ClientFunc: clientFunc,
+		Logger:     config.Logger,
+		Name:       Name,
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
+			return getObjectMeta(v, config)
+		},
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
+			return toIngress(v, config)
+		},
+		HasChangedFunc: hasChanged,
+	}
+	r, err := generic.New(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}
+
+func getObjectMeta(v interface{}, config Config) (metav1.ObjectMeta, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return metav1.ObjectMeta{}, microerror.Mask(err)
+	}
+
+	return metav1.ObjectMeta{
+		Name:      fmt.Sprintf("prometheus-%s-remote-write", key.ClusterID(cluster)),
+		Namespace: key.Namespace(cluster),
+		Labels:    key.PrometheusLabels(cluster),
+	}, nil
+}
+
+func toIngress(v interface{}, config Config) (metav1.Object, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	return &networkingv1.Ingress{}, nil
+}
+
+func hasChanged(current, desired metav1.Object) bool {
+	c := current.(*networkingv1.Ingress)
+	d := desired.(*networkingv1.Ingress)
+
+	return !reflect.DeepEqual(c.Spec, d.Spec) || !reflect.DeepEqual(c.GetAnnotations(), d.GetAnnotations())
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/resource_test.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/resource_test.go
@@ -1,0 +1,36 @@
+package v1
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
+)
+
+var update = flag.Bool("update", false, "update the ouput file")
+
+func TestIngress(t *testing.T) {
+	outputDir, err := filepath.Abs("./test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := unittest.Config{
+		OutputDir: outputDir,
+		T:         t,
+		TestFunc: func(v interface{}) (interface{}, error) {
+			return toIngress(v, Config{BaseDomain: "https://prometheus"})
+		},
+		Update: *update,
+	}
+	runner, err := unittest.NewRunner(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = runner.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/test/case-1-awsconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/test/case-2-azureconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/test/case-3-kvmconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/test/case-4-control-plane.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1/test/case-5-cluster-api-v1alpha3.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/client.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/client.go
@@ -1,0 +1,29 @@
+package v1beta1
+
+import (
+	"context"
+
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/typed/networking/v1beta1"
+)
+
+type wrappedClient struct {
+	client v1beta1.IngressInterface
+}
+
+func (c wrappedClient) Create(ctx context.Context, o metav1.Object, options metav1.CreateOptions) (metav1.Object, error) {
+	return c.client.Create(ctx, o.(*networkingv1beta1.Ingress), options)
+}
+
+func (c wrappedClient) Update(ctx context.Context, o metav1.Object, options metav1.UpdateOptions) (metav1.Object, error) {
+	return c.client.Update(ctx, o.(*networkingv1beta1.Ingress), options)
+}
+
+func (c wrappedClient) Get(ctx context.Context, name string, options metav1.GetOptions) (metav1.Object, error) {
+	return c.client.Get(ctx, name, options)
+}
+
+func (c wrappedClient) Delete(ctx context.Context, name string, options *metav1.DeleteOptions) error {
+	return c.client.Delete(ctx, name, *options)
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/resource.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/resource.go
@@ -1,0 +1,80 @@
+package v1beta1
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const (
+	Name = "monitoringremotewriteingress"
+)
+
+type Config struct {
+	K8sClient  k8sclient.Interface
+	Logger     micrologger.Logger
+	BaseDomain string
+}
+
+func New(config Config) (*generic.Resource, error) {
+	clientFunc := func(namespace string) generic.Interface {
+		c := config.K8sClient.K8sClient().NetworkingV1beta1().Ingresses(namespace)
+		return wrappedClient{client: c}
+	}
+
+	c := generic.Config{
+		ClientFunc: clientFunc,
+		Logger:     config.Logger,
+		Name:       Name,
+		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
+			return getObjectMeta(v, config)
+		},
+		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
+			return toIngress(v, config)
+		},
+		HasChangedFunc: hasChanged,
+	}
+	r, err := generic.New(c)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return r, nil
+}
+
+func getObjectMeta(v interface{}, config Config) (metav1.ObjectMeta, error) {
+	cluster, err := key.ToCluster(v)
+	if err != nil {
+		return metav1.ObjectMeta{}, microerror.Mask(err)
+	}
+
+	return metav1.ObjectMeta{
+		Name:      fmt.Sprintf("prometheus-%s-remote-write", key.ClusterID(cluster)),
+		Namespace: key.Namespace(cluster),
+		Labels:    key.PrometheusLabels(cluster),
+	}, nil
+}
+
+func toIngress(v interface{}, config Config) (metav1.Object, error) {
+	if v == nil {
+		return nil, nil
+	}
+
+	return &networkingv1beta1.Ingress{}, nil
+}
+
+func hasChanged(current, desired metav1.Object) bool {
+	c := current.(*networkingv1beta1.Ingress)
+	d := desired.(*networkingv1beta1.Ingress)
+
+	return !reflect.DeepEqual(c.Spec, d.Spec) || !reflect.DeepEqual(c.GetAnnotations(), d.GetAnnotations())
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/resource_test.go
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/resource_test.go
@@ -1,0 +1,36 @@
+package v1beta1
+
+import (
+	"flag"
+	"path/filepath"
+	"testing"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
+)
+
+var update = flag.Bool("update", false, "update the ouput file")
+
+func TestIngress(t *testing.T) {
+	outputDir, err := filepath.Abs("./test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c := unittest.Config{
+		OutputDir: outputDir,
+		T:         t,
+		TestFunc: func(v interface{}) (interface{}, error) {
+			return toIngress(v, Config{BaseDomain: "https://prometheus"})
+		},
+		Update: *update,
+	}
+	runner, err := unittest.NewRunner(c)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = runner.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-1-awsconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-2-azureconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-3-kvmconfig.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-4-control-plane.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/v1beta1/test/case-5-cluster-api-v1alpha3.golden
@@ -1,0 +1,5 @@
+metadata:
+  creationTimestamp: null
+spec: {}
+status:
+  loadBalancer: {}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -19,6 +19,8 @@ import (
 	ingressv1beta1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/ingress/v1beta1"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/prometheus"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteconfig"
+	remotewriteingressv1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingress/v1"
+	remotewriteingressv1beta1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingress/v1beta1"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/namespace"
@@ -118,6 +120,31 @@ func New(config Config) ([]resource.Interface, error) {
 		}
 
 		heartbeatWebhookConfigResource, err = heartbeatwebhookconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var remoteWriteIngressResource resource.Interface
+	if config.IngressAPIVersion == "networking.k8s.io/v1beta1" {
+		c := remotewriteingressv1beta1.Config{
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+			BaseDomain: config.PrometheusBaseDomain,
+		}
+
+		remoteWriteIngressResource, err = remotewriteingressv1beta1.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else {
+		c := remotewriteingressv1.Config{
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+			BaseDomain: config.PrometheusBaseDomain,
+		}
+
+		remoteWriteIngressResource, err = remotewriteingressv1.New(c)
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}
@@ -272,6 +299,7 @@ func New(config Config) ([]resource.Interface, error) {
 		rbacResource,
 		heartbeatWebhookConfigResource,
 		scrapeConfigResource,
+		remoteWriteIngressResource,
 		remoteWriteConfigResource,
 		alertmanagerWiringResource,
 		prometheusResource,


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23130
Add ingress boilerplates so the agent can access prometheus

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
