### PR TITLE
heartbeat tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increased heartbeat delay before alert from 25min to 60min
+- Updated alertmanager heartbeat config for faster response
+
 ## [4.36.1] - 2023-04-28
 
 ### Fixed

--- a/service/controller/resource/alerting/heartbeat/resource.go
+++ b/service/controller/resource/alerting/heartbeat/resource.go
@@ -90,8 +90,8 @@ func toHeartbeat(v interface{}, installation string, pipeline string) (*heartbea
 
 	h := &heartbeat.Heartbeat{
 		Name:         key.HeartbeatName(cluster, installation),
-		Description:  "*Recipe:* https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/heartbeat-expired/",
-		Interval:     25,
+		Description:  "📗 Runbook: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/heartbeat-expired/",
+		Interval:     60,
 		IntervalUnit: string(heartbeat.Minutes),
 		Enabled:      true,
 		Expired:      false,

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
@@ -140,11 +140,12 @@ func toAlertmanagerConfig(v interface{}, config Config) (metav1.Object, error) {
 					{Name: key.TypeKey(), Value: key.Heartbeat()},
 				},
 				Continue: false,
-				// We wait for 5 minutes before we start to ping Ops Genie to allow the prometheus server to start
-				GroupWait:     "5m",
+				// wait for 30s before sending the first notification to opsgenie
+				GroupWait: "30s",
+				// wait for 30s between 2 alerts from the same group
 				GroupInterval: "30s",
-				// We ping OpsGenie every minute
-				RepeatInterval: "1m",
+				// ping OpsGenie every 15 minutes
+				RepeatInterval: "15m",
 			},
 			Receivers: []monitoringv1alpha1.Receiver{receiver},
 		},

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-1-awsconfig.golden
@@ -20,7 +20,7 @@ spec:
       url: https://api.opsgenie.com/v2/heartbeats/test-installation-alice/ping
   route:
     groupInterval: 30s
-    groupWait: 5m
+    groupWait: 30s
     matchers:
     - name: cluster_id
       value: alice
@@ -29,4 +29,4 @@ spec:
     - name: type
       value: heartbeat
     receiver: heartbeat_test-installation_alice
-    repeatInterval: 1m
+    repeatInterval: 15m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-2-azureconfig.golden
@@ -20,7 +20,7 @@ spec:
       url: https://api.opsgenie.com/v2/heartbeats/test-installation-foo/ping
   route:
     groupInterval: 30s
-    groupWait: 5m
+    groupWait: 30s
     matchers:
     - name: cluster_id
       value: foo
@@ -29,4 +29,4 @@ spec:
     - name: type
       value: heartbeat
     receiver: heartbeat_test-installation_foo
-    repeatInterval: 1m
+    repeatInterval: 15m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-3-kvmconfig.golden
@@ -20,7 +20,7 @@ spec:
       url: https://api.opsgenie.com/v2/heartbeats/test-installation-bar/ping
   route:
     groupInterval: 30s
-    groupWait: 5m
+    groupWait: 30s
     matchers:
     - name: cluster_id
       value: bar
@@ -29,4 +29,4 @@ spec:
     - name: type
       value: heartbeat
     receiver: heartbeat_test-installation_bar
-    repeatInterval: 1m
+    repeatInterval: 15m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-4-control-plane.golden
@@ -20,7 +20,7 @@ spec:
       url: https://api.opsgenie.com/v2/heartbeats/test-installation-kubernetes/ping
   route:
     groupInterval: 30s
-    groupWait: 5m
+    groupWait: 30s
     matchers:
     - name: cluster_id
       value: kubernetes
@@ -29,4 +29,4 @@ spec:
     - name: type
       value: heartbeat
     receiver: heartbeat_test-installation_kubernetes
-    repeatInterval: 1m
+    repeatInterval: 15m

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/test/case-5-cluster-api-v1alpha3.golden
@@ -20,7 +20,7 @@ spec:
       url: https://api.opsgenie.com/v2/heartbeats/test-installation-baz/ping
   route:
     groupInterval: 30s
-    groupWait: 5m
+    groupWait: 30s
     matchers:
     - name: cluster_id
       value: baz
@@ -29,4 +29,4 @@ spec:
     - name: type
       value: heartbeat
     receiver: heartbeat_test-installation_baz
-    repeatInterval: 1m
+    repeatInterval: 15m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26770

- alertmanager heartbeats config updated for faster response when receiving heartbeats, and less stress on opsgenie
- opsgenie now waits for 1h with no heartbeat before sending an alert, instead of 25min previously
- runbook link style is consistent with other alerts

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
