### PR TITLE
simplified and fixed mem limit calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- simplified and fixed mem limit calculation to actually do what the comments say - will result in higher mem limits.
+- VPA settings: changes in 4.24.0 were wrong, resulting in too low limits.
+    - Previous logic (4.23.0) was right, and limits were 90% node size.
+    - Comments have been updated for better understanding
+    - limit has been reverted to 90% node size
+    - code for CPU limits has been updated to do the same kind of calculations
+    - tests have been updated for more meaningful results
 
 ## [4.24.0] - 2023-03-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- simplified and fixed mem limit calculation to actually do what the comments say - will result in higher mem limits.
+
 ## [4.24.0] - 2023-03-02
 
 ### Changed

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -204,11 +204,6 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(err)
 	}
 
-	q, err = quantityMultiply(q, 1/key.PrometheusMemoryLimitCoefficient)
-	if err != nil {
-		return nil, microerror.Mask(err)
-	}
-
 	// Memory must be a whole number of bytes
 	q.Set(int64(q.AsApproximateFloat64()))
 	if err != nil {

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -166,7 +166,14 @@ func (r *Resource) getMaxCPU(nodes *v1.NodeList) (*resource.Quantity, error) {
 		return nil, microerror.Mask(nodeCpuNotFoundError)
 	}
 
-	q, err := quantityMultiply(nodeCpu, 0.5)
+	// set max CPU to 75% node CPU.
+	q, err := quantityMultiply(nodeCpu, 0.75)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Scale down MaxCPU for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than xx% of node's available CPU.
+	q, err = quantityMultiply(q, 1/key.PrometheusCPULimitCoefficient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -195,11 +202,14 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(nodeMemoryNotFoundError)
 	}
 
-	// set max `requests` RAM to 80% node RAM.
-	// When setting default limit, make sure max VPA limit won't go higher than available RAM!
-	// because limit grows proportionnaly to requests, and here we compute max requests
-	// So check that PrometheusMemoryLimitCoefficient*MaxMemory < node memory
-	q, err := quantityMultiply(nodeMemory, 0.8)
+	// set max RAM to 90% node RAM.
+	q, err := quantityMultiply(nodeMemory, 0.9)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	// Scale down MaxMemory for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than xx% of node's available memory.
+	q, err = quantityMultiply(q, 1/key.PrometheusMemoryLimitCoefficient)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -166,13 +166,13 @@ func (r *Resource) getMaxCPU(nodes *v1.NodeList) (*resource.Quantity, error) {
 		return nil, microerror.Mask(nodeCpuNotFoundError)
 	}
 
-	// set max CPU to 75% node CPU.
+	// set max CPU (cpu limit) to 75% node CPU.
 	q, err := quantityMultiply(nodeCpu, 0.75)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	// Scale down MaxCPU for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than xx% of node's available CPU.
+	// Scale down MaxCPU for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than 75% of node's available CPU in that case.
 	q, err = quantityMultiply(q, 1/key.PrometheusCPULimitCoefficient)
 	if err != nil {
 		return nil, microerror.Mask(err)
@@ -202,13 +202,13 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(nodeMemoryNotFoundError)
 	}
 
-	// set max RAM to 90% node RAM.
+	// set max RAM (memory limit) to 90% node RAM.
 	q, err := quantityMultiply(nodeMemory, 0.9)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	// Scale down MaxMemory for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than xx% of node's available memory.
+	// Scale down MaxMemory for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than 90% of node's available memory in that case.
 	q, err = quantityMultiply(q, 1/key.PrometheusMemoryLimitCoefficient)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource_test.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource_test.go
@@ -42,7 +42,7 @@ func TestVerticalPodAutoScaler(t *testing.T) {
 			Status: v1.NodeStatus{
 				Allocatable: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("8"),
-					v1.ResourceMemory: resource.MustParse("10"),
+					v1.ResourceMemory: resource.MustParse("16Gi"),
 				},
 			},
 		}

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "8"
+        memory: 12Gi
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "6"
+        memory: "8"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "8"
+        memory: 12Gi
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "6"
+        memory: "8"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "8"
+        memory: 12Gi
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "6"
+        memory: "8"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "8"
+        memory: 12Gi
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "6"
+        memory: "8"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "8"
+        memory: 12Gi
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "6"
+        memory: "8"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -25,11 +25,11 @@ const (
 	OrganizationLabel    string = "giantswarm.io/organization"
 	ServicePriorityLabel string = "giantswarm.io/service-priority"
 	TeamLabel            string = "application.giantswarm.io/team"
+	// PrometheusCPULimitCoefficient is the number used to compute the CPU limit from the CPU request.
+	// It is used when computing VPA settings, to set a max requests that will result in some max limits respecting MaxCPU factor
+	PrometheusCPULimitCoefficient float64 = 1.5
 	// PrometheusMemoryLimitCoefficient is the number used to compute the memory limit from the memory request.
-	// When setting default limit, make sure max VPA limit won't go higher than available RAM!
-	// because limit grows proportionnaly to requests, and here we compute max requests
-	// So check that [MaxMemory factor]*PrometheusMemoryLimitCoefficient < 1 (100% node memory)
-	// for instance, 0.8*1.2 = 0.96 => OK.
+	// It is used when computing VPA settings, to set a max requests that will result in some max limits respecting MaxMemory factor
 	PrometheusMemoryLimitCoefficient      float64 = 1.2
 	PrometheusMetaOperatorRemoteWriteName string  = "prometheus-meta-operator"
 	PrometheusServiceName                         = "prometheus-operated"
@@ -193,7 +193,12 @@ func PrometheusDefaultCPU() *resource.Quantity {
 }
 
 func PrometheusDefaultCPULimit() *resource.Quantity {
-	return resource.NewMilliQuantity(100*1.5, resource.DecimalSI)
+	return resource.NewMilliQuantity(
+		int64(math.Floor(
+			100*PrometheusCPULimitCoefficient,
+		)),
+		resource.DecimalSI,
+	)
 }
 
 func PrometheusDefaultMemory() *resource.Quantity {

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -26,10 +26,10 @@ const (
 	ServicePriorityLabel string = "giantswarm.io/service-priority"
 	TeamLabel            string = "application.giantswarm.io/team"
 	// PrometheusCPULimitCoefficient is the number used to compute the CPU limit from the CPU request.
-	// It is used when computing VPA settings, to set a max requests that will result in some max limits respecting MaxCPU factor
+	// It is used when computing VPA settings, to set `max requests` so that `max limits` respects MaxCPU factor.
 	PrometheusCPULimitCoefficient float64 = 1.5
 	// PrometheusMemoryLimitCoefficient is the number used to compute the memory limit from the memory request.
-	// It is used when computing VPA settings, to set a max requests that will result in some max limits respecting MaxMemory factor
+	// It is used when computing VPA settings, to set `max request` so that `max limits` respect MaxMemory factor.
 	PrometheusMemoryLimitCoefficient      float64 = 1.2
 	PrometheusMetaOperatorRemoteWriteName string  = "prometheus-meta-operator"
 	PrometheusServiceName                         = "prometheus-operated"


### PR DESCRIPTION

VPA settings: changes in 4.24.0 were wrong, resulting in too low limits.
    - Previous logic (4.23.0) was right, and limits were 90% node size.
    - Comments have been updated for better understanding
    - limit has been reverted to 90% node size
    - code for CPU limits has been updated to do the same kind of calculations
    - tests have been updated for more meaningful results
 
Towards https://github.com/giantswarm/giantswarm/issues/26142

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
