### PR TITLE
prometheus-agent: increase max samples per send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - remotewrite ingress allows bigger requests
+- prometheus-agent: increase max samples per send. ⚠️ Warning: updates an immutable secret, will require manual actions at deployment.
 
 ## [4.18.0] - 2022-12-19
 

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -166,7 +166,7 @@ func toSecret(ctx context.Context, v interface{}, config Config) (*corev1.Secret
 func defaultQueueConfig() promv1.QueueConfig {
 	return promv1.QueueConfig{
 		Capacity:          30000,
-		MaxSamplesPerSend: 10000,
+		MaxSamplesPerSend: 50000,
 		MaxShards:         10,
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25049

For prometheus-agent remotewrite to work fine, it has to send data in rather big batches.
The previous batch size was too small, let's increase it.

I have to understand the deployment procedure before merging it. I'll probably add stuff in the CHANGELOG when I test it.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
