### PR TITLE
Prometheus remotewrite endpoints for agents: increase max body size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prometheus remotewrite endpoints for agents: increase max body size from 10m to 50m
+
 ### Removed
 
 - Removed pod_id relabelling as it's not needed anymore.

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-1-awsconfig.golden
@@ -5,8 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: alice

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-2-azureconfig.golden
@@ -5,8 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: foo

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-3-kvmconfig.golden
@@ -5,8 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: bar

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-4-control-plane.golden
@@ -5,8 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubernetes

--- a/service/controller/resource/monitoring/remotewriteingress/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/case-5-cluster-api-v1alpha3.golden
@@ -5,8 +5,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: baz

--- a/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-1-awsconfig.golden
@@ -7,8 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: alice

--- a/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-2-azureconfig.golden
@@ -7,8 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: foo

--- a/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-3-kvmconfig.golden
@@ -7,8 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: bar

--- a/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-4-control-plane.golden
@@ -7,8 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: kubernetes

--- a/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/remotewriteingress/test/externaldns/case-5-cluster-api-v1alpha3.golden
@@ -7,8 +7,8 @@ metadata:
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: remote-write-ingress-auth
     nginx.ingress.kubernetes.io/auth-type: basic
-    nginx.ingress.kubernetes.io/client-body-buffer-size: 10m
-    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+    nginx.ingress.kubernetes.io/client-body-buffer-size: 50m
+    nginx.ingress.kubernetes.io/proxy-body-size: 50m
   creationTimestamp: null
   labels:
     app.kubernetes.io/instance: baz

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -155,9 +155,9 @@ func RemoteWriteAuthenticationAnnotations(baseDomain string, externalDNS bool) m
 		"nginx.ingress.kubernetes.io/auth-secret": RemoteWriteIngressAuthSecretName,
 		"nginx.ingress.kubernetes.io/auth-realm":  "Authentication Required",
 		// Set this annotation to avoid using a temporary buffer file for remote write requests
-		"nginx.ingress.kubernetes.io/client-body-buffer-size": "10m",
+		"nginx.ingress.kubernetes.io/client-body-buffer-size": "50m",
 		// Remote write requests can be quite big. (default max body size: 1m)
-		"nginx.ingress.kubernetes.io/proxy-body-size": "10m",
+		"nginx.ingress.kubernetes.io/proxy-body-size": "50m",
 	}
 
 	// create external-dns required annotations


### PR DESCRIPTION
Prometheus remotewrite endpoints for agents: increase max body size from 10m to 50m.
Needed because with latest prometheus-agent tuning of `maxsamplespersend` some clusters get failed sends because they're too big.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
