### PR TITLE
Send SLO (sloth based) notify level alerts to '#alert-phoenix' Slack channel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use resource.Quantity.AsApproximateFloat64() instead of AsInt64(), in order to avoid conversion issue when multiply cpu, e.g. 3880m
 - Use label selector to selects only worker nodes for vpa resource to get maxCPU and maxMemory
 - List nodes from API only once in VPA resource
+- Prevent 'notify' severity alerts from being sent to '#alert-phoenix' Slack channel (too noisy).
+
+### Added
+
+- Send SLO (sloth based) notify level alerts to '#alert-phoenix' Slack channel.
 
 ## [4.20.6] - 2023-02-13
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -73,22 +73,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -73,25 +73,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -58,25 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -58,22 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -58,25 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -58,22 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -58,25 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -58,22 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -58,25 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -58,22 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -58,25 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="celestial"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="firecracker"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity="notify"
+    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity="ticket"
+    - sloth_severity=~"page|ticket"
     continue: false
 
   # Team Hydra Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -58,22 +58,25 @@ route:
   # Team Celestial Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="celestial"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Firecracker Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="firecracker"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
+    - severity="notify"
     - team="phoenix"
+    - sloth_severity="ticket"
     continue: false
 
   # Team Hydra Slack


### PR DESCRIPTION
`notify` severity alerts are too many to be actionable for phoenix.
This PR disables them, while enabling the `notify` severity alerts generated by SLOTH only.

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
