### PR TITLE
remove prometheus readinessProbe delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove Prometheus readinessProbe 5mn delay; since there is already a 15mn startupProbe
+
 ### Changed
 
 - Use resource.Quantity.AsApproximateFloat64() instead of AsInt64(), in order to avoid conversion issue when multiply cpu, e.g. 3880m

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -182,18 +182,6 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 						},
 					},
 				},
-				// Add 5mn initial delay to the readinessProbe to give Prometheus more
-				// time to load data and start. This fixes the current 10mn delay set
-				// by default in prometheus-operator which results in crash looping Prometheus
-				// when there are too much data to load.
-				Containers: []corev1.Container{
-					{
-						Name: "prometheus",
-						ReadinessProbe: &corev1.Probe{
-							InitialDelaySeconds: 300,
-						},
-					},
-				},
 				EnableFeatures: []string{"remote-write-receiver"},
 				ExternalLabels: map[string]string{
 					key.ClusterIDKey:    key.ClusterID(cluster),

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -32,11 +32,6 @@ spec:
       certFile: /etc/prometheus/secrets/cluster-certificates/crt
       keyFile: /etc/prometheus/secrets/cluster-certificates/key
   arbitraryFSAccessThroughSMs: {}
-  containers:
-  - name: prometheus
-    readinessProbe:
-      initialDelaySeconds: 300
-    resources: {}
   enableFeatures:
   - remote-write-receiver
   externalLabels:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -32,11 +32,6 @@ spec:
       certFile: /etc/prometheus/secrets/cluster-certificates/crt
       keyFile: /etc/prometheus/secrets/cluster-certificates/key
   arbitraryFSAccessThroughSMs: {}
-  containers:
-  - name: prometheus
-    readinessProbe:
-      initialDelaySeconds: 300
-    resources: {}
   enableFeatures:
   - remote-write-receiver
   externalLabels:

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -32,11 +32,6 @@ spec:
       certFile: /etc/prometheus/secrets/cluster-certificates/crt
       keyFile: /etc/prometheus/secrets/cluster-certificates/key
   arbitraryFSAccessThroughSMs: {}
-  containers:
-  - name: prometheus
-    readinessProbe:
-      initialDelaySeconds: 300
-    resources: {}
   enableFeatures:
   - remote-write-receiver
   externalLabels:

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -32,11 +32,6 @@ spec:
       cert: {}
       insecureSkipVerify: true
   arbitraryFSAccessThroughSMs: {}
-  containers:
-  - name: prometheus
-    readinessProbe:
-      initialDelaySeconds: 300
-    resources: {}
   enableFeatures:
   - remote-write-receiver
   externalLabels:

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -32,11 +32,6 @@ spec:
       certFile: /etc/prometheus/secrets/cluster-certificates/crt
       keyFile: /etc/prometheus/secrets/cluster-certificates/key
   arbitraryFSAccessThroughSMs: {}
-  containers:
-  - name: prometheus
-    readinessProbe:
-      initialDelaySeconds: 300
-    resources: {}
   enableFeatures:
   - remote-write-receiver
   externalLabels:


### PR DESCRIPTION
This changed was introduced back in #893 and is no longer needed, as there is now a 15mn startupProbe allowing for slow Prometheus with a big WAL data to load.

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`