### PR TITLE
Change GetOrganization to rely on the namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Enable Opsgenie alerts for Shield.
 
+### Fixed
+
+- Change source for the organization label.
+
 ## [4.46.0] - 2023-08-21
 
 ### Added

--- a/files/templates/scrapeconfigs/_labelingschema.yaml
+++ b/files/templates/scrapeconfigs/_labelingschema.yaml
@@ -16,7 +16,7 @@
   replacement: [[ .ServicePriority | default "highest"]]
 # Add organization label.
 - target_label: organization
-  replacement: [[ .Organization | default "giantswarm" ]] 
+  replacement: [[ .Organization | default "giantswarm" ]]
 # Add customer label.
 - target_label: customer
   replacement: [[ .Customer ]]

--- a/pkg/nodecounter/nodecounter.go
+++ b/pkg/nodecounter/nodecounter.go
@@ -33,7 +33,7 @@ func countMachineDeploymentClusterNodes(ctx context.Context, k8sClient k8sclient
 		client.MatchingLabels{
 			key.ClusterLabel: key.ClusterID(cluster),
 		},
-		client.InNamespace(key.OrganizationNamespace(cluster)),
+		client.InNamespace(cluster.GetNamespace()),
 	}
 
 	err := k8sClient.CtrlClient().List(ctx, &machinedeployments, opts...)
@@ -59,7 +59,7 @@ func countMachinePoolClusterNodes(ctx context.Context, k8sClient k8sclient.Inter
 		client.MatchingLabels{
 			key.ClusterLabel: key.ClusterID(cluster),
 		},
-		client.InNamespace(key.OrganizationNamespace(cluster)),
+		client.InNamespace(cluster.GetNamespace()),
 	}
 
 	err := k8sClient.CtrlClient().List(ctx, &machinepools, opts...)

--- a/pkg/organization/reader.go
+++ b/pkg/organization/reader.go
@@ -1,0 +1,48 @@
+package organization
+
+import (
+	"context"
+	"errors"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const (
+	DefaultOrganization string = "giantswarm"
+	OrganizationLabel   string = "giantswarm.io/organization"
+)
+
+type Reader interface {
+	Read(ctx context.Context, cluster metav1.Object) (string, error)
+}
+
+type NamespaceReader struct {
+	client       kubernetes.Interface
+	installation string
+	provider     string
+}
+
+func NewNamespaceReader(client kubernetes.Interface, installation string, provider string) Reader {
+	return NamespaceReader{client, installation, provider}
+}
+
+func (r NamespaceReader) Read(ctx context.Context, cluster metav1.Object) (string, error) {
+	// Vintage MC
+	if key.IsManagementCluster(r.installation, cluster) && !key.IsCAPIManagementCluster(r.provider) {
+		return DefaultOrganization, nil
+	}
+
+	// For the rest, we extract the organization name from the namespace labels
+	namespace, err := r.client.CoreV1().Namespaces().Get(ctx, cluster.GetNamespace(), metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if organization, ok := namespace.Labels[OrganizationLabel]; ok {
+		return organization, nil
+	}
+	return "", errors.New("cluster namespace missing organization label")
+}

--- a/pkg/unittest/input/case-1-awsconfig.golden
+++ b/pkg/unittest/input/case-1-awsconfig.golden
@@ -3,7 +3,6 @@ kind: AWSConfig
 metadata:
   labels:
     "giantswarm.io/service-priority": "highest"
-    giantswarm.io/organization: my-organization
-    "release.giantswarm.io/version": 16.0.0
+    "release.giantswarm.io/version": "16.0.0"
   name: alice
   namespace: org-my-organization

--- a/pkg/unittest/input/case-2-azureconfig.golden
+++ b/pkg/unittest/input/case-2-azureconfig.golden
@@ -3,7 +3,6 @@ kind: AzureConfig
 metadata:
   labels:
     "giantswarm.io/service-priority": "medium"
-    giantswarm.io/organization: my-organization
-    "release.giantswarm.io/version": 18.0.0
+    "release.giantswarm.io/version": "18.0.0"
   name: foo
   namespace: org-my-organization

--- a/pkg/unittest/input/case-3-kvmconfig.golden
+++ b/pkg/unittest/input/case-3-kvmconfig.golden
@@ -2,8 +2,7 @@ apiVersion: provider.giantswarm.io/v1alpha1
 kind: KVMConfig
 metadata:
   labels:
-    "giantswarm.io/service-priority": "lowest"
-    giantswarm.io/organization: my-organization
-    "release.giantswarm.io/version": 17.0.0
+    "giantswarm.io/service-priority": lowest
+    "release.giantswarm.io/version": "17.0.0"
   name: bar
   namespace: org-my-organization

--- a/pkg/unittest/input/case-4-control-plane.golden
+++ b/pkg/unittest/input/case-4-control-plane.golden
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes
-  namespace: org-my-organization
-  labels:
-    giantswarm.io/organization: my-organization
+  namespace: default
 spec:
   clusterIP: 127.0.0.1

--- a/pkg/unittest/input/case-5-cluster-api-v1alpha3.golden
+++ b/pkg/unittest/input/case-5-cluster-api-v1alpha3.golden
@@ -2,8 +2,7 @@ apiVersion: cluster.x-k8s.io/v1beta1
 kind: Cluster
 metadata:
   labels:
-    release.giantswarm.io/version: 18.0.0
-    giantswarm.io/organization: my-organization
+    "release.giantswarm.io/version": 18.0.0
   name: baz
   namespace: org-my-organization
 spec:

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -12,6 +12,7 @@ import (
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerconfig"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerwiring"
@@ -209,11 +210,13 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 	}
 
+	organizationReader := organization.NewNamespaceReader(config.K8sClient.K8sClient(), config.Installation, config.Provider)
 	var scrapeConfigResource resource.Interface
 	{
 		c := scrapeconfigs.Config{
-			K8sClient: config.K8sClient,
-			Logger:    config.Logger,
+			K8sClient:          config.K8sClient,
+			Logger:             config.Logger,
+			OrganizationReader: organizationReader,
 
 			AdditionalScrapeConfigs: config.AdditionalScrapeConfigs,
 			Bastions:                config.Bastions,
@@ -309,8 +312,10 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var remoteWriteConfigResource resource.Interface
 	{
 		c := remotewriteconfig.Config{
-			K8sClient:    config.K8sClient,
-			Logger:       config.Logger,
+			K8sClient:          config.K8sClient,
+			Logger:             config.Logger,
+			OrganizationReader: organizationReader,
+
 			Customer:     config.Customer,
 			Installation: config.Installation,
 			Pipeline:     config.Pipeline,
@@ -346,8 +351,10 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var remoteWriteAPIEndpointConfigSecretResource resource.Interface
 	{
 		c := remotewriteapiendpointconfigsecret.Config{
-			K8sClient:    config.K8sClient,
-			Logger:       config.Logger,
+			K8sClient:          config.K8sClient,
+			Logger:             config.Logger,
+			OrganizationReader: organizationReader,
+
 			BaseDomain:   config.PrometheusBaseDomain,
 			Customer:     config.Customer,
 			Installation: config.Installation,

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
@@ -22,18 +22,18 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 
 		// Get password from remote-write-secret
 		r.logger.Debugf(ctx, "looking up for secret remote write secret")
-		_, password, err := remotewriteconfiguration.GetUsernameAndPassword(r.k8sClient.K8sClient(), ctx, cluster, r.Installation, r.Provider)
+		_, password, err := remotewriteconfiguration.GetUsernameAndPassword(r.k8sClient.K8sClient(), ctx, cluster, r.installation, r.provider)
 		if err != nil {
 			r.logger.Errorf(ctx, err, "lookup for remote write secret failed")
 			return microerror.Mask(err)
 		}
 
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Provider)
-		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
+		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.provider)
+		namespace := key.GetClusterAppsNamespace(cluster, r.installation, r.provider)
 		// Get the current secret if it exists.
 		current, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			err = r.createSecret(ctx, cluster, name, namespace, password, r.Version)
+			err = r.createSecret(ctx, cluster, name, namespace, password, r.version)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -42,7 +42,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if current != nil {
-			desired, err := r.desiredSecret(cluster, name, namespace, password, r.Version)
+			desired, err := r.desiredSecret(ctx, cluster, name, namespace, password, r.version)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/delete.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/delete.go
@@ -19,8 +19,8 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Provider)
-		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
+		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.provider)
+		namespace := key.GetClusterAppsNamespace(cluster, r.installation, r.provider)
 
 		_, err = r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/service/controller/resource/monitoring/remotewriteconfig/create.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/create.go
@@ -24,12 +24,12 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		name := key.RemoteWriteConfigName(cluster)
-		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
+		namespace := key.GetClusterAppsNamespace(cluster, r.installation, r.provider)
 
 		// Get the current configmap if it exists.
 		current, err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			err = r.createConfigMap(ctx, cluster, name, namespace, r.Version)
+			err = r.createConfigMap(ctx, cluster, name, namespace, r.version)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -48,7 +48,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			desired, err := r.desiredConfigMap(cluster, name, namespace, r.Version, shards)
+			desired, err := r.desiredConfigMap(ctx, cluster, name, namespace, r.version, shards)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/monitoring/remotewriteconfig/delete.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/delete.go
@@ -20,7 +20,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 		name := key.RemoteWriteConfigName(cluster)
-		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
+		namespace := key.GetClusterAppsNamespace(cluster, r.installation, r.provider)
 
 		_, err = r.k8sClient.K8sClient().CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {

--- a/service/controller/resource/monitoring/scrapeconfigs/error.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/error.go
@@ -4,6 +4,15 @@ import (
 	"github.com/giantswarm/microerror"
 )
 
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}
+
 var wrongTypeError = &microerror.Error{
 	Kind: "wrongTypeError",
 }

--- a/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
@@ -10,6 +10,7 @@ import (
 	appsv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -36,6 +37,12 @@ const additionalScrapeConfigs = `- job_name: test1
   - source_labels: [__address__]
     target_label: __param_target`
 
+type FakeReader struct{}
+
+func (r FakeReader) Read(ctx context.Context, cluster metav1.Object) (string, error) {
+	return "my-organization", nil
+}
+
 func TestAWSScrapeconfigs(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
@@ -60,11 +67,12 @@ func TestAWSScrapeconfigs(t *testing.T) {
 		}
 
 		config := Config{
-			TemplatePath: path,
-			Provider:     "aws",
-			Customer:     "pmo",
-			Vault:        "vault1.some-installation.test",
-			Installation: "test-installation",
+			TemplatePath:       path,
+			OrganizationReader: FakeReader{},
+			Provider:           "aws",
+			Customer:           "pmo",
+			Vault:              "vault1.some-installation.test",
+			Installation:       "test-installation",
 		}
 		testFunc = func(v interface{}) (interface{}, error) {
 			return toData(context.Background(), client, v, config)
@@ -118,11 +126,12 @@ func TestAzureScrapeconfigs(t *testing.T) {
 		}
 
 		config := Config{
-			TemplatePath: path,
-			Provider:     "azure",
-			Customer:     "pmo",
-			Vault:        "vault1.some-installation.test",
-			Installation: "test-installation",
+			TemplatePath:       path,
+			OrganizationReader: FakeReader{},
+			Provider:           "azure",
+			Customer:           "pmo",
+			Vault:              "vault1.some-installation.test",
+			Installation:       "test-installation",
 		}
 		testFunc = func(v interface{}) (interface{}, error) {
 			return toData(context.Background(), client, v, config)
@@ -177,6 +186,7 @@ func TestKVMScrapeconfigs(t *testing.T) {
 
 		config := Config{
 			AdditionalScrapeConfigs: additionalScrapeConfigs,
+			OrganizationReader:      FakeReader{},
 			TemplatePath:            path,
 			Provider:                "kvm",
 			Customer:                "pmo",
@@ -259,6 +269,7 @@ func TestOpenStackScrapeconfigs(t *testing.T) {
 
 		config := Config{
 			AdditionalScrapeConfigs: additionalScrapeConfigs,
+			OrganizationReader:      FakeReader{},
 			TemplatePath:            path,
 			Provider:                "openstack",
 			Customer:                "pmo",
@@ -341,6 +352,7 @@ func TestGCPScrapeconfigs(t *testing.T) {
 
 		config := Config{
 			AdditionalScrapeConfigs: additionalScrapeConfigs,
+			OrganizationReader:      FakeReader{},
 			TemplatePath:            path,
 			Provider:                "gcp",
 			Customer:                "pmo",
@@ -423,6 +435,7 @@ func TestCAPAScrapeconfigs(t *testing.T) {
 
 		config := Config{
 			AdditionalScrapeConfigs: additionalScrapeConfigs,
+			OrganizationReader:      FakeReader{},
 			TemplatePath:            path,
 			Provider:                "capa",
 			Customer:                "pmo",

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -81,7 +81,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -144,7 +144,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -188,7 +188,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -244,7 +244,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -320,7 +320,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -381,7 +381,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -458,7 +458,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -537,7 +537,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -607,7 +607,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -679,7 +679,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -753,7 +753,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -802,7 +802,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -895,7 +895,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1063,7 +1063,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1104,7 +1104,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1160,7 +1160,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1200,7 +1200,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1263,7 +1263,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -81,7 +81,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -144,7 +144,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -188,7 +188,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -244,7 +244,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -320,7 +320,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -381,7 +381,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -458,7 +458,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -537,7 +537,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -607,7 +607,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -679,7 +679,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -753,7 +753,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -802,7 +802,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -895,7 +895,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1063,7 +1063,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1104,7 +1104,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1160,7 +1160,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1200,7 +1200,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1263,7 +1263,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -1,4 +1,47 @@
 
+- job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
 # falco-exporter
 - job_name: kubernetes-prometheus/falco-exporter-kubernetes/0
   honor_labels: true
@@ -51,10 +94,124 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add kubelet configuration
+- job_name: kubernetes-prometheus/kubelet-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+  # drop uid label from kubelet
+  - action: labeldrop
+    regex: uid
+# Add scrape configuration for cadvisor
+- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop id and name labels from cAdvisor as they do not provide value but use a lot of RAM
+  - action: labeldrop
+    regex: id|name
+  # dropping explained here https://github.com/giantswarm/giantswarm/issues/26361
+  - source_labels: [__name__]
+    regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
+    action: drop
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
@@ -113,10 +270,230 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add etcd configuration
+- job_name: kubernetes-prometheus/etcd-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/etcd-certificates/ca
+    cert_file: /etc/prometheus/secrets/etcd-certificates/crt
+    key_file: /etc/prometheus/secrets/etcd-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10257
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# kube-scheduler
+- job_name: kubernetes-prometheus/kubernetes-scheduler-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10259
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: kubernetes-prometheus/kube-proxy-kubernetes/0
   honor_labels: true
@@ -178,7 +555,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -186,6 +563,78 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# coredns
+- job_name: kubernetes-prometheus/coredns-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
     action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
@@ -252,10 +701,64 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# node-exporter
+- job_name: kubernetes-prometheus/node-exporter-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: capa
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: node_(filesystem_files|filesystem_readonly|nfs_requests_total|network_carrier|network_transmit_colls_total|network_carrier_changes_total|network_transmit_packets_total|network_carrier_down_changes_total|network_carrier_up_changes_total|network_iface_id|xfs_.+|ethtool_.+)
+    action: drop
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https
@@ -340,20 +843,11 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  - source_labels: [container]
-    regex: prometheus-operator-app
-    action: drop
-  - source_labels: [app]
-    regex: coredns
-    action: drop
-  - source_labels: [app]
-    regex: kube-state-metrics
-    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)
@@ -517,7 +1011,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -590,7 +1084,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -630,7 +1124,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -693,7 +1187,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -46,7 +46,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -109,7 +109,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -192,7 +192,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -256,7 +256,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -331,7 +331,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -410,7 +410,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -491,7 +491,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -586,7 +586,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -1,4 +1,47 @@
 
+- job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
 # falco-exporter
 - job_name: kubernetes-prometheus/falco-exporter-kubernetes/0
   honor_labels: true
@@ -51,10 +94,124 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add kubelet configuration
+- job_name: kubernetes-prometheus/kubelet-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+  # drop uid label from kubelet
+  - action: labeldrop
+    regex: uid
+# Add scrape configuration for cadvisor
+- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop id and name labels from cAdvisor as they do not provide value but use a lot of RAM
+  - action: labeldrop
+    regex: id|name
+  # dropping explained here https://github.com/giantswarm/giantswarm/issues/26361
+  - source_labels: [__name__]
+    regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
+    action: drop
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
@@ -113,10 +270,230 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add etcd configuration
+- job_name: kubernetes-prometheus/etcd-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/etcd-certificates/ca
+    cert_file: /etc/prometheus/secrets/etcd-certificates/crt
+    key_file: /etc/prometheus/secrets/etcd-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10257
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# kube-scheduler
+- job_name: kubernetes-prometheus/kubernetes-scheduler-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10259
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: kubernetes-prometheus/kube-proxy-kubernetes/0
   honor_labels: true
@@ -178,7 +555,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -186,6 +563,78 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# coredns
+- job_name: kubernetes-prometheus/coredns-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
     action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
@@ -252,10 +701,64 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# node-exporter
+- job_name: kubernetes-prometheus/node-exporter-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: gcp
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: node_(filesystem_files|filesystem_readonly|nfs_requests_total|network_carrier|network_transmit_colls_total|network_carrier_changes_total|network_transmit_packets_total|network_carrier_down_changes_total|network_carrier_up_changes_total|network_iface_id|xfs_.+|ethtool_.+)
+    action: drop
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https
@@ -340,20 +843,11 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  - source_labels: [container]
-    regex: prometheus-operator-app
-    action: drop
-  - source_labels: [app]
-    regex: coredns
-    action: drop
-  - source_labels: [app]
-    regex: kube-state-metrics
-    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)
@@ -517,7 +1011,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -590,7 +1084,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -630,7 +1124,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -693,7 +1187,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -46,7 +46,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -109,7 +109,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -192,7 +192,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -256,7 +256,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -331,7 +331,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -410,7 +410,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -491,7 +491,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -586,7 +586,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -443,7 +443,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -529,7 +529,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -606,7 +606,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -685,7 +685,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -766,7 +766,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -822,7 +822,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -922,7 +922,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1046,7 +1046,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -35,7 +35,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -81,7 +81,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -144,7 +144,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -188,7 +188,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -244,7 +244,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -320,7 +320,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -381,7 +381,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -458,7 +458,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -537,7 +537,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -607,7 +607,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -679,7 +679,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -753,7 +753,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -802,7 +802,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -895,7 +895,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1063,7 +1063,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1138,7 +1138,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1196,7 +1196,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1254,7 +1254,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1289,7 +1289,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1329,7 +1329,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1385,7 +1385,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1425,7 +1425,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -1488,7 +1488,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -95,7 +95,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -153,7 +153,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -216,7 +216,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -299,7 +299,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -359,7 +359,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -434,7 +434,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -513,7 +513,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -594,7 +594,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -650,7 +650,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -750,7 +750,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -874,7 +874,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -42,7 +42,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -42,7 +42,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: medium
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -42,7 +42,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -96,7 +96,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -159,7 +159,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -242,7 +242,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -306,7 +306,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -390,7 +390,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -476,7 +476,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -553,7 +553,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -632,7 +632,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -769,7 +769,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -869,7 +869,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -993,7 +993,7 @@
     replacement: lowest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -1,4 +1,47 @@
 
+- job_name: kubernetes-prometheus/kubernetes-apiserver-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_service_label_component]
+    regex: apiserver
+    action: keep
+  - source_labels: [__meta_kubernetes_endpoint_port_name]
+    regex: https
+    action: keep
+  - target_label: app
+    replacement: kubernetes
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
 # falco-exporter
 - job_name: kubernetes-prometheus/falco-exporter-kubernetes/0
   honor_labels: true
@@ -51,10 +94,124 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add kubelet configuration
+- job_name: kubernetes-prometheus/kubelet-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: app
+    replacement: kubelet
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+  # drop uid label from kubelet
+  - action: labeldrop
+    regex: uid
+# Add scrape configuration for cadvisor
+- job_name: kubernetes-prometheus/cadvisor-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: node
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_node_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/nodes/${1}:10250/proxy/metrics/cadvisor
+  - target_label: app
+    replacement: cadvisor
+  # Add node name.
+  - source_labels: [__meta_kubernetes_node_label_kubernetes_io_hostname]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  metric_relabel_configs:
+  # drop id and name labels from cAdvisor as they do not provide value but use a lot of RAM
+  - action: labeldrop
+    regex: id|name
+  # dropping explained here https://github.com/giantswarm/giantswarm/issues/26361
+  - source_labels: [__name__]
+    regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
+    action: drop
+  - source_labels: [namespace]
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
+    action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0
   honor_labels: true
@@ -113,10 +270,230 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# Add etcd configuration
+- job_name: kubernetes-prometheus/etcd-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+  
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+  tls_config:
+    ca_file: /etc/prometheus/secrets/etcd-certificates/ca
+    cert_file: /etc/prometheus/secrets/etcd-certificates/crt
+    key_file: /etc/prometheus/secrets/etcd-certificates/key
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (etcd)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:2381/proxy/metrics
+    action: replace
+  - source_labels: [ __meta_kubernetes_pod_name ]
+    target_label: pod_name
+  - target_label: app
+    replacement: etcd
+  - source_labels: [__address__]
+    target_label: instance
+  # Add ip label.
+  - target_label: ip
+    source_labels: [__meta_kubernetes_node_address_InternalIP]
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+# kube-controller-manager
+- job_name: kubernetes-prometheus/kubernetes-controller-manager-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10257
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-controller-manager|kube-controller-manager)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-controller-manager
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# kube-scheduler
+- job_name: kubernetes-prometheus/kubernetes-scheduler-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    replacement: 10259
+    target_label: __tmp_port
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring_port,__meta_kubernetes_pod_annotation_giantswarm_io_monitoring_port]
+    action: replace
+    regex: true;(\d+)
+    replacement: $1
+    target_label: __tmp_port
+  - source_labels: [__address__, __tmp_port]
+    target_label: instance
+    regex: (.+);(.+)
+    replacement: $1:$2
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: (k8s-scheduler|kube-scheduler)
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name, __tmp_port]
+    target_label: __metrics_path__
+    regex: (.+);(\d+)
+    replacement: /api/v1/namespaces/kube-system/pods/https:${1}:${2}/proxy/metrics
+  - target_label: app
+    replacement: kube-scheduler
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: kubernetes-prometheus/kube-proxy-kubernetes/0
   honor_labels: true
@@ -178,7 +555,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -186,6 +563,78 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
+# coredns
+- job_name: kubernetes-prometheus/coredns-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: endpoints
+    namespaces:
+      names:
+      - kube-system
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - source_labels: [__address__]
+    target_label: instance
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    regex: coredns
+    action: keep
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (coredns.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:9153/proxy/metrics
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_service_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_service_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  # Add namespace label.
+  - source_labels: [__meta_kubernetes_namespace]
+    target_label: namespace
+  # Add pod label.
+  - source_labels: [__meta_kubernetes_pod_name]
+    target_label: pod
+  # Add container label.
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: container
+  # Add node label.
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add role label.
+  - source_labels: [__meta_kubernetes_node_label_role]
+    target_label: role
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
     action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
@@ -252,10 +701,64 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
+# node-exporter
+- job_name: kubernetes-prometheus/node-exporter-kubernetes/0
+  honor_labels: true
+  scheme: https
+  kubernetes_sd_configs:
+  - role: pod
+
+  bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+  tls_config:
+    ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+    insecure_skip_verify: true
+  relabel_configs:
+  - target_label: __address__
+    replacement: kubernetes.default:443
+  - source_labels: [__meta_kubernetes_pod_name]
+    regex: (node-exporter.*)
+    target_label: __metrics_path__
+    replacement: /api/v1/namespaces/kube-system/pods/${1}:10300/proxy/metrics
+  - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_pod_name]
+    regex: kube-system;node-exporter.*
+    action: keep
+  - source_labels: [__meta_kubernetes_pod_container_name]
+    target_label: app
+  - source_labels: [__meta_kubernetes_pod_annotationpresent_giantswarm_io_monitoring, __meta_kubernetes_pod_labelpresent_giantswarm_io_monitoring]
+    regex: .*(true).*
+    action: drop
+  - source_labels: [__meta_kubernetes_pod_node_name]
+    target_label: node
+  # Add cluster_id label.
+  - target_label: cluster_id
+    replacement: kubernetes
+  # Add cluster_type label.
+  - target_label: cluster_type
+    replacement: management_cluster
+  # Add provider label.
+  - target_label: provider
+    replacement: openstack
+  # Add installation label.
+  - target_label: installation
+    replacement: test-installation
+  # Add priority label.
+  - target_label: service_priority
+    replacement: highest
+  # Add organization label.
+  - target_label: organization
+    replacement: my-organization
+  # Add customer label.
+  - target_label: customer
+    replacement: pmo
+  metric_relabel_configs:
+  # drop unused metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: node_(filesystem_files|filesystem_readonly|nfs_requests_total|network_carrier|network_transmit_colls_total|network_carrier_changes_total|network_transmit_packets_total|network_carrier_down_changes_total|network_carrier_up_changes_total|network_iface_id|xfs_.+|ethtool_.+)
+    action: drop
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https
@@ -340,20 +843,11 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  - source_labels: [container]
-    regex: prometheus-operator-app
-    action: drop
-  - source_labels: [app]
-    regex: coredns
-    action: drop
-  - source_labels: [app]
-    regex: kube-state-metrics
-    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)
@@ -517,7 +1011,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -590,7 +1084,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -630,7 +1124,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -693,7 +1187,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -46,7 +46,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -109,7 +109,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -192,7 +192,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -256,7 +256,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -331,7 +331,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -410,7 +410,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -491,7 +491,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -586,7 +586,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo
@@ -713,7 +713,7 @@
     replacement: highest
   # Add organization label.
   - target_label: organization
-    replacement: my-organization 
+    replacement: my-organization
   # Add customer label.
   - target_label: customer
     replacement: pmo

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -3,7 +3,6 @@ package key
 import (
 	"fmt"
 	"math"
-	"regexp"
 
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/core/v1"
@@ -20,11 +19,9 @@ const (
 	MonitoringNamespace = "monitoring"
 
 	DefaultServicePriority string = "highest"
-	DefaultOrganization    string = "giantswarm"
 
 	ClusterLabel                 string = "giantswarm.io/cluster"
 	MonitoringLabel              string = "giantswarm.io/monitoring"
-	OrganizationLabel            string = "giantswarm.io/organization"
 	ServicePriorityLabel         string = "giantswarm.io/service-priority"
 	TeamLabel                    string = "application.giantswarm.io/team"
 	OpsGenieApiKey               string = "opsGenieApiKey" // #nosec G101
@@ -86,7 +83,7 @@ func NamespaceDefault(cluster metav1.Object) string {
 	return v1.NamespaceDefault
 }
 
-func OrganizationNamespace(cluster metav1.Object) string {
+func ClusterNamespace(cluster metav1.Object) string {
 	return cluster.GetNamespace()
 }
 
@@ -99,15 +96,6 @@ func GetServicePriority(cluster metav1.Object) string {
 		return servicePriority
 	}
 	return DefaultServicePriority
-}
-
-func GetOrganization(cluster metav1.Object) string {
-	re := regexp.MustCompile(`org-(.*)`)
-	match := re.FindStringSubmatch(cluster.GetNamespace())
-	if len(match) >= 2 {
-		return match[1]
-	}
-	return DefaultOrganization
 }
 
 func IsMonitoringDisabled(cluster metav1.Object) bool {

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -3,6 +3,7 @@ package key
 import (
 	"fmt"
 	"math"
+	"regexp"
 
 	"github.com/giantswarm/microerror"
 	v1 "k8s.io/api/core/v1"
@@ -101,8 +102,10 @@ func GetServicePriority(cluster metav1.Object) string {
 }
 
 func GetOrganization(cluster metav1.Object) string {
-	if organization, ok := cluster.GetLabels()[OrganizationLabel]; ok && organization != "" {
-		return organization
+	re := regexp.MustCompile(`org-(.*)`)
+	match := re.FindStringSubmatch(cluster.GetNamespace())
+	if len(match) >= 2 {
+		return match[1]
 	}
 	return DefaultOrganization
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26105

Both vintage and capi clusters reside on the org namespace. 
Since, org label is deprecated, we need to rely on the namespace...  
