### PR TITLE
Remove remote write immutable secret deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.27.0] - 2023-03-22
+### Removed
+
+- Remove immutable secret deletion not needed after 4.27.0.
 
 ## [4.27.0] - 2023-03-22
 
@@ -1970,7 +1972,6 @@ This release was created on release-v3.5.x branch to fix release 3.6.0 see PR#99
 
 [Unreleased]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.27.0...HEAD
 [4.27.0]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.27.0...v4.27.0
-[4.27.0]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.26.0...v4.27.0
 [4.26.0]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.25.3...v4.26.0
 [4.25.3]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.25.2...v4.25.3
 [4.25.2]: https://github.com/giantswarm/prometheus-meta-operator/compare/v4.25.1...v4.25.2

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
@@ -36,20 +36,6 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if current != nil {
-			// We thought that having an immutable secret would be a good thing as the remote write password cannot be changed (causing remote write errors)
-			// However, this causes a lot of issues if we want to update the other configurations like the queue config.
-			// Hence if the secret is immutable, we force delete it to create a non-immutable one
-			if current.Immutable != nil && *current.Immutable {
-				err = r.deleteSecret(ctx, current)
-				if err != nil {
-					return microerror.Mask(err)
-				}
-				err = r.createSecret(ctx, cluster, name, namespace)
-				if err != nil {
-					return microerror.Mask(err)
-				}
-			}
-
 			// As it takes a long time to apply the new password to the agent due to a built-in delay in the app-platform,
 			// we keep the already generated remote write password.
 			password, err := readRemoteWritePasswordFromSecret(*current)


### PR DESCRIPTION
4.27.0 was released and kicked out all immutable secrets.

Code can now be removed

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
