### PR TITLE
Drop a hefty number of unused metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Drop `coredns_dns_response_size_bytes_bucket` and `coredns_dns_request_size_bytes_bucket` from coredns metrics.
 - Drop `nginx_ingress_controller_connect_duration_seconds_bucket` `nginx_ingress_controller_header_duration_seconds_bucket` `nginx_ingress_controller_bytes_sent_count` `nginx_ingress_controller_request_duration_seconds_sum` from nginx-ingress-controller metrics.
 - Drop `kong_upstream_target_health` and `kong_latency_bucket` Kong metrics.
-- Drop `kube_pod_tolerations` `kube_pod_status_reason` `kube_pod_status_scheduled` `kube_replicaset_metadata_generation` `kube_replicaset_status_observed_generation` `kube_replicaset_annotations` and`kube_replicaset_status_fully_labeled_replicas` kube-state-metrics metrics.
+- Drop `kube_pod_tolerations` `kube_pod_status_scheduled` `kube_replicaset_metadata_generation` `kube_replicaset_status_observed_generation` `kube_replicaset_annotations` and`kube_replicaset_status_fully_labeled_replicas` kube-state-metrics metrics.
 - Drop `promtail_request_duration_seconds_bucket` and `loki_request_duration_seconds_bucket` metrics from promtail and loki.
 
 ## [4.30.0] - 2023-03-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Drop `rest_client_rate_limiter_duration_seconds_bucket` `rest_client_request_size_bytes_bucket` `rest_client_response_size_bytes_bucket` from Kubernetes component metrics.
+- Drop `coredns_dns_response_size_bytes_bucket` and `coredns_dns_request_size_bytes_bucket` from coredns metrics.
+- Drop `nginx_ingress_controller_connect_duration_seconds_bucket` `nginx_ingress_controller_header_duration_seconds_bucket` `nginx_ingress_controller_bytes_sent_count` `nginx_ingress_controller_request_duration_seconds_sum` from nginx-ingress-controller metrics.
+- Drop `kong_upstream_target_health` and `kong_latency_bucket` Kong metrics.
+- Drop `kube_pod_tolerations` `kube_pod_status_reason` `kube_pod_status_scheduled` `kube_replicaset_metadata_generation` `kube_replicaset_status_observed_generation` `kube_replicaset_annotations` and`kube_replicaset_status_fully_labeled_replicas` kube-state-metrics metrics.
+- Drop `promtail_request_duration_seconds_bucket` and `loki_request_duration_seconds_bucket` metrics from promtail and loki.
+
 ## [4.30.0] - 2023-03-28
 
 ### Removed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -259,6 +259,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -312,6 +313,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 [[- end ]]
 [[- if not (contains "kube-scheduler" .IgnoredTargets) ]]
 # kube-scheduler
@@ -363,6 +365,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 [[- end ]]
 # kube-proxy
 - job_name: [[ .ClusterID ]]-prometheus/kube-proxy-[[ .ClusterID ]]/0
@@ -396,6 +399,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: [[ .ClusterID ]]-prometheus/coredns-[[ .ClusterID ]]/0
   honor_labels: true
@@ -553,14 +557,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -256,6 +256,9 @@
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -305,6 +308,10 @@
     replacement: kube-controller-manager
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 [[- end ]]
 [[- if not (contains "kube-scheduler" .IgnoredTargets) ]]
 # kube-scheduler
@@ -352,6 +359,10 @@
     replacement: kube-scheduler
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 [[- end ]]
 # kube-proxy
 - job_name: [[ .ClusterID ]]-prometheus/kube-proxy-[[ .ClusterID ]]/0
@@ -381,6 +392,10 @@
     replacement: kube-proxy
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: [[ .ClusterID ]]-prometheus/coredns-[[ .ClusterID ]]/0
   honor_labels: true
@@ -411,6 +426,11 @@
     action: drop
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: [[ .ClusterID ]]-prometheus/cert-exporter-[[ .ClusterID ]]/0
   honor_labels: true
@@ -523,10 +543,24 @@
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1153,6 +1187,11 @@
     action: drop
 [[ include "_labelingschema" . | indent 2 ]]
 [[ include "_node_role" . | indent 2 ]]
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 [[ end ]]
 # prometheus
 - job_name: [[ .ClusterID ]]-prometheus/prometheus-[[ .ClusterID ]]/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -378,6 +378,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -466,6 +467,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -551,6 +553,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -627,6 +630,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -944,14 +948,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-1-awsconfig.golden
@@ -375,6 +375,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -459,6 +462,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -540,6 +547,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -612,6 +623,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -686,6 +701,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -914,10 +934,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -375,6 +375,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -450,6 +453,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -524,6 +531,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -752,10 +764,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-2-azureconfig.golden
@@ -378,6 +378,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -457,6 +458,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -774,14 +776,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -378,6 +378,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -466,6 +467,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -551,6 +553,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -627,6 +630,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -944,14 +948,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-3-kvmconfig.golden
@@ -375,6 +375,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -459,6 +462,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -540,6 +547,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -612,6 +623,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -686,6 +701,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -914,10 +934,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -403,6 +403,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -475,6 +476,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -764,14 +766,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -400,6 +400,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -468,6 +471,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -535,6 +542,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -742,10 +754,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1650,6 +1676,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -375,6 +375,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -450,6 +453,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -524,6 +531,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -752,10 +764,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-cluster-api-v1alpha3.golden
@@ -378,6 +378,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -457,6 +458,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -774,14 +776,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-1-awsconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -380,6 +383,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -454,6 +461,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -682,10 +694,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-2-azureconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -387,6 +388,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -704,14 +706,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-3-kvmconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -337,6 +337,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -405,6 +408,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -472,6 +479,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -679,10 +691,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1587,6 +1613,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -340,6 +340,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -412,6 +413,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -701,14 +703,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -380,6 +383,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -454,6 +461,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -682,10 +694,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-cluster-api-v1alpha3.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -387,6 +388,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -704,14 +706,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -258,6 +258,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -337,6 +338,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -654,14 +656,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-1-awsconfig.golden
@@ -255,6 +255,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -330,6 +333,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -404,6 +411,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -632,10 +644,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-2-azureconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-3-kvmconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -340,6 +340,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -412,6 +413,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -701,14 +703,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -337,6 +337,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -405,6 +408,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -472,6 +479,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -679,10 +691,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1602,6 +1628,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -255,6 +255,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -330,6 +333,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -404,6 +411,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -632,10 +644,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -258,6 +258,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -337,6 +338,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -654,14 +656,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -258,6 +258,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -337,6 +338,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -654,14 +656,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-1-awsconfig.golden
@@ -255,6 +255,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -330,6 +333,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -404,6 +411,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -632,10 +644,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-azureconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-kvmconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -340,6 +340,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -412,6 +413,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -701,14 +703,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -337,6 +337,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -405,6 +408,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -472,6 +479,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -679,10 +691,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1602,6 +1628,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -255,6 +255,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -330,6 +333,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -404,6 +411,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -632,10 +644,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -258,6 +258,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -337,6 +338,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -654,14 +656,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-1-awsconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -380,6 +383,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -454,6 +461,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -682,10 +694,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-2-azureconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -387,6 +388,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -704,14 +706,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-3-kvmconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -340,6 +340,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -412,6 +413,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -701,14 +703,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -337,6 +337,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -405,6 +408,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -472,6 +479,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -679,10 +691,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1812,6 +1838,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -380,6 +383,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -454,6 +461,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -682,10 +694,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-5-cluster-api-v1alpha3.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -387,6 +388,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -704,14 +706,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-1-awsconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: alice-prometheus/kubernetes-scheduler-alice/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: alice-prometheus/kube-proxy-alice/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: alice-prometheus/coredns-alice/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: alice-prometheus/cert-exporter-alice/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-azureconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: foo-prometheus/kubernetes-scheduler-foo/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: foo-prometheus/kube-proxy-foo/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: foo-prometheus/coredns-foo/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: foo-prometheus/cert-exporter-foo/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -308,6 +308,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -396,6 +397,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -481,6 +483,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -557,6 +560,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -874,14 +878,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-kvmconfig.golden
@@ -305,6 +305,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -389,6 +392,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-scheduler
 - job_name: bar-prometheus/kubernetes-scheduler-bar/0
   honor_labels: true
@@ -470,6 +477,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # kube-proxy
 - job_name: bar-prometheus/kube-proxy-bar/0
   honor_labels: true
@@ -542,6 +553,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: bar-prometheus/coredns-bar/0
   honor_labels: true
@@ -616,6 +631,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: bar-prometheus/cert-exporter-bar/0
   honor_labels: true
@@ -844,10 +864,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -340,6 +340,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -412,6 +413,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -701,14 +703,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -337,6 +337,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -405,6 +408,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: kubernetes-prometheus/coredns-kubernetes/0
   honor_labels: true
@@ -472,6 +479,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: kubernetes-prometheus/cert-exporter-kubernetes/0
   honor_labels: true
@@ -679,10 +691,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;
@@ -1602,6 +1628,11 @@
   # Add role label.
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
+  metric_relabel_configs:
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
+    action: drop
 
 # prometheus
 - job_name: kubernetes-prometheus/prometheus-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -255,6 +255,9 @@
   - source_labels: [__meta_kubernetes_node_label_role]
     target_label: role
   metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -330,6 +333,10 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -404,6 +411,11 @@
   # Add customer label.
   - target_label: customer
     replacement: pmo
+  metric_relabel_configs:
+  # drop unused coredns metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: coredns_dns_(response_size_bytes_bucket|request_size_bytes_bucket)
+    action: drop
 # cert-exporter
 - job_name: baz-prometheus/cert-exporter-baz/0
   honor_labels: true
@@ -632,10 +644,24 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
-  # drop metrics with the highest cardinality as they increase Prometheus memory usage
+  # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: (nginx_ingress_controller_bytes_sent_bucket|nginx_ingress_controller_request_size_bucket|nginx_ingress_controller_response_duration_seconds_bucket|nginx_ingress_controller_response_size_bucket)
+    regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum)
     action: drop
+  # drop unused kong metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kong_(upstream_target_health|latency_bucket)
+    action: drop
+  # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
+  - source_labels: [__name__]
+    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    action: drop
+  # drop unused promtail/loki metrics
+  - source_labels: [__name__]
+    regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+  # drop unused rest client metrics
+  - source_labels: [__name__]
+    regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -258,6 +258,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kubelet
   - action: labeldrop
     regex: uid
@@ -337,6 +338,7 @@
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
 # coredns
 - job_name: baz-prometheus/coredns-baz/0
   honor_labels: true
@@ -654,14 +656,16 @@
     action: drop
   # drop unused kube-state-metrics metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
-    regex: kube_(pod_tolerations|pod_status_reason|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
+    regex: kube_(pod_tolerations|pod_status_scheduled|replicaset_metadata_generation|replicaset_status_observed_generation|replicaset_annotations|replicaset_status_fully_labeled_replicas)
     action: drop
   # drop unused promtail/loki metrics
   - source_labels: [__name__]
     regex: promtail_request_duration_seconds_bucket|loki_request_duration_seconds_bucket
+    action: drop
   # drop unused rest client metrics
   - source_labels: [__name__]
     regex: rest_client_(rate_limiter_duration_seconds_bucket|request_size_bytes_bucket|response_size_bytes_bucket)
+    action: drop
   # drop uid label from kube-state-metrics
   - source_labels: [app,uid]
     separator: ;


### PR DESCRIPTION
Towards Prometheus Stability (https://github.com/giantswarm/giantswarm/issues/25937), this PR drops some of the most scraped metrics that are currently unused. This should hopefully give us some leeway

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
