### PR TITLE
Fix Observability Bundle detection for vintage WCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change Atlas slack alert router to only route alerts with page and/or notify severity matcher.
 
+### Fixed
+
+- Fix list of ignored targets for Vintage WCs.
+
 ## [4.35.2] - 2023-04-13
 
 ### Fixed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -558,6 +558,11 @@
 [[ include "_common" . | indent 2 ]]
 [[ include "_labelingschema" . | indent 2 ]]
   metric_relabel_configs:
+  [[- if (contains "prometheus-operator-app" .IgnoredTargets) ]]
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
+  [[- end ]]
   [[- if (contains "coredns" .IgnoredTargets) ]]
   - source_labels: [app]
     regex: coredns
@@ -566,6 +571,11 @@
   [[- if (contains "kube-state-metrics" .IgnoredTargets) ]]
   - source_labels: [app]
     regex: kube-state-metrics
+    action: drop
+  [[- end ]]
+  [[- if (contains "aws-load-balancer-controller" .IgnoredTargets) ]]
+  - source_labels: [app]
+    regex: aws-load-balancer-controller
     action: drop
   [[- end ]]
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -208,10 +208,14 @@ func getObservabilityBundleAppVersion(ctx context.Context, ctrlClient client.Cli
 	appName := fmt.Sprintf("%s-observability-bundle", key.ClusterID(cluster))
 	appNamespace := cluster.GetNamespace()
 
-	if key.IsManagementCluster(config.Installation, cluster) && !key.IsCAPIManagementCluster(config.Provider) {
-		// Vintage MC
-		appName = "observability-bundle"
-		appNamespace = "giantswarm"
+	if !key.IsCAPIManagementCluster(config.Provider) {
+		if key.IsManagementCluster(config.Installation, cluster) {
+			// Vintage MC
+			appName = "observability-bundle"
+			appNamespace = "giantswarm"
+		} else {
+			appNamespace = key.ClusterID(cluster)
+		}
 	}
 
 	app := &appsv1alpha1.App{}

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -30,8 +30,6 @@ const (
 	unknownObservabilityBundleVersion = "0.0.0"
 )
 
-var kubernetesTargets = []string{"kube-apiserver", "kube-controller-manager", "kube-scheduler"}
-
 type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
@@ -260,11 +258,11 @@ func listTargetsToIgnore(ctx context.Context, ctrlClient client.Client, cluster 
 	}
 
 	if version.GTE(initialBundleVersion) {
-		ignoredTargets = append(ignoredTargets, kubernetesTargets...)
+		ignoredTargets = append(ignoredTargets, "prometheus-operator-app", "kube-apiserver", "kube-controller-manager", "kube-scheduler")
 	}
 
 	if version.GTE(bundleWithKSMAndExportersVersion) {
-		ignoredTargets = append(ignoredTargets, "kubelet", "coredns", "kube-state-metrics")
+		ignoredTargets = append(ignoredTargets, "kubelet", "coredns", "kube-state-metrics", "aws-load-balancer-controller")
 
 		if key.IsCAPIManagementCluster(config.Provider) {
 			ignoredTargets = append(ignoredTargets, "etcd")

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-control-plane.golden
@@ -450,11 +450,17 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   - source_labels: [app]
     regex: coredns
     action: drop
   - source_labels: [app]
     regex: kube-state-metrics
+    action: drop
+  - source_labels: [app]
+    regex: aws-load-balancer-controller
     action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-cluster-api-v1alpha3.golden
@@ -651,6 +651,9 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-control-plane.golden
@@ -450,11 +450,17 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   - source_labels: [app]
     regex: coredns
     action: drop
   - source_labels: [app]
     regex: kube-state-metrics
+    action: drop
+  - source_labels: [app]
+    regex: aws-load-balancer-controller
     action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-cluster-api-v1alpha3.golden
@@ -651,6 +651,9 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-control-plane.golden
@@ -450,11 +450,17 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   - source_labels: [app]
     regex: coredns
     action: drop
   - source_labels: [app]
     regex: kube-state-metrics
+    action: drop
+  - source_labels: [app]
+    regex: aws-load-balancer-controller
     action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-cluster-api-v1alpha3.golden
@@ -651,6 +651,9 @@
   - target_label: customer
     replacement: pmo
   metric_relabel_configs:
+  - source_labels: [container]
+    regex: prometheus-operator-app
+    action: drop
   # drop unused nginx metrics with the highest cardinality as they increase Prometheus memory usage
   - source_labels: [__name__]
     regex: nginx_ingress_controller_(bytes_sent_bucket|request_size_bucket|response_duration_seconds_bucket|response_size_bucket|request_duration_seconds_count|connect_duration_seconds_bucket|header_duration_seconds_bucket|bytes_sent_count|request_duration_seconds_sum|bytes_sent_sum|request_size_count|response_size_count|response_duration_seconds_sum|response_duration_seconds_count|ingress_upstream_latency_seconds|ingress_upstream_latency_seconds_sum|ingress_upstream_latency_seconds_count)


### PR DESCRIPTION
We currently have duplicate targets because the observability bundle app for vintage WC is not where pmo is looking for it

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
