### PR TITLE
Fix certificates created as directories rather than files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix certificates created as directories rathen than files
+
 ## [4.20.3] - 2023-02-02
 
 ### Fixed

--- a/helm/prometheus-meta-operator/templates/deployment.yaml
+++ b/helm/prometheus-meta-operator/templates/deployment.yaml
@@ -36,12 +36,15 @@ spec:
       - name: etcd-client-ca
         hostPath:
           path: {{ .Values.prometheus.etcdClientCertificates.ca }}
+          type: File
       - name: etcd-client-crt
         hostPath:
           path: {{ .Values.prometheus.etcdClientCertificates.crt }}
+          type: File
       - name: etcd-client-key
         hostPath:
           path: {{ .Values.prometheus.etcdClientCertificates.key }}
+          type: File
       serviceAccountName: {{ include "resource.default.name"  . }}
       securityContext:
         runAsUser: {{ .Values.pod.user.id }}


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/25713

=> to avoid certificates created as directories when `pmo` is started before systemd unit runs into the node.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
