### PR TITLE
Only route page and/or notify alert to Atlas slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change Atlas slack alert router to only route alerts with page and/or notify severity matcher.
+
 ## [4.35.2] - 2023-04-13
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -63,7 +63,9 @@ route:
   - receiver: team_atlas_slack
     matchers:
     [[- if eq .Pipeline "stable" ]]
-    - severity!="page"
+    - severity="notify"
+    [[- else ]]
+    - severity=~"page|notify"
     [[- end ]]
     - team="atlas"
     - type!="heartbeat"


### PR DESCRIPTION
This PR updates the Atlas slack alert routing to only route alert to slack when :

- severity=page on stable installations
- severity~=notify|page on other installations

This way we can keep some alerts in Alertmanager and not send them anywhere.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`