### PR TITLE
Remove shared app collection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,22 +80,6 @@ workflows:
               only: /^v.*/
 
       - architect/push-to-app-collection:
-          name: shared-app-collection
-          context: "architect"
-          app_name: "prometheus-meta-operator"
-          app_namespace: "monitoring"
-          app_collection_repo: "shared-app-collection"
-          requires:
-            - push-to-quay
-            - push-to-aliyun
-            - app-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-collection:
           name: aws-app-collection
           context: "architect"
           app_name: "prometheus-meta-operator"


### PR DESCRIPTION
Shared app collection is deprecated

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
