### PR TITLE
adjust VPA settings to prevent prometheus from using all node RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Un-drop `nginx_ingress_controller_request_duration_seconds_bucket` for workload clusters
 - Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`
+- VPA settings: changed max memory requests from 90% to 80% of node RAM, so that memory limit is 96% node RAM (avoids crashing node with big prometheis)
 
 ## [4.23.0] - 2023-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Un-drop `nginx_ingress_controller_request_duration_seconds_bucket` for workload clusters
 - Add additional annotations on all `ingress` objects to support DNS record creation via `external-dns`
 - VPA settings: changed max memory requests from 90% to 80% of node RAM, so that memory limit is 96% node RAM (avoids crashing node with big prometheis)
+- VPA settings: remove useless config for `prometheus-config-reloader` and `rules-configmap-reloader`: now it's only 1 container called `config-reloader`, and default config scales it down just nice!
 
 ## [4.23.0] - 2023-02-28
 

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -204,7 +204,11 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(nodeMemoryNotFoundError)
 	}
 
-	q, err := quantityMultiply(nodeMemory, 0.9)
+	// set max `requests` RAM to 80% node RAM.
+	// When setting default limit, make sure max VPA limit won't go higher than available RAM!
+	// because limit grows proportionnaly to requests, and here we compute max requests
+	// So check that PrometheusMemoryLimitCoefficient*MaxMemory < node memory
+	q, err := quantityMultiply(nodeMemory, 0.8)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -99,7 +99,6 @@ func (r *Resource) getObject(ctx context.Context, v interface{}) (*vpa_types.Ver
 
 	updateModeAuto := vpa_types.UpdateModeAuto
 	containerScalingModeAuto := vpa_types.ContainerScalingModeAuto
-	containerScalingModeOff := vpa_types.ContainerScalingModeOff
 	containerControlledValuesRequestsAndLimits := vpa_types.ContainerControlledValuesRequestsAndLimits
 	vpa := &vpa_types.VerticalPodAutoscaler{
 		ObjectMeta: objectMeta,

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -209,6 +209,12 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(err)
 	}
 
+	// Memory must be a whole number of bytes
+	q.Set(int64(q.AsApproximateFloat64()))
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	return q, nil
 }
 

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -127,14 +127,6 @@ func (r *Resource) getObject(ctx context.Context, v interface{}) (*vpa_types.Ver
 							v1.ResourceMemory: *maxMemory,
 						},
 					},
-					{
-						ContainerName: "prometheus-config-reloader",
-						Mode:          &containerScalingModeOff,
-					},
-					{
-						ContainerName: "rules-configmap-reloader",
-						Mode:          &containerScalingModeOff,
-					},
 				},
 			},
 		},

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -19,10 +19,6 @@ spec:
         cpu: 100m
         memory: "1073741824"
       mode: Auto
-    - containerName: prometheus-config-reloader
-      mode: "Off"
-    - containerName: rules-configmap-reloader
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 7500m
+        memory: 6666m
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 6666m
+        memory: "6"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -19,10 +19,6 @@ spec:
         cpu: 100m
         memory: "1073741824"
       mode: Auto
-    - containerName: prometheus-config-reloader
-      mode: "Off"
-    - containerName: rules-configmap-reloader
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 7500m
+        memory: 6666m
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 6666m
+        memory: "6"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -19,10 +19,6 @@ spec:
         cpu: 100m
         memory: "1073741824"
       mode: Auto
-    - containerName: prometheus-config-reloader
-      mode: "Off"
-    - containerName: rules-configmap-reloader
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 7500m
+        memory: 6666m
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 6666m
+        memory: "6"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -19,10 +19,6 @@ spec:
         cpu: 100m
         memory: "1073741824"
       mode: Auto
-    - containerName: prometheus-config-reloader
-      mode: "Off"
-    - containerName: rules-configmap-reloader
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 7500m
+        memory: 6666m
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 6666m
+        memory: "6"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -19,10 +19,6 @@ spec:
         cpu: 100m
         memory: "1073741824"
       mode: Auto
-    - containerName: prometheus-config-reloader
-      mode: "Off"
-    - containerName: rules-configmap-reloader
-      mode: "Off"
   targetRef:
     apiVersion: apps/v1
     kind: StatefulSet

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 7500m
+        memory: 6666m
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: 6666m
+        memory: "6"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -26,6 +26,10 @@ const (
 	ServicePriorityLabel string = "giantswarm.io/service-priority"
 	TeamLabel            string = "application.giantswarm.io/team"
 	// PrometheusMemoryLimitCoefficient is the number used to compute the memory limit from the memory request.
+	// When setting default limit, make sure max VPA limit won't go higher than available RAM!
+	// because limit grows proportionnaly to requests, and here we compute max requests
+	// So check that [MaxMemory factor]*PrometheusMemoryLimitCoefficient < 1 (100% node memory)
+	// for instance, 0.8*1.2 = 0.96 => OK.
 	PrometheusMemoryLimitCoefficient      float64 = 1.2
 	PrometheusMetaOperatorRemoteWriteName string  = "prometheus-meta-operator"
 	PrometheusServiceName                         = "prometheus-operated"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/25767

Memory limit could go up to 108% of node's memory. And memory exhaustion on node leads to killing node.
This change in codes makes:
* max requests reduced from 90% to 80% node memory
* max limit reduced from 108% to 96% node memory

Maybe we should restrict even more to avoid nodes being killed, but I don't want to go too fast. Step by step.

Also, removed VPA config for `prometheus-config-reloader` and `rules-configmap-reloader`: these containers don't exist, so this config has no effect.
On top of that, we actually have a `config-reloader` container, which is scaled down with default VPA config, and it works well like that.

BTW, found and fixed a bug when our computed maxmemory would give a non-round number of bytes, and VPA did not like!
=> CPU can (should) be float
=> RAM must be int

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
