### PR TITLE
Drop job in favor of SM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove the `CLUSTER-prometheus/app-exporter-CLUSTER/0` job in favor of Service Monitor provided by the app.
+
 ### Added
 
 - Ensure the remote write endpoint configuration is enabled for MCs

--- a/Documentation/targets.md
+++ b/Documentation/targets.md
@@ -2,7 +2,6 @@
 
 - alertmanager
 - api
-- app-exporter
 - app-operator
 - cadvisor
 - calico

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -657,47 +657,6 @@
     action: drop
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
-# app-exporter (missing label)
-- job_name: [[ .ClusterID ]]-prometheus/app-exporter-[[ .ClusterID ]]/0
-  honor_labels: true
-  scheme: http
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - giantswarm
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    regex: app-exporter
-    action: keep
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    target_label: app
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_version]
-    target_label: version
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: $1
-    action: replace
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    regex: (.+)(?::\d+);(\d+)
-    target_label: __address__
-    replacement: $1:$2
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-    regex: (https?)
-    target_label: __scheme__
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
-    regex: .*(true).*
-    action: drop
-[[ include "_common" . | indent 2 ]]
-[[ include "_labelingschema" . | indent 2 ]]
 # alertmanager
 - job_name: [[ .ClusterID ]]-prometheus/alertmanager-[[ .ClusterID ]]/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -319,7 +319,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -328,9 +328,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-
+  
   - role: node
-
+  
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -380,7 +380,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -425,7 +425,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -502,7 +502,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -576,7 +576,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -642,7 +642,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -709,7 +709,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -778,7 +778,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -827,7 +827,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -921,7 +921,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1061,7 +1061,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1136,7 +1136,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1209,7 +1209,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1282,7 +1282,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1354,7 +1354,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1426,7 +1426,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1498,7 +1498,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1570,7 +1570,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1642,7 +1642,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1714,7 +1714,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1786,7 +1786,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1822,7 +1822,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1877,7 +1877,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1912,7 +1912,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1975,7 +1975,8 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
+

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -319,7 +319,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -328,9 +328,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  
+
   - role: node
-  
+
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -380,7 +380,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -425,7 +425,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -502,7 +502,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -576,7 +576,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -642,7 +642,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -709,7 +709,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -778,7 +778,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -827,7 +827,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -921,7 +921,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1061,7 +1061,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1136,82 +1136,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
-  # Add customer label.
-  - target_label: customer
-    replacement: pmo
-# app-exporter (missing label)
-- job_name: kubernetes-prometheus/app-exporter-kubernetes/0
-  honor_labels: true
-  scheme: http
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - giantswarm
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    regex: app-exporter
-    action: keep
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    target_label: app
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_version]
-    target_label: version
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: $1
-    action: replace
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    regex: (.+)(?::\d+);(\d+)
-    target_label: __address__
-    replacement: $1:$2
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-    regex: (https?)
-    target_label: __scheme__
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
-    regex: .*(true).*
-    action: drop
-  # Add namespace label.
-  - source_labels: [__meta_kubernetes_namespace]
-    target_label: namespace
-  # Add pod label.
-  - source_labels: [__meta_kubernetes_pod_name]
-    target_label: pod
-  # Add container label.
-  - source_labels: [__meta_kubernetes_pod_container_name]
-    target_label: container
-  # Add node label.
-  - source_labels: [__meta_kubernetes_pod_node_name]
-    target_label: node
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
-  # Add cluster_id label.
-  - target_label: cluster_id
-    replacement: kubernetes
-  # Add cluster_type label.
-  - target_label: cluster_type
-    replacement: management_cluster
-  # Add provider label.
-  - target_label: provider
-    replacement: aws
-  # Add installation label.
-  - target_label: installation
-    replacement: test-installation
-  # Add priority label.
-  - target_label: service_priority
-    replacement: highest
-  # Add organization label.
-  - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1284,7 +1209,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1357,7 +1282,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1429,7 +1354,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1501,7 +1426,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1573,7 +1498,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1645,7 +1570,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1717,7 +1642,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1789,7 +1714,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1861,7 +1786,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1897,7 +1822,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1952,7 +1877,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1987,7 +1912,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2050,8 +1975,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
-

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  
+
   - role: node
-  
+
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,82 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
-  # Add customer label.
-  - target_label: customer
-    replacement: pmo
-# app-exporter (missing label)
-- job_name: kubernetes-prometheus/app-exporter-kubernetes/0
-  honor_labels: true
-  scheme: http
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - giantswarm
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    regex: app-exporter
-    action: keep
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    target_label: app
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_version]
-    target_label: version
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: $1
-    action: replace
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    regex: (.+)(?::\d+);(\d+)
-    target_label: __address__
-    replacement: $1:$2
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-    regex: (https?)
-    target_label: __scheme__
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
-    regex: .*(true).*
-    action: drop
-  # Add namespace label.
-  - source_labels: [__meta_kubernetes_namespace]
-    target_label: namespace
-  # Add pod label.
-  - source_labels: [__meta_kubernetes_pod_name]
-    target_label: pod
-  # Add container label.
-  - source_labels: [__meta_kubernetes_pod_container_name]
-    target_label: container
-  # Add node label.
-  - source_labels: [__meta_kubernetes_pod_node_name]
-    target_label: node
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
-  # Add cluster_id label.
-  - target_label: cluster_id
-    replacement: kubernetes
-  # Add cluster_type label.
-  - target_label: cluster_type
-    replacement: management_cluster
-  # Add provider label.
-  - target_label: provider
-    replacement: azure
-  # Add installation label.
-  - target_label: installation
-    replacement: test-installation
-  # Add priority label.
-  - target_label: service_priority
-    replacement: highest
-  # Add organization label.
-  - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1226,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1299,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1371,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1443,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1515,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1587,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1659,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1731,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1803,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1839,7 +1764,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1894,7 +1819,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1929,7 +1854,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1992,8 +1917,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
-

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-
+  
   - role: node
-
+  
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,7 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1151,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1224,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1296,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1368,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1440,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1512,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1584,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1656,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1728,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1764,7 +1764,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1819,7 +1819,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1854,7 +1854,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1917,7 +1917,8 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
+

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  
+
   - role: node
-  
+
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,82 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
-  # Add customer label.
-  - target_label: customer
-    replacement: pmo
-# app-exporter (missing label)
-- job_name: kubernetes-prometheus/app-exporter-kubernetes/0
-  honor_labels: true
-  scheme: http
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - giantswarm
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    regex: app-exporter
-    action: keep
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    target_label: app
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_version]
-    target_label: version
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: $1
-    action: replace
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    regex: (.+)(?::\d+);(\d+)
-    target_label: __address__
-    replacement: $1:$2
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-    regex: (https?)
-    target_label: __scheme__
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
-    regex: .*(true).*
-    action: drop
-  # Add namespace label.
-  - source_labels: [__meta_kubernetes_namespace]
-    target_label: namespace
-  # Add pod label.
-  - source_labels: [__meta_kubernetes_pod_name]
-    target_label: pod
-  # Add container label.
-  - source_labels: [__meta_kubernetes_pod_container_name]
-    target_label: container
-  # Add node label.
-  - source_labels: [__meta_kubernetes_pod_node_name]
-    target_label: node
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
-  # Add cluster_id label.
-  - target_label: cluster_id
-    replacement: kubernetes
-  # Add cluster_type label.
-  - target_label: cluster_type
-    replacement: management_cluster
-  # Add provider label.
-  - target_label: provider
-    replacement: kvm
-  # Add installation label.
-  - target_label: installation
-    replacement: test-installation
-  # Add priority label.
-  - target_label: service_priority
-    replacement: highest
-  # Add organization label.
-  - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1226,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1299,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1371,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1443,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1515,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1587,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1659,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1731,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1803,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1878,7 +1803,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1936,7 +1861,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1994,7 +1919,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2029,7 +1954,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2064,7 +1989,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2119,7 +2044,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2154,7 +2079,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2217,8 +2142,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
-

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-
+  
   - role: node
-
+  
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,7 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1151,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1224,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1296,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1368,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1440,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1512,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1584,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1656,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1728,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1803,7 +1803,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1861,7 +1861,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1919,7 +1919,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1954,7 +1954,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1989,7 +1989,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2044,7 +2044,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2079,7 +2079,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2142,7 +2142,8 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
+

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-
+  
   - role: node
-
+  
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,7 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1151,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1224,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1296,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1368,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1440,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1512,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1584,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1656,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1728,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1779,7 +1779,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1834,7 +1834,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1869,7 +1869,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1932,7 +1932,8 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm
+    replacement: giantswarm 
   # Add customer label.
   - target_label: customer
     replacement: pmo
+

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -82,7 +82,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -146,7 +146,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -191,7 +191,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -260,7 +260,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -270,9 +270,9 @@
   honor_labels: true
   scheme: https
   kubernetes_sd_configs:
-  
+
   - role: node
-  
+
 
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
@@ -322,7 +322,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -367,7 +367,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -444,7 +444,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -518,7 +518,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -584,7 +584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -651,7 +651,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -720,7 +720,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -863,7 +863,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1003,7 +1003,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1078,82 +1078,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
-  # Add customer label.
-  - target_label: customer
-    replacement: pmo
-# app-exporter (missing label)
-- job_name: kubernetes-prometheus/app-exporter-kubernetes/0
-  honor_labels: true
-  scheme: http
-  kubernetes_sd_configs:
-  - role: endpoints
-    namespaces:
-      names:
-      - giantswarm
-  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-  tls_config:
-    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-    insecure_skip_verify: true
-  relabel_configs:
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    regex: app-exporter
-    action: keep
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
-    target_label: app
-  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_version]
-    target_label: version
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
-    regex: (.+)
-    target_label: __metrics_path__
-    replacement: $1
-    action: replace
-  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
-    regex: (.+)(?::\d+);(\d+)
-    target_label: __address__
-    replacement: $1:$2
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
-    regex: (https?)
-    target_label: __scheme__
-    replacement: $1
-    action: replace
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
-    regex: .*(true).*
-    action: drop
-  # Add namespace label.
-  - source_labels: [__meta_kubernetes_namespace]
-    target_label: namespace
-  # Add pod label.
-  - source_labels: [__meta_kubernetes_pod_name]
-    target_label: pod
-  # Add container label.
-  - source_labels: [__meta_kubernetes_pod_container_name]
-    target_label: container
-  # Add node label.
-  - source_labels: [__meta_kubernetes_pod_node_name]
-    target_label: node
-  # Add role label.
-  - source_labels: [__meta_kubernetes_node_label_role]
-    target_label: role
-  # Add cluster_id label.
-  - target_label: cluster_id
-    replacement: kubernetes
-  # Add cluster_type label.
-  - target_label: cluster_type
-    replacement: management_cluster
-  # Add provider label.
-  - target_label: provider
-    replacement: openstack
-  # Add installation label.
-  - target_label: installation
-    replacement: test-installation
-  # Add priority label.
-  - target_label: service_priority
-    replacement: highest
-  # Add organization label.
-  - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1226,7 +1151,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1299,7 +1224,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1371,7 +1296,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1443,7 +1368,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1515,7 +1440,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1587,7 +1512,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1659,7 +1584,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1731,7 +1656,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1803,7 +1728,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1854,7 +1779,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1909,7 +1834,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1944,7 +1869,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -2007,8 +1932,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: giantswarm 
+    replacement: giantswarm
   # Add customer label.
   - target_label: customer
     replacement: pmo
-


### PR DESCRIPTION
## Description

Towards: https://github.com/giantswarm/giantswarm/issues/24541

App Exporter provides Service Monitor that configures job that is redundant to the `CLUSTER-prometheus/app-exporter-CLUSTER/0`. The target can be  dropped from this job with the `giantswarm.io/monitoring` label set, but setting this label at the same time adds (keeps) target to the `CLUSTER-prometheus/workload-CLUSTER/0` job, still making the App Exporter to be scrapped twice. 

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
