### PR TITLE
Configure working queueconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add scraping of Cilium on Management Clusters.
 
+### Changed
+
+- Configure working queue config for the remote write receiver (reducing max number of shards but increasing sample capacity).
+
 ## [4.6.4] - 2022-10-17
 
 ### Changed

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -138,9 +138,9 @@ func toSecret(ctx context.Context, v interface{}, config Config) (*corev1.Secret
 
 func defaultQueueConfig() promv1.QueueConfig {
 	return promv1.QueueConfig{
-		Capacity:          10000,
-		MaxSamplesPerSend: 1000,
-		MaxShards:         50,
+		Capacity:          30000,
+		MaxSamplesPerSend: 10000,
+		MaxShards:         10,
 	}
 }
 


### PR DESCRIPTION
After some experimentation, it seems that either nginx or the prometheus receiver are not able to accept too many requests and setting the number of maxShards to 10 plus an increased capacity (more samples stored per shards and more samples sent per batch) does the trick.

Remote write is not falling behind and the situation appears stable:

![image](https://user-images.githubusercontent.com/2787548/196659698-f5af811a-ae78-451c-bad3-9c9b21339fe9.png)

![image](https://user-images.githubusercontent.com/2787548/196659806-71ef276e-824e-4e2b-a788-65607afc98fa.png)


For information:
- [MaxShards](https://prometheus.io/docs/practices/remote_write/#max_shards): We currently use only 1 shards (we have only 5 targets so ...) and it's not increasing. I set it to 10 because it can take a bit more when replaying the WAL but it's mostly fine
- [Capacity](https://prometheus.io/docs/practices/remote_write/#capacity): Set to 30000 as it should be 3-10 times the max number of sent samples
- [MaxSamplesPerSecond](https://prometheus.io/docs/practices/remote_write/#max_samples_per_send): Sending 10K works. maybe we can reduce that value but remote write is not falling behind so far

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
