### PR TITLE
Allow secret patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow PMO to patch secrets so it can remove finalizers.
+
 ## [4.35.1] - 2023-04-12
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -33,6 +33,7 @@ rules:
       - secrets
     verbs:
       - create
+      - patch # Needed to remove a finalizer
       - update # Needed to update the additionalScrapeConfigs
       - delete
       - deletecollection


### PR DESCRIPTION
We added finalizers on a PMO secret that we patch out with PMO but PMO is not autorized to patch secret


## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
