### PR TITLE
Set memory limit to 80% of node size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- VPA settings: set memory limit to 80% node size
+
 ## [4.29.1] - 2023-03-27
 
 ### Changed

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -202,13 +202,13 @@ func (r *Resource) getMaxMemory(nodes *v1.NodeList) (*resource.Quantity, error) 
 		return nil, microerror.Mask(nodeMemoryNotFoundError)
 	}
 
-	// set max RAM (memory limit) to 90% node RAM.
-	q, err := quantityMultiply(nodeMemory, 0.9)
+	// set max RAM (memory limit) to 80% node RAM.
+	q, err := quantityMultiply(nodeMemory, 0.8)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
 
-	// Scale down MaxMemory for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than 90% of node's available memory in that case.
+	// Scale down MaxMemory for VPA to take into account the fact that it sets VPA `requests`, and we want the `limit` to be no more than 80% of node's available memory in that case.
 	q, err = quantityMultiply(q, 1/key.PrometheusMemoryLimitCoefficient)
 	if err != nil {
 		return nil, microerror.Mask(err)

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "15461882265"
+        memory: "13743895347"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "15461882265"
+        memory: "13743895347"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "15461882265"
+        memory: "13743895347"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "15461882265"
+        memory: "13743895347"
       minAllowed:
         cpu: 100m
         memory: "1073741824"

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -14,7 +14,7 @@ spec:
       controlledValues: RequestsAndLimits
       maxAllowed:
         cpu: "4"
-        memory: "15461882265"
+        memory: "13743895347"
       minAllowed:
         cpu: 100m
         memory: "1073741824"


### PR DESCRIPTION
Reducing the memory limit to 80% of node size following many incident with node crashes.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
