### PR TITLE
Prometheus-agent tuning: increase maxSamplesPerSend from 50000 to 150000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Prometheus resources: set requests=limits. Still allowing prometheus up to 90% of node capacity.
 - Prometheus TSDB size: reduce it to 85% of disk space, to keep space for WAL before alerts fire.
+- Prometheus-agent tuning: increase maxSamplesPerSend from 50000 to 150000
 
 ## [4.25.3] - 2023-03-15
 

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -167,7 +167,7 @@ func toSecret(ctx context.Context, v interface{}, config Config) (*corev1.Secret
 func defaultQueueConfig() promv1.QueueConfig {
 	return promv1.QueueConfig{
 		Capacity:          30000,
-		MaxSamplesPerSend: 50000,
+		MaxSamplesPerSend: 150000,
 		MaxShards:         10,
 	}
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26288

Better performance for prometheus-agent, less lagging behind sending metrics.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
