### PR TITLE
Use prometheus-agent on CAPA MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change HasPrometheusAgent function to ignore prometheus-agent scraping targets on capa.
+- Do not reconcile service monitors in kube-system for capa MCs .
+
 ## [4.14.0] - 2022-11-30
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -347,7 +347,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 
 		namespaceSelector := []metav1.LabelSelectorRequirement{}
 
-		if config.Provider == "openstack" || config.Provider == "gcp" {
+		if config.Provider == "openstack" || config.Provider == "gcp" || config.Provider == "capa" {
 			namespaceSelector = append(namespaceSelector, metav1.LabelSelectorRequirement{
 				Key:      "kubernetes.io/metadata.name",
 				Operator: metav1.LabelSelectorOpNotIn,

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -237,6 +237,12 @@ func hasPrometheusAgent(ctx context.Context, ctrlClient client.Client, cluster m
 				return false, microerror.Mask(err)
 			}
 			return version.GTE(gcpAgentVersion), nil
+		case "capa":
+			gcpAgentVersion, err := semver.Parse("0.11.0")
+			if err != nil {
+				return false, microerror.Mask(err)
+			}
+			return version.GTE(gcpAgentVersion), nil
 		default:
 			return false, nil
 		}

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -238,11 +238,11 @@ func hasPrometheusAgent(ctx context.Context, ctrlClient client.Client, cluster m
 			}
 			return version.GTE(gcpAgentVersion), nil
 		case "capa":
-			gcpAgentVersion, err := semver.Parse("0.11.0")
+			capaAgentVersion, err := semver.Parse("0.11.0")
 			if err != nil {
 				return false, microerror.Mask(err)
 			}
-			return version.GTE(gcpAgentVersion), nil
+			return version.GTE(capaAgentVersion), nil
 		default:
 			return false, nil
 		}

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-0-cluster-api.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-0-cluster-api.golden
@@ -1,0 +1,1073 @@
+- job_name: bob-prometheus/kubernetes-apiserver-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+
+
+
+# Add scrape configuration for docker
+- job_name: bob-prometheus/docker-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:9323/proxy/metrics
+  - target_label: app
+    replacement: docker
+  - source_labels: [__meta_kubernetes_node_address_InternalIP]
+    replacement: ${1}:9323
+    target_label: instance
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
+    action: keep
+
+# Add scrape configuration for cadvisor
+- job_name: bob-prometheus/cadvisor-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*)
+    action: keep
+- job_name: bob-prometheus/calico-node-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+
+# Add etcd configuration
+- job_name: bob-prometheus/etcd-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: master
+    action: keep
+  - source_labels: [__address__]
+    regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: bob-prometheus/kubelet-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: bob-prometheus/kubernetes-controller-manager-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10252
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10252/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# kube-scheduler
+- job_name: bob-prometheus/kubernetes-scheduler-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10251
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10251/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# kube-proxy
+- job_name: bob-prometheus/kube-proxy-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# coredns
+- job_name: bob-prometheus/coredns-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# chart-operator
+- job_name: bob-prometheus/chart-operator-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: chart-operator
+    action: keep
+
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (chart-operator.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/giantswarm/pods/${1}:8000/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# net-exporter
+- job_name: bob-prometheus/net-exporter-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: net-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (net-exporter.*)
+    target_label: __metrics_path__
+
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:8000/proxy/metrics
+
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# cert-exporter
+- job_name: bob-prometheus/cert-exporter-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+# node-exporter
+- job_name: bob-prometheus/node-exporter-bob/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: node-exporter
+    action: keep
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+# kube-state-metrics
+- job_name: bob-prometheus/kube-state-metrics-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: kube-state-metrics
+    action: keep
+  - target_label: __address__
+    replacement: master.bob:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-state-metrics.*)
+    target_label: __metrics_path__
+
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10301/proxy/metrics
+
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+
+  metric_relabel_configs:
+  - source_labels: [deployment]
+    regex: (.+)
+    target_label: workload_type
+    replacement: deployment
+  - source_labels: [daemonset]
+    regex: (.+)
+    target_label: workload_type
+    replacement: daemonset
+  - source_labels: [statefulset]
+    regex: (.+)
+    target_label: workload_type
+    replacement: statefulset
+  - source_labels: [deployment]
+    regex: (.+)
+    target_label: workload_name
+    replacement: ${1}
+  - source_labels: [daemonset]
+    regex: (.+)
+    target_label: workload_name
+    replacement: ${1}
+  - source_labels: [statefulset]
+    regex: (.+)
+    target_label: workload_name
+    replacement: ${1}
+
+- job_name: bob-prometheus/workload-bob/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.bob:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${4}/proxy${5}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: master.bob:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+
+# prometheus
+- job_name: bob-prometheus/prometheus-bob/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /bob/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bob
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: kvm
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -1,0 +1,729 @@
+
+# Add scrape configuration for cadvisor
+- job_name: alice-prometheus/cadvisor-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# calico-node
+- job_name: alice-prometheus/calico-node-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# aws-node
+# Add etcd configuration
+- job_name: alice-prometheus/etcd-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: alice-prometheus/kubelet-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-proxy
+- job_name: alice-prometheus/kube-proxy-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# coredns
+- job_name: alice-prometheus/coredns-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-exporter
+- job_name: alice-prometheus/cert-exporter-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# node-exporter
+- job_name: alice-prometheus/node-exporter-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: master.alice:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+- job_name: alice-prometheus/workload-alice/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.alice:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: master.alice:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
+
+# prometheus
+- job_name: alice-prometheus/prometheus-alice/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /alice/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: alice
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -1,0 +1,943 @@
+
+- job_name: foo-prometheus/kubernetes-apiserver-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+
+# Add scrape configuration for cadvisor
+- job_name: foo-prometheus/cadvisor-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# calico-node
+- job_name: foo-prometheus/calico-node-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# aws-node
+# Add etcd configuration
+- job_name: foo-prometheus/etcd-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: foo-prometheus/kubelet-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: foo-prometheus/kubernetes-controller-manager-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10257
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# kube-scheduler
+- job_name: foo-prometheus/kubernetes-scheduler-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10259
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+
+# kube-proxy
+- job_name: foo-prometheus/kube-proxy-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# coredns
+- job_name: foo-prometheus/coredns-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-exporter
+- job_name: foo-prometheus/cert-exporter-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# node-exporter
+- job_name: foo-prometheus/node-exporter-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: master.foo:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+- job_name: foo-prometheus/workload-foo/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.foo:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: master.foo:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
+
+# prometheus
+- job_name: foo-prometheus/prometheus-foo/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /foo/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: foo
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: medium
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -1,0 +1,943 @@
+
+- job_name: bar-prometheus/kubernetes-apiserver-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+
+# Add scrape configuration for cadvisor
+- job_name: bar-prometheus/cadvisor-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# calico-node
+- job_name: bar-prometheus/calico-node-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# aws-node
+# Add etcd configuration
+- job_name: bar-prometheus/etcd-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: bar-prometheus/kubelet-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: bar-prometheus/kubernetes-controller-manager-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10257
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# kube-scheduler
+- job_name: bar-prometheus/kubernetes-scheduler-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10259
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+
+# kube-proxy
+- job_name: bar-prometheus/kube-proxy-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# coredns
+- job_name: bar-prometheus/coredns-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-exporter
+- job_name: bar-prometheus/cert-exporter-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# node-exporter
+- job_name: bar-prometheus/node-exporter-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: master.bar:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+- job_name: bar-prometheus/workload-bar/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.bar:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: master.bar:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
+
+# prometheus
+- job_name: bar-prometheus/prometheus-bar/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /bar/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: bar
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: lowest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -1,0 +1,1748 @@
+
+# Add scrape configuration for docker
+- job_name: kubernetes-prometheus/docker-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:9323/proxy/metrics
+  - target_label: app
+    replacement: docker
+  - source_labels: [__meta_kubernetes_node_address_InternalIP]
+    replacement: ${1}:9323
+    target_label: instance
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [__name__]
+    regex: (engine_daemon_image_actions_seconds_count|process_virtual_memory_bytes|process_resident_memory_bytes)
+    action: keep
+
+# falco-exporter
+- job_name: kubernetes-prometheus/falco-exporter-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app_kubernetes_io_name]
+    regex: falco-exporter
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoints_label_app_kubernetes_io_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# Add scrape configuration for cadvisor
+- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    action: keep
+# calico-node
+- job_name: kubernetes-prometheus/calico-node-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# aws-node
+# Add etcd configuration
+- job_name: kubernetes-prometheus/etcd-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: node
+  
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/etcd-certificates/ca
+    cert_file: /etc/prometheus/secrets/etcd-certificates/crt
+    key_file: /etc/prometheus/secrets/etcd-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_node_label_role]
+    regex: master
+    action: keep
+  # by default use node address
+  - source_labels: [__address__]
+    regex: (.*):10250
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+
+  # if the 'ip' label is present, use the value
+  - source_labels: [__meta_kubernetes_node_label_ip]
+    regex: (.+)
+    target_label: __address__
+    replacement: ${1}:2379
+    action: replace
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: kubernetes-prometheus/kubelet-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-proxy
+- job_name: kubernetes-prometheus/kube-proxy-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# coredns
+- job_name: kubernetes-prometheus/coredns-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-exporter
+- job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - monitoring
+
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# node-exporter
+- job_name: kubernetes-prometheus/node-exporter-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+- job_name: kubernetes-prometheus/workload-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: kubernetes.default:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
+
+# cluster-operator before 3.2.0
+- job_name: kubernetes-prometheus/cluster-operator-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    regex: cluster-operator
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-operator (missing label)
+- job_name: kubernetes-prometheus/cert-operator-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+    regex: cert-operator
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_pod_label_app_kubernetes_io_version]
+    target_label: version
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# alertmanager
+- job_name: kubernetes-prometheus/alertmanager-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - monitoring
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: alertmanager
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# fluentbit
+- job_name: kubernetes-prometheus/fluentbit-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - monitoring
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: fluentbit
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# giantswarm-api (missing label)
+- job_name: kubernetes-prometheus/giantswarm-api-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: api
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# tokend (missing label)
+- job_name: kubernetes-prometheus/tokend-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: tokend
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# companyd (missing label)
+- job_name: kubernetes-prometheus/companyd-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: companyd
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# userd (missing label)
+- job_name: kubernetes-prometheus/userd-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: userd
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# kubernetesd (missing label)
+- job_name: kubernetes-prometheus/kubernetesd-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: kubernetesd
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# credentiald (missing label)
+- job_name: kubernetes-prometheus/credentiald-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: credentiald
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cluster-service (missing label)
+- job_name: kubernetes-prometheus/cluster-service-kubernetes/0
+  honor_labels: true
+  scheme: http
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - giantswarm
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cluster-service
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scrape]
+    regex: true
+    action: keep
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_path]
+    regex: (.+)
+    target_label: __metrics_path__
+    replacement: $1
+    action: replace
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_prometheus_io_port]
+    regex: (.+)(?::\d+);(\d+)
+    target_label: __address__
+    replacement: $1:$2
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_prometheus_io_scheme]
+    regex: (https?)
+    target_label: __scheme__
+    replacement: $1
+    action: replace
+  - source_labels: [__meta_kubernetes_pod_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+
+# installation-specific configs from config repo
+- job_name: test1
+  static_configs:
+  - targets:
+    - 1.1.1.1:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+- job_name: test2
+  static_configs:
+  - targets:
+    - 8.8.8.8:123
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: __param_target
+
+
+- job_name: kubernetes-prometheus/vault-kubernetes/0
+  honor_labels: true
+  scheme: http
+  static_configs:
+  - targets:
+    - vault1.some-installation.test:10300
+    labels:
+      app: vault
+  - targets:
+    - vault1.some-installation.test:9005
+    labels:
+      app: cert-exporter
+  relabel_configs:
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+
+# nginx-ingress-controller
+- job_name: kubernetes-prometheus/nginx-ingress-controller-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring]
+    regex: "true"
+    action: drop
+  - source_labels: [__meta_kubernetes_service_label_k8s_app]
+    regex: nginx-ingress-controller.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_ip]
+    target_label: instance
+    replacement: ${1}:10254
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - target_label: app
+    replacement: nginx-ingress-controller
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10254/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+
+# prometheus
+- job_name: kubernetes-prometheus/prometheus-kubernetes/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /kubernetes/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cilium agent and cilium operator
+- job_name: kubernetes-prometheus/cilium-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - replacement: http
+    target_label: __scheme__
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (cilium-agent|cilium-operator)
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_port_number]
+    regex: (9090|6942)
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (.*)
+    target_label: app
+    replacement: $1
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -1,0 +1,729 @@
+
+# Add scrape configuration for cadvisor
+- job_name: baz-prometheus/cadvisor-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|kong.*)
+    action: keep
+# calico-node
+- job_name: baz-prometheus/calico-node-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: false
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: ${1}:9091
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (calico-node.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9091/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;calico-node.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# aws-node
+# Add etcd configuration
+- job_name: baz-prometheus/etcd-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# Add kubelet configuration
+- job_name: baz-prometheus/kubelet-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-proxy
+- job_name: baz-prometheus/kube-proxy-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: $1:10249
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    action: keep
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (kube-proxy.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10249/proxy/metrics
+  - target_label: app
+    replacement: kube-proxy
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# coredns
+- job_name: baz-prometheus/coredns-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# cert-exporter
+- job_name: baz-prometheus/cert-exporter-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+
+      - kube-system
+
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_service_label_app]
+    regex: cert-exporter
+    action: keep
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (cert-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9005/proxy/metrics
+  - source_labels: [__meta_kubernetes_service_label_app]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+# node-exporter
+- job_name: baz-prometheus/node-exporter-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: master.baz:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  - source_labels: [mountpoint]
+    target_label: pod_id
+    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
+    action: replace
+    replacement: $1
+- job_name: baz-prometheus/workload-baz/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+    api_server: https://master.baz:443
+    tls_config:
+      ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+      cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+      key_file: /etc/prometheus/secrets/cluster-certificates/key
+      insecure_skip_verify: false
+  tls_config:
+    ca_file: /etc/prometheus/secrets/cluster-certificates/ca
+    cert_file: /etc/prometheus/secrets/cluster-certificates/crt
+    key_file: /etc/prometheus/secrets/cluster-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: keep
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_path is present, we use it as the metrics path
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_path]
+    action: replace
+    target_label: __metrics_path__
+    regex: (.+)
+    # if __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port, we use it as the metrics port
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    target_label: __address__
+    regex: ([^:]+):(\d+);(\d+)
+    replacement: $1:$3
+    # if the protocol is empty, we set it to http by default, this allows to override the protocol for services using https like prometheus operator
+  - source_labels: [__address__, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol]
+    action: replace
+    target_label: __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol
+    regex: (.*);
+    replacement: "http"
+  - source_labels: [__meta_kubernetes_pod_ip, __address__]
+    regex: (.*);([^:]+):(\d+)
+    replacement: $1:$3
+    target_label: instance
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_annotation_giantswarm_io_monitoring_protocol, __meta_kubernetes_pod_name, __address__, __metrics_path__]
+    regex: (.*);(.*);(.*);(.+:)(\d+);(.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/${1}/pods/${2}:${3}:${5}/proxy${6}
+    action: replace
+  - regex: (.*)
+    target_label: __address__
+    replacement: master.baz:443
+    action: replace
+  - source_labels: [__meta_kubernetes_service_name]
+    regex: (.*)
+    target_label: app
+    action: replace
+  - source_labels: [__meta_kubernetes_service_annotation_giantswarm_io_monitoring_app_label]
+    regex: (.+)
+    target_label: app
+    action: replace
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_duration_seconds_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    action: drop
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: deployment
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: daemonset
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_type
+    replacement: statefulset
+    action: replace
+  - source_labels: [app,deployment]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,daemonset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,statefulset]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: workload_name
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_region]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: region
+    replacement: ${1}
+    action: replace
+  - source_labels: [app,label_topology_kubernetes_io_zone]
+    separator: ;
+    regex: kube-state-metrics;(.+)
+    target_label: zone
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_topology_kubernetes_io_region|label_topology_kubernetes_io_zone"
+  # Override with label for AWS clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_deployment]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  # Override with label for Azure clusters if exists.
+  - source_labels: [app,label_giantswarm_io_machine_pool]
+    regex: kube-state-metrics;(.+)
+    target_label: nodepool
+    replacement: ${1}
+    action: replace
+  - action: labeldrop
+    regex: "label_giantswarm_io_machine_pool|label_giantswarm_io_machine_deployment"
+
+# prometheus
+- job_name: baz-prometheus/prometheus-baz/0
+  honor_labels: true
+  scheme: http
+  metrics_path: /baz/metrics
+  static_configs:
+    - targets: ['localhost:9090']
+  relabel_configs:
+  - replacement: prometheus
+    target_label: app
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: baz
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: workload_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization 
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo


### PR DESCRIPTION
towards: https://github.com/giantswarm/giantswarm/issues/24788

This will make PMO ignore static targets on CAPA MCs, and add namespaceSelector for Prometheus to ignore kube-system.