### PR TITLE
Keep accepting 'master' as `role` label value for etcd scraping.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Keep accepting 'master' as `role` label value for etcd scraping.
+
 ## [4.36.0] - 2023-04-27
 
 ### Changed

--- a/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
+++ b/files/templates/scrapeconfigs/additional-scrape-configs.template.yaml
@@ -234,7 +234,7 @@
     target_label: pod_name
 [[- else ]]
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: control-plane
+    regex: control-plane|master
     action: keep
   # by default use node address
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-4-control-plane.golden
@@ -404,7 +404,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: control-plane
+    regex: control-plane|master
     action: keep
   # by default use node address
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-4-control-plane.golden
@@ -341,7 +341,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: control-plane
+    regex: control-plane|master
     action: keep
   # by default use node address
   - source_labels: [__address__]

--- a/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/kvm/case-4-control-plane.golden
@@ -341,7 +341,7 @@
     insecure_skip_verify: true
   relabel_configs:
   - source_labels: [__meta_kubernetes_node_label_role]
-    regex: control-plane
+    regex: control-plane|master
     action: keep
   # by default use node address
   - source_labels: [__address__]


### PR DESCRIPTION
https://gigantic.slack.com/archives/C02HLSDH3DZ/p1682680595002609

## Checklist

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
