### PR TITLE
Fix alertmanager psp (add projected and downardAPI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix alertmanager psp (add projected and downardAPI)
+
 ## [4.7.0] - 2022-10-20
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/alertmanager-psp.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager-psp.yaml
@@ -28,7 +28,9 @@ spec:
     rule: MustRunAs
   privileged: false
   volumes:
-    - 'emptyDir'
-    - 'secret'
     - 'configMap'
+    - 'emptyDir'
+    - 'projected'
+    - 'secret'
+    - 'downwardAPI'
     - 'persistentVolumeClaim'


### PR DESCRIPTION
Alertmanager was failing to start with these errors:
```
create Pod alertmanager-alertmanager-0 in StatefulSet alertmanager-alertmanager failed 
error: pods "alertmanager-alertmanager-0" is forbidden: PodSecurityPolicy: unable to admit pod:
[
spec.volumes[2]: Invalid value: "projected": projected volumes are not allowed to be used
spec.volumes[2]: Invalid value: "projected": projected volumes are not allowed to be used
spec.volumes[0]: Invalid value: "persistentVolumeClaim": persistentVolumeClaim volumes are not allowed to be used
]
```

Reason: alertmanager is updated with prometheus-operator upgrade, but the PSPs, managed by prometheus-meta-operator, were not updated accordingly.