### PR TITLE
fix node-exporter discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add proxy support to remote write endpoint consumers.
 
+### Fixed
+
+- Fix node-exporter discovery.
+
 ## [4.19.0] - 2023-01-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fix node-exporter discovery.
+- Fix node-exporter target discovery
 
 ## [4.19.0] - 2023-01-02
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -447,7 +447,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -778,7 +778,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -778,7 +778,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -778,7 +778,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -612,7 +612,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -778,7 +778,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -554,7 +554,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -499,7 +499,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -554,7 +554,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -499,7 +499,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -499,7 +499,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -554,7 +554,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -499,7 +499,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -554,7 +554,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -713,7 +713,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -554,7 +554,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -499,7 +499,7 @@
     action: keep
   - source_labels: [__meta_kubernetes_pod_container_name]
     target_label: app
-  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
     regex: .*(true).*
     action: drop
   - source_labels: [__meta_kubernetes_pod_node_name]


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/25216

This PR fixes the `node-exporter` job to correctly ignore targets when they have the `giantswarm.io/monitoring` annotation or label.

This was broken due to the fact that `node-exporter` job is targeting `pods` but our relabeling config was using service metadata.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`