### PR TITLE
Add loki namespace to cadvisor on MC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `loki` namespace in cAdvisor scrape config for MC.
+
 ## [4.33.0] - 2023-04-04
 
 ### Changed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -99,7 +99,7 @@
     action: drop
 [[- if eq .ClusterType "management_cluster" ]]
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 [[- else ]]
   - source_labels: [namespace]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -162,7 +162,7 @@
     regex: container_(blkio_device_usage_total|network_transmit_errors_total|network_receive_errors_total|tasks_state|memory_failures_total|memory_max_usage_bytes|cpu_load_average_10s|memory_failcnt|cpu_system_seconds_total)
     action: drop
   - source_labels: [namespace]
-    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno)
+    regex: (kube-system|giantswarm.*|.*-prometheus|monitoring|flux-.*|kyverno|loki)
     action: keep
 # calico-node
 - job_name: kubernetes-prometheus/calico-node-kubernetes/0


### PR DESCRIPTION
towards https://github.com/giantswarm/roadmap/issues/2182

In order to have cAdvisor metrics on loki pods, we have to scrape the `loki` namespace.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
