### PR TITLE
Fix spec Prometheus : add enable remote-write-receiver (schema 0.62.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable `remote-write-receiver` via `EnableFeatures` field added in `CommonPrometheusFields` (schema 0.62.0)
+
 ## [4.20.0] - 2023-01-17
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -194,8 +194,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 						},
 					},
 				},
-				EnableFeatures:            []string{"remote-write-receiver"},
-				EnableRemoteWriteReceiver: true,
+				EnableFeatures: []string{"remote-write-receiver"},
 				ExternalLabels: map[string]string{
 					key.ClusterIDKey:    key.ClusterID(cluster),
 					key.ClusterTypeKey:  key.ClusterType(config.Installation, cluster),

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -194,6 +194,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 						},
 					},
 				},
+				EnableFeatures:            []string{"remote-write-receiver"},
 				EnableRemoteWriteReceiver: true,
 				ExternalLabels: map[string]string{
 					key.ClusterIDKey:    key.ClusterID(cluster),

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: alice

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -39,7 +39,6 @@ spec:
     resources: {}
   enableFeatures:
   - remote-write-receiver
-  enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: alice
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -39,7 +39,6 @@ spec:
     resources: {}
   enableFeatures:
   - remote-write-receiver
-  enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: foo
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: foo

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -39,7 +39,6 @@ spec:
     resources: {}
   enableFeatures:
   - remote-write-receiver
-  enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: bar
     cluster_type: workload_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: bar

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -39,7 +39,6 @@ spec:
     resources: {}
   enableFeatures:
   - remote-write-receiver
-  enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: kubernetes
     cluster_type: management_cluster

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: kubernetes

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -37,6 +37,8 @@ spec:
     readinessProbe:
       initialDelaySeconds: 300
     resources: {}
+  enableFeatures:
+  - remote-write-receiver
   enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: baz

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -39,7 +39,6 @@ spec:
     resources: {}
   enableFeatures:
   - remote-write-receiver
-  enableRemoteWriteReceiver: true
   externalLabels:
     cluster_id: baz
     cluster_type: workload_cluster


### PR DESCRIPTION
Fix release 4.20.0 with the missing enable-feature:

```
ts=2023-01-17T11:26:17.244Z caller=dedupe.go:112 component=remote level=error remote_name=63fb6b url=https://prometheus.g8s.icecream.westeurope.azure.gigantic.io/icecream/api/v1/write msg="non-recoverable error" count=6642 exemplarCount=0 err="server returned HTTP status 404 Not Found: remote write receiver needs to be enabled with --enable-feature=remote-write-receiver"
```

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
