### PR TITLE
Add template for harbor slack alerts

### DIFF
--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -20,7 +20,7 @@ route:
 
   - receiver: harbor_implementation
     matchers:
-    - team="harbor"
+    - app="harbor"
     continue: false
 
   # Falco noise Slack

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -17,6 +17,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - team="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -114,6 +120,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -13,6 +13,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - app="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -99,6 +105,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -13,6 +13,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - app="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -99,6 +105,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -13,6 +13,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - app="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -99,6 +105,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -13,6 +13,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - app="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -99,6 +105,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -13,6 +13,12 @@ route:
   receiver: root
 
   routes:
+
+  - receiver: harbor_implementation
+    matchers:
+    - app="harbor"
+    continue: false
+
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -99,6 +105,10 @@ route:
 
 receivers:
 - name: root
+
+- name: 'harbor_implementation'
+  slack_configs:
+  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:


### PR DESCRIPTION
Added the `harbor_implementation` receiver in order to send slack alerts to the `#harbor-implementation` channel based on harbor alerts.

Signed-off-by: William Young <will.young@engineerbetter.com>
Co-authored-by: Ajayi Dipo <ajayidipo@ymail.com>
