### PR TITLE
slack alert templating: fix list of instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* alert templating: list of firing instances
+* opsgenie alert templating: list of firing instances
+* slack alert templating: list of firing instances
 
 ## [4.16.0] - 2022-12-07
 

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
@@ -15,9 +15,11 @@
 {{- if (index .Alerts 0).Annotations.description }}
 *Instances*
 {{ if eq .Status "firing" }}
-{{ range .Alerts.Firing }}:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Firing }}
+:fire: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ else }}
-{{ range .Alerts.Resolved }}:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
+{{ range .Alerts.Resolved }}
+:success: {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{- end }}
 {{ end }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/20661

Noticed instances list is wrong in slack templates as well:
![image](https://user-images.githubusercontent.com/12008875/207274101-3efbac63-fecf-4469-a8e3-d241b4e60107.png)

So this should fix it.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
