### PR TITLE
Updated RetentionSize property in Prometheus CR according to Volume Storage Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated `RetentionSize` property in Prometheus CR according to Volume Storage Size (90%)
+
 ## [4.24.1] - 2023-03-09
 
 ### Changed

--- a/pkg/pvcresizing/pvc.go
+++ b/pkg/pvcresizing/pvc.go
@@ -1,9 +1,14 @@
 package pvcresizing
 
+import "strconv"
+
 const (
 	PrometheusStorageSizeSmall  PrometheusStorageSizeType = "small"
 	PrometheusStorageSizeMedium PrometheusStorageSizeType = "medium"
 	PrometheusStorageSizeLarge  PrometheusStorageSizeType = "large"
+
+	// We apply a ratio to the volume storage size to compute the RetentionSize property (RetentionSize = 90% volume storage size)
+	VOLUME_STORAGE_LIMIT = 0.9
 )
 
 type PrometheusStorageSizeType string
@@ -20,4 +25,9 @@ func PrometheusVolumeSize(annotationValue string) string {
 	default:
 		return "100Gi"
 	}
+}
+
+func GetRetentionSize(storageSize float64) string {
+	// Set Retention.Size (TSDB limit) to a ratio of the volume storage size.
+	return strconv.FormatInt(int64(storageSize*VOLUME_STORAGE_LIMIT), 10)
 }

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -245,7 +245,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 
 			EvaluationInterval: promv1.Duration(config.EvaluationInterval),
 			Retention:          promv1.Duration(config.RetentionDuration),
-			RetentionSize:      promv1.ByteSize(config.RetentionSize),
+			RetentionSize:      promv1.ByteSize(pvcresizing.GetRetentionSize(storageSize.AsApproximateFloat64())),
 			// Fetches Prometheus rules from any namespace on the Management Cluster
 			// using https://v1-22.docs.kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name
 			RuleNamespaceSelector: &metav1.LabelSelector{

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 45Gi
+  retentionSize: "96636764160"
   routePrefix: /alice
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 45Gi
+  retentionSize: "96636764160"
   routePrefix: /foo
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 45Gi
+  retentionSize: "96636764160"
   routePrefix: /bar
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -68,7 +68,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 45Gi
+  retentionSize: "96636764160"
   routePrefix: /kubernetes
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 45Gi
+  retentionSize: "96636764160"
   routePrefix: /baz
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/pvcresizingresource/resource.go
+++ b/service/controller/resource/monitoring/pvcresizingresource/resource.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/micrologger"
+	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 )
 
 const (
@@ -12,19 +13,22 @@ const (
 )
 
 type Config struct {
-	K8sClient k8sclient.Interface
-	Logger    micrologger.Logger
+	K8sClient        k8sclient.Interface
+	PrometheusClient promclient.Interface
+	Logger           micrologger.Logger
 }
 
 type Resource struct {
-	k8sClient k8sclient.Interface
-	logger    micrologger.Logger
+	k8sClient  k8sclient.Interface
+	promClient promclient.Interface
+	logger     micrologger.Logger
 }
 
 func New(config Config) (*Resource, error) {
 	r := &Resource{
-		k8sClient: config.K8sClient,
-		logger:    config.Logger,
+		k8sClient:  config.K8sClient,
+		promClient: config.PrometheusClient,
+		logger:     config.Logger,
 	}
 
 	return r, nil


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/26041

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`

## How to test it

- [ ] Check RetentionSize property on all Prometheus CR => must be equal to 90% of the volume storage size (pvc)
- [ ] Update the volume storage size by updating the annotation in Cluster CR `monitoring.giantswarm.io/prometheus-volume-size` and check the RetentionSize is updated
