### PR TITLE
allow ownership job to fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Updated `RetentionSize` property in Prometheus CR according to Volume Storage Size (90%)
+- Allow ownership job patch `alertmanagerConfigSelector` to fail in case the label has been already removed.
 
 ## [4.25.1] - 2023-03-14
 

--- a/helm/prometheus-meta-operator/templates/alertmanager/ownership-job/job.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/ownership-job/job.yaml
@@ -39,6 +39,6 @@ spec:
               name=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-meta-operator --output=jsonpath="{.items[0].spec.name}")
               namespace=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-meta-operator --output=jsonpath="{.items[0].spec.namespace}")
               kubectl patch --type=merge --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "'"${name}"'","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' -n "${namespace}" alertmanager alertmanager
-              kubectl patch --record=false -n "${namespace}" --type json --patch '[{ "op": "remove", "path": "/spec/alertmanagerConfigSelector/matchLabels/app.kubernetes.io~1managed-by", "value": "prometheus-meta-operator" }]' alertmanager alertmanager
+              kubectl patch --record=false -n "${namespace}" --type json --patch '[{ "op": "remove", "path": "/spec/alertmanagerConfigSelector/matchLabels/app.kubernetes.io~1managed-by", "value": "prometheus-meta-operator" }]' alertmanager alertmanager || true
       restartPolicy: Never
   backoffLimit: 4

--- a/helm/prometheus-meta-operator/templates/alertmanager/ownership-job/job.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/ownership-job/job.yaml
@@ -39,6 +39,7 @@ spec:
               name=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-meta-operator --output=jsonpath="{.items[0].spec.name}")
               namespace=$(kubectl get chart --namespace=giantswarm -l app.kubernetes.io/name=prometheus-meta-operator --output=jsonpath="{.items[0].spec.namespace}")
               kubectl patch --type=merge --record=false -p '{"metadata":{"annotations":{"meta.helm.sh/release-name": "'"${name}"'","meta.helm.sh/release-namespace": "'"${namespace}"'"},"labels":{"app.kubernetes.io/managed-by": "Helm"}}}' -n "${namespace}" alertmanager alertmanager
-              kubectl patch --record=false -n "${namespace}" --type json --patch '[{ "op": "remove", "path": "/spec/alertmanagerConfigSelector/matchLabels/app.kubernetes.io~1managed-by", "value": "prometheus-meta-operator" }]' alertmanager alertmanager || true
+              managedByLabel=$(kubectl get alertmanager -n "${namespace}" alertmanager -o=jsonpath='{.spec.alertmanagerConfigSelector.matchLabels.app\.kubernetes\.io/managed-by}')
+              [ "$managedByLabel" == "prometheus-meta-operator" ] && kubectl patch --record=false -n "${namespace}" --type json --patch '[{ "op": "remove", "path": "/spec/alertmanagerConfigSelector/matchLabels/app.kubernetes.io~1managed-by", "value": "prometheus-meta-operator" }]' alertmanager alertmanager
       restartPolicy: Never
   backoffLimit: 4


### PR DESCRIPTION
The job also patch the Alertmanager resource to removes the label `managed-by: pmo `
from `alertmanagerConfigSelector`.

If the field doesn't has the label, the job will fail. so deployment will be stuck