### PR TITLE
Adds kyverno namespace to default scrape config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use resource.Quantity.AsApproximateFloat64() instead of AsInt64(), in order to avoid conversion issue when multiply cpu, e.g. 3880m
 - Use label selector to selects only worker nodes for vpa resource to get maxCPU and maxMemory
 - List nodes from API only once in VPA resource
+- Adds `kyverno` namespace to default scrape config for WC
 
 ## [4.20.6] - 2023-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use resource.Quantity.AsApproximateFloat64() instead of AsInt64(), in order to avoid conversion issue when multiply cpu, e.g. 3880m
 - Use label selector to selects only worker nodes for vpa resource to get maxCPU and maxMemory
 - List nodes from API only once in VPA resource
-- Adds `kyverno` namespace to default scrape config for WC
+- Adds `kyverno` namespace to WC & MC default scrape config for cadvisor metrics
 
 ## [4.20.6] - 2023-02-13
 

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -92,7 +92,7 @@
   metric_relabel_configs:
 [[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 [[- else ]]
   - source_labels: [namespace]

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -96,7 +96,7 @@
     action: keep
 [[- else ]]
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 [[- end ]]
 # calico-node

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -56,7 +56,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -56,7 +56,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -56,7 +56,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -56,7 +56,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: alice-prometheus/calico-node-alice/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: foo-prometheus/calico-node-foo/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -106,7 +106,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: bar-prometheus/calico-node-bar/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -155,7 +155,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|draughtsman|flux-.*|kyverno)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -56,7 +56,7 @@
     target_label: role
   metric_relabel_configs:
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|kong.*)
+    regex: (kube-system|giantswarm.*|kong.*|kyverno)
     action: keep
 # calico-node
 - job_name: baz-prometheus/calico-node-baz/0


### PR DESCRIPTION
## Description

Adds `kyverno` namespace to default scrape config for WC to look for cadvisor metrics.
Towards https://github.com/giantswarm/giantswarm/issues/24831

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
