### PR TITLE
Remove 'vault' targets on CAPI clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove `vault` targets for CAPI clusters.
+
 ## [4.11.1] - 2022-11-22
 
 ### Fixed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -1110,6 +1110,7 @@
   relabel_configs:
 [[ include "_labelingschema" . | indent 2 ]]
 [[ end ]]
+[[ if not .CAPICluster ]]
 - job_name: [[ .ClusterID ]]-prometheus/vault-[[ .ClusterID ]]/0
   honor_labels: true
   scheme: http
@@ -1124,6 +1125,7 @@
       app: cert-exporter
   relabel_configs:
 [[ include "_labelingschema" . | indent 2 ]]
+[[ end ]]
 # nginx-ingress-controller
 - job_name: [[ .ClusterID ]]-prometheus/nginx-ingress-controller-[[ .ClusterID ]]/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -1792,6 +1792,7 @@
     replacement: pmo
 
 
+
 - job_name: kubernetes-prometheus/vault-kubernetes/0
   honor_labels: true
   scheme: http
@@ -1826,6 +1827,7 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+
 # nginx-ingress-controller
 - job_name: kubernetes-prometheus/nginx-ingress-controller-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -1734,6 +1734,7 @@
     replacement: pmo
 
 
+
 - job_name: kubernetes-prometheus/vault-kubernetes/0
   honor_labels: true
   scheme: http
@@ -1768,6 +1769,7 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+
 # nginx-ingress-controller
 - job_name: kubernetes-prometheus/nginx-ingress-controller-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -1959,6 +1959,7 @@
   - target_label: customer
     replacement: pmo
 
+
 - job_name: kubernetes-prometheus/vault-kubernetes/0
   honor_labels: true
   scheme: http
@@ -1993,6 +1994,7 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+
 # nginx-ingress-controller
 - job_name: kubernetes-prometheus/nginx-ingress-controller-kubernetes/0
   honor_labels: true

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -1749,6 +1749,7 @@
   - source_labels: [__address__]
     target_label: __param_target
 
+
 - job_name: kubernetes-prometheus/vault-kubernetes/0
   honor_labels: true
   scheme: http
@@ -1783,6 +1784,7 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+
 # nginx-ingress-controller
 - job_name: kubernetes-prometheus/nginx-ingress-controller-kubernetes/0
   honor_labels: true


### PR DESCRIPTION
towards https://gigantic.slack.com/archives/C01176DKNP4/p1669133286733979

In CAPI clusters, `vault` is replaced by `sops`.
This PR removes `vault` targets for CAPI clusters from the additional scraping configuration file.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
