### PR TITLE
move shield route so alerts for shield don't go to opsgenie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move shield route so alerts for shield don't go to opsgenie at all, only to their slack.
+
 ## [4.6.3] - 2022-10-17
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -23,6 +23,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -81,13 +91,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
@@ -19,6 +19,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -71,13 +81,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
@@ -19,6 +19,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -71,13 +81,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
@@ -19,6 +19,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -71,13 +81,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
@@ -19,6 +19,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -71,13 +81,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -19,6 +19,16 @@ route:
     - alertname=~"Falco.*"
     continue: false
 
+  # Team Shield Slack
+  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
+  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
+  # the default opsgenie route
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
+    continue: false
+
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -71,13 +81,6 @@ route:
     matchers:
     - severity=~"page|notify"
     - team="rocket"
-    continue: false
-
-  # Team Shield Slack
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
     continue: false
 
   # Team Ops Slack


### PR DESCRIPTION
Move team-shield route so alerts for shield don't go to opsgenie at all, only to their slack.