### PR TITLE
Add Inhibition rule when prometheus-agent is down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add Inhibition rule when prometheus-agent is down.
+
 ## [4.35.3] - 2023-04-18
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -508,9 +508,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -508,7 +508,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -508,7 +508,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -508,6 +508,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -468,9 +468,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -468,6 +468,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -468,9 +468,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -468,6 +468,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -468,9 +468,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -468,6 +468,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -468,9 +468,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -468,6 +468,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - prometheus_agent_down=true
+    - inhibition_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -468,9 +468,9 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_prometheus_agent_down=true
+    - prometheus_agent_down=true
   target_matchers:
-    - cancel_if_cluster_is_prometheus_agent_down=true
+    - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]
 
 - source_matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -468,7 +468,7 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - inhibition_prometheus_agent_down=true
+    - inhibit_prometheus_agent_down=true
   target_matchers:
     - cancel_if_prometheus_agent_down=true
   equal: [cluster_id]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -468,6 +468,12 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_prometheus_agent_down=true
+  target_matchers:
+    - cancel_if_cluster_is_prometheus_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/26678

To avoid several types of alerts to fire because metrics are missing, we create an inhibition when prometheus-agent is down.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
