### PR TITLE
Send notify alert to Atlas slack channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Ensure the remote write endpoint configuration is enabled for MCs
 
+### Changed
+
+- Send non-paging alert to Atlas slack channels.
+
 ### Fixed
 
 - Fix a reconciliation bug on CAPI MC that were reconciled twice.

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -127,7 +127,11 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
+  [[- if eq .Pipeline "stable" ]]
   - channel: '#alert-atlas'
+  [[- else ]]
+  - channel: '#alert-atlas-test'
+  [[- end ]]
     send_resolved: true
     actions:
     - type: button

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -54,7 +54,9 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
+    [[- if eq .Pipeline "stable" ]]
     - severity!="page"
+    [[- end ]]
     - team="atlas"
     continue: false
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -54,7 +54,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
@@ -44,7 +44,6 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-1-awsconfig.golden
@@ -44,7 +44,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 
@@ -117,7 +117,7 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
-  - channel: '#alert-atlas'
+  - channel: '#alert-atlas-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
@@ -44,7 +44,6 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-2-azureconfig.golden
@@ -44,7 +44,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 
@@ -117,7 +117,7 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
-  - channel: '#alert-atlas'
+  - channel: '#alert-atlas-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
@@ -44,7 +44,6 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-3-kvmconfig.golden
@@ -44,7 +44,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 
@@ -117,7 +117,7 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
-  - channel: '#alert-atlas'
+  - channel: '#alert-atlas-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
@@ -44,7 +44,6 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-4-control-plane.golden
@@ -44,7 +44,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 
@@ -117,7 +117,7 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
-  - channel: '#alert-atlas'
+  - channel: '#alert-atlas-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -44,7 +44,6 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity!="page"
     - team="atlas"
     continue: false
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -44,7 +44,7 @@ route:
   # Team Atlas Slack (team)
   - receiver: team_atlas_slack
     matchers:
-    - severity="page"
+    - severity!="page"
     - team="atlas"
     continue: false
 
@@ -117,7 +117,7 @@ receivers:
 
 - name: team_atlas_slack
   slack_configs:
-  - channel: '#alert-atlas'
+  - channel: '#alert-atlas-test'
     send_resolved: true
     actions:
     - type: button


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/24062

This PR configures alertmanager to send non-paging alerts to our slack channels.

#alert-atlas: receive alerts for stable installations
#alert-atlas-test: receive alerts for testing installations