### PR TITLE
Prometheus TSDB size: reduce it to 85% of disk space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Prometheus resources: set requests=limits. Still allowing prometheus up to 90% of node capacity.
+- Prometheus TSDB size: reduce it to 85% of disk space, to keep space for WAL before alerts fire.
 
 ## [4.25.3] - 2023-03-15
 

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 90GiB
+  retentionSize: 85GiB
   routePrefix: /alice
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 90GiB
+  retentionSize: 85GiB
   routePrefix: /foo
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 90GiB
+  retentionSize: 85GiB
   routePrefix: /bar
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -68,7 +68,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 90GiB
+  retentionSize: 85GiB
   routePrefix: /kubernetes
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -63,7 +63,7 @@ spec:
       cpu: 100m
       memory: "1073741824"
   retention: 2w
-  retentionSize: 90GiB
+  retentionSize: 85GiB
   routePrefix: /baz
   ruleNamespaceSelector:
     matchExpressions:

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -40,7 +40,7 @@ const (
 	// PrometheusVolumeSizeAnnotation is the annotation referenced in the Cluster CR to define the size of Prometheus Volume.
 	PrometheusVolumeSizeAnnotation string = "monitoring.giantswarm.io/prometheus-volume-size"
 	// We apply a ratio to the volume storage size to compute the RetentionSize property (RetentionSize = 90% volume storage size)
-	PrometheusVolumeStorageLimitRatio = 0.9
+	PrometheusVolumeStorageLimitRatio = 0.85
 
 	ClusterIDKey       string = "cluster_id"
 	ClusterTypeKey     string = "cluster_type"


### PR DESCRIPTION
Prometheus TSDB size: reduce it to 85% of disk space, to keep space for WAL before alerts fire.

Towards https://github.com/giantswarm/giantswarm/issues/26041

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
