### PR TITLE
Do not reconcile service monitors in CAPO MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not reconcile service monitors in CAPO MCs.
+
 ## [4.12.0] - 2022-11-25
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -345,9 +345,19 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 			MatchExpressions: []metav1.LabelSelectorRequirement{},
 		}
 
+		namespaceSelector := []metav1.LabelSelectorRequirement{}
+
+		if config.Provider == "openstack" {
+			namespaceSelector = append(namespaceSelector, metav1.LabelSelectorRequirement{
+				Key:      "kubernetes.io/metadata.name",
+				Operator: metav1.LabelSelectorOpNotIn,
+				Values:   []string{"kube-system"},
+			})
+		}
+
 		// An empty label selector matches all objects.
 		prometheus.Spec.ServiceMonitorNamespaceSelector = &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{},
+			MatchExpressions: namespaceSelector,
 		}
 
 		// An empty label selector matches all objects.
@@ -357,7 +367,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 
 		// An empty label selector matches all objects.
 		prometheus.Spec.PodMonitorNamespaceSelector = &metav1.LabelSelector{
-			MatchExpressions: []metav1.LabelSelectorRequirement{},
+			MatchExpressions: namespaceSelector,
 		}
 	}
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23130

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
