### PR TITLE
Remotewrite ingress allows bigger requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- remotewrite ingress allows bigger requests
+
 ## [4.18.0] - 2022-12-19
 
 ### Changed

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-1-awsconfig.golden
@@ -5,7 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: alice

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-2-azureconfig.golden
@@ -5,7 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: foo

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-3-kvmconfig.golden
@@ -5,7 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: bar

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-4-control-plane.golden
@@ -5,7 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubernetes

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-5-cluster-api-v1alpha3.golden
@@ -5,7 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 1M
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: baz

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -148,7 +148,9 @@ func RemoteWriteAuthenticationAnnotations() map[string]string {
 		"nginx.ingress.kubernetes.io/auth-secret": RemoteWriteIngressAuthSecretName,
 		"nginx.ingress.kubernetes.io/auth-realm":  "Authentication Required",
 		// Set this annotation to avoid using a temporary buffer file for remote write requests
-		"nginx.ingress.kubernetes.io/client-body-buffer-size": "1M",
+		"nginx.ingress.kubernetes.io/client-body-buffer-size": "10m",
+		// Remote write requests can be quite big. (default max body size: 1m)
+		"nginx.ingress.kubernetes.io/proxy-body-size": "10m",
 	}
 }
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25049

For prometheus-agent remotewrite to work fine, it has to send data in rather big batches.
We have observed that proper performance requires batches at minimum between 1 to 2 MB big.
And default nginx config limits requests to 1MB.

So let's increase this limit for remotewrite ingress.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
