### PR TITLE
Remove pod_id label from node-exporter targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Removed pod_id relabelling as it's not needed anymore.
+
 ## [4.29.0] - 2023-03-27
 
 ### Changed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -462,12 +462,6 @@
   - source_labels: [__meta_kubernetes_pod_node_name]
     target_label: node
 [[ include "_labelingschema" . | indent 2 ]]
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: [[ .ClusterID ]]-prometheus/workload-[[ .ClusterID ]]/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -809,12 +809,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -647,12 +647,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -809,12 +809,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -644,12 +644,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -647,12 +647,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -582,12 +582,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -586,12 +586,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -582,12 +582,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -532,12 +532,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -586,12 +586,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -532,12 +532,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -532,12 +532,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -586,12 +586,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -532,12 +532,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -582,12 +582,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -586,12 +586,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -582,12 +582,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: alice-prometheus/workload-alice/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: foo-prometheus/workload-foo/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -744,12 +744,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: bar-prometheus/workload-bar/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -586,12 +586,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: kubernetes-prometheus/workload-kubernetes/0
   honor_labels: true
   scheme: https

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -532,12 +532,6 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
-  metric_relabel_configs:
-  - source_labels: [mountpoint]
-    target_label: pod_id
-    regex: /var/lib/kubelet/pods/([a-zA-Z0-9-]+)/.*
-    action: replace
-    replacement: $1
 - job_name: baz-prometheus/workload-baz/0
   honor_labels: true
   scheme: https


### PR DESCRIPTION
Removing useless label. Cardinality will not change because this value was extracted from the mountpoint but let's clean up

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
