### PR TITLE
Revert maxSamplesPerSend to 150000

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Prometheus-agent tuning: revert maxSamplesPerSend to 150000
+
 ## [4.31.0] - 2023-03-28
 
 ### Removed

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -167,7 +167,7 @@ func (r *Resource) deleteSecret(ctx context.Context, secret *corev1.Secret) erro
 func defaultQueueConfig() promv1.QueueConfig {
 	return promv1.QueueConfig{
 		Capacity:          30000,
-		MaxSamplesPerSend: 300000,
+		MaxSamplesPerSend: 150000,
 		MaxShards:         10,
 	}
 }


### PR DESCRIPTION
Prometheus-agent: Revert maxSamplesPerSend to 150000 as we suspect it overloads Prometheis and may be the cause of crashes.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
