### PR TITLE
Enable remote write receiver for MC prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ensure the remote write endpoint configuration is enabled for MCs
+
 ## [4.10.0] - 2022-11-15
 
 ### Fixed

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -11,6 +11,7 @@ import (
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/domain"
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanager"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerconfig"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerwiring"
@@ -21,6 +22,10 @@ import (
 	ingressv1beta1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/ingress/v1beta1"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/prometheus"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/pvcresizingresource"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret"
+	remotewriteingressv1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingress/v1"
+	remotewriteingressv1beta1 "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingress/v1beta1"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingressauth"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/namespace"
@@ -75,6 +80,8 @@ type resourcesConfig struct {
 
 func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var err error
+
+	passwordManager := password.SimpleManager{}
 
 	var namespaceResource resource.Interface
 	{
@@ -301,6 +308,66 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	var remoteWriteIngressAuthResource resource.Interface
+	{
+		c := remotewriteingressauth.Config{
+			K8sClient:       config.K8sClient,
+			Logger:          config.Logger,
+			PasswordManager: passwordManager,
+			Provider:        config.Provider,
+		}
+
+		remoteWriteIngressAuthResource, err = remotewriteingressauth.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var remoteWriteIngressResource resource.Interface
+	if config.IngressAPIVersion == "networking.k8s.io/v1beta1" {
+		c := remotewriteingressv1beta1.Config{
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+			BaseDomain: config.PrometheusBaseDomain,
+		}
+
+		remoteWriteIngressResource, err = remotewriteingressv1beta1.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	} else {
+		c := remotewriteingressv1.Config{
+			K8sClient:  config.K8sClient,
+			Logger:     config.Logger,
+			BaseDomain: config.PrometheusBaseDomain,
+		}
+
+		remoteWriteIngressResource, err = remotewriteingressv1.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var remoteWriteAPIEndpointConfigSecretResource resource.Interface
+	{
+		c := remotewriteapiendpointconfigsecret.Config{
+			K8sClient:       config.K8sClient,
+			Logger:          config.Logger,
+			PasswordManager: passwordManager,
+			BaseDomain:      config.PrometheusBaseDomain,
+			Customer:        config.Customer,
+			Installation:    config.Installation,
+			Pipeline:        config.Pipeline,
+			Provider:        config.Provider,
+			Region:          config.Region,
+		}
+
+		remoteWriteAPIEndpointConfigSecretResource, err = remotewriteapiendpointconfigsecret.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	resources := []resource.Interface{
 		namespaceResource,
 		etcdCertificatesResource,
@@ -309,6 +376,9 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		alertmanagerConfigResource,
 		heartbeatWebhookConfigResource,
 		alertmanagerWiringResource,
+		remoteWriteAPIEndpointConfigSecretResource,
+		remoteWriteIngressAuthResource,
+		remoteWriteIngressResource,
 		scrapeConfigResource,
 		prometheusResource,
 		verticalPodAutoScalerResource,


### PR DESCRIPTION
## Checklist

This change is being introduced because CAPI MC clusters will be running the agent as default apps are installing the observability bundle everywhere.

Enabling the remote write receiver on the MC prometheus will ensure we can use service monitors on both CAPI MC and WC and remove the additional scrape config section.

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
