### PR TITLE
Add shard configuration

### DIFF
--- a/.nancy-ignore
+++ b/.nancy-ignore
@@ -17,3 +17,6 @@ sonatype-2021-1485 until=2023-06-01
 # pkg:golang/k8s.io/apiserver@v0.25.4
 sonatype-2022-6522 until=2023-06-01
 CVE-2020-8561 until=2023-06-01
+
+# pkg:golang/github.com/gin-gonic/gin@v1.7.7
+CVE-2023-26125

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add sharding capabilities to the Prometheus Agent.
+- Create new remote-write-secret Secret and remote-write-config ConfigMap per cluster to not have a bad workaround in the observability bundle.
+
 ## [4.36.4] - 2023-05-02
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add sharding capabilities to the Prometheus Agent.
 - Create new remote-write-secret Secret and remote-write-config ConfigMap per cluster to not have a bad workaround in the observability bundle.
 
+### Fixed
+
+- Fix prometheus control plane node toleration.
+
 ## [4.36.4] - 2023-05-02
 
 ### Fixed

--- a/helm/prometheus-meta-operator/templates/pod-monitor.yaml
+++ b/helm/prometheus-meta-operator/templates/pod-monitor.yaml
@@ -13,4 +13,4 @@ spec:
     matchLabels:
       {{- include "labels.selector" . | nindent 6 }}
   podMetricsEndpoints:
-    - targetPort: http
+    - port: http

--- a/helm/prometheus-meta-operator/templates/rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/rbac.yaml
@@ -31,6 +31,7 @@ rules:
       - ""
     resources:
       - secrets
+      - configmaps
     verbs:
       - create
       - patch # Needed to remove a finalizer

--- a/pkg/remotewrite/configuration/error.go
+++ b/pkg/remotewrite/configuration/error.go
@@ -1,0 +1,23 @@
+package configuration
+
+import (
+	"github.com/giantswarm/microerror"
+)
+
+var secretNotFound = &microerror.Error{
+	Kind: "secretNotFound",
+}
+
+// IsSecretNotFound asserts secretNotFound.
+func IsSecretNotFound(err error) bool {
+	return microerror.Cause(err) == secretNotFound
+}
+
+var remoteWriteNotFound = &microerror.Error{
+	Kind: "remoteWriteNotFound",
+}
+
+// IsRemoteWriteNotFound asserts remoteWriteNotFound.
+func IsRemoteWriteNotFound(err error) bool {
+	return microerror.Cause(err) == remoteWriteNotFound
+}

--- a/pkg/remotewrite/configuration/type.go
+++ b/pkg/remotewrite/configuration/type.go
@@ -1,0 +1,37 @@
+package configuration
+
+import (
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+)
+
+type RemoteWriteConfig struct {
+	// We keep this until we are sure this can be removed
+	GlobalConfig          GlobalConfig          `yaml:"global,omitempty" json:"global,omitempty"`
+	PrometheusAgentConfig PrometheusAgentConfig `yaml:"prometheus-agent,omitempty" json:"prometheus-agent,omitempty"`
+}
+
+type GlobalConfig struct {
+	RemoteWrite    []RemoteWrite     `yaml:"remoteWrite,omitempty" json:"remoteWrite,omitempty"`
+	ExternalLabels map[string]string `yaml:"externalLabels,omitempty" json:"externalLabels,omitempty"`
+}
+
+type PrometheusAgentConfig struct {
+	RemoteWrite    []RemoteWrite        `yaml:"remoteWrite,omitempty" json:"remoteWrite,omitempty"`
+	ExternalLabels map[string]string    `yaml:"externalLabels,omitempty" json:"externalLabels,omitempty"`
+	Image          PrometheusAgentImage `yaml:"image,omitempty" json:"image,omitempty"`
+	Shards         int                  `yaml:"shards,omitempty" json:"shards,omitempty"`
+	Version        string               `yaml:"version,omitempty" json:"version,omitempty"`
+}
+
+type PrometheusAgentImage struct {
+	Tag string `yaml:"tag" json:"tag"`
+}
+
+type RemoteWrite struct {
+	Name        string             `yaml:"name" json:"name"`
+	Password    string             `yaml:"password" json:"password"`
+	Username    string             `yaml:"username" json:"username"`
+	URL         string             `yaml:"url" json:"url"`
+	QueueConfig promv1.QueueConfig `yaml:"queueConfig" json:"queueConfig"`
+	TLSConfig   promv1.TLSConfig   `yaml:"tlsConfig" json:"tlsConfig"`
+}

--- a/pkg/remotewrite/configuration/utils.go
+++ b/pkg/remotewrite/configuration/utils.go
@@ -1,0 +1,81 @@
+package configuration
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/giantswarm/microerror"
+	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const remoteWriteEndpointTemplateURL = "https://%s/%s/api/v1/write"
+
+func GetUsernameAndPassword(client kubernetes.Interface, ctx context.Context, cluster v1.Object, installation string, provider string) (string, string, error) {
+	secretName := key.RemoteWriteSecretName(cluster)
+	secretNamespace := key.GetClusterAppsNamespace(cluster, installation, provider)
+
+	remoteWriteSecret, err := client.CoreV1().Secrets(secretNamespace).Get(ctx, secretName, v1.GetOptions{})
+	if err != nil {
+		return "", "", microerror.Mask(err)
+	}
+
+	username, password, err := extractUsernameAndPasswordFromSecret(remoteWriteSecret)
+	if err != nil {
+		return "", "", microerror.Mask(err)
+	}
+	return username, password, nil
+}
+
+func extractUsernameAndPasswordFromSecret(secret *corev1.Secret) (string, string, error) {
+	data := secret.Data["values"]
+	remoteWriteValues := RemoteWriteConfig{}
+	err := yaml.Unmarshal(data, &remoteWriteValues)
+	if err != nil {
+		return "", "", microerror.Mask(err)
+	}
+
+	if len(remoteWriteValues.GlobalConfig.RemoteWrite) == 0 && len(remoteWriteValues.PrometheusAgentConfig.RemoteWrite) == 0 {
+		// skipping
+		return "", "", secretNotFound
+	}
+
+	for _, rw := range remoteWriteValues.GlobalConfig.RemoteWrite {
+		if rw.Name == key.PrometheusMetaOperatorRemoteWriteName {
+			return rw.Username, rw.Password, nil
+		}
+	}
+
+	for _, rw := range remoteWriteValues.PrometheusAgentConfig.RemoteWrite {
+		if rw.Name == key.PrometheusMetaOperatorRemoteWriteName {
+			return rw.Username, rw.Password, nil
+		}
+	}
+
+	return "", "", remoteWriteNotFound
+}
+
+func DefaultRemoteWrite(clusterID string, baseDomain string, password string, insecureCA bool) RemoteWrite {
+	url := fmt.Sprintf(remoteWriteEndpointTemplateURL, baseDomain, clusterID)
+	return RemoteWrite{
+		Name:     key.PrometheusMetaOperatorRemoteWriteName,
+		URL:      url,
+		Username: clusterID,
+		Password: password,
+		QueueConfig: promv1.QueueConfig{
+			Capacity:          30000,
+			MaxSamplesPerSend: 150000,
+			MaxShards:         10,
+		},
+		TLSConfig: promv1.TLSConfig{
+			SafeTLSConfig: promv1.SafeTLSConfig{
+				InsecureSkipVerify: insecureCA,
+			},
+		},
+	}
+}

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -22,8 +22,10 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/prometheus"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/pvcresizingresource"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteconfig"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingress"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewriteingressauth"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/remotewritesecret"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/namespace"
@@ -306,20 +308,56 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		}
 	}
 
-	var remoteWriteAPIEndpointConfigSecretResource resource.Interface
+	var remoteWriteConfigResource resource.Interface
 	{
-		c := remotewriteapiendpointconfigsecret.Config{
+		c := remotewriteconfig.Config{
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			Customer:     config.Customer,
+			Installation: config.Installation,
+			Pipeline:     config.Pipeline,
+			Provider:     config.Provider,
+			Region:       config.Region,
+			Version:      config.PrometheusVersion,
+		}
+
+		remoteWriteConfigResource, err = remotewriteconfig.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var remoteWriteSecretResource resource.Interface
+	{
+		c := remotewritesecret.Config{
 			K8sClient:       config.K8sClient,
 			Logger:          config.Logger,
 			PasswordManager: passwordManager,
 			BaseDomain:      config.PrometheusBaseDomain,
-			Customer:        config.Customer,
 			Installation:    config.Installation,
 			InsecureCA:      config.InsecureCA,
-			Pipeline:        config.Pipeline,
 			Provider:        config.Provider,
-			Region:          config.Region,
-			Version:         config.PrometheusVersion,
+		}
+
+		remoteWriteSecretResource, err = remotewritesecret.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var remoteWriteAPIEndpointConfigSecretResource resource.Interface
+	{
+		c := remotewriteapiendpointconfigsecret.Config{
+			K8sClient:    config.K8sClient,
+			Logger:       config.Logger,
+			BaseDomain:   config.PrometheusBaseDomain,
+			Customer:     config.Customer,
+			Installation: config.Installation,
+			InsecureCA:   config.InsecureCA,
+			Pipeline:     config.Pipeline,
+			Provider:     config.Provider,
+			Region:       config.Region,
+			Version:      config.PrometheusVersion,
 		}
 
 		remoteWriteAPIEndpointConfigSecretResource, err = remotewriteapiendpointconfigsecret.New(c)
@@ -335,6 +373,8 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		alertmanagerConfigResource,
 		heartbeatWebhookConfigResource,
 		alertmanagerWiringResource,
+		remoteWriteConfigResource,
+		remoteWriteSecretResource,
 		remoteWriteAPIEndpointConfigSecretResource,
 		remoteWriteIngressAuthResource,
 		remoteWriteIngressResource,

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -319,6 +319,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			Pipeline:        config.Pipeline,
 			Provider:        config.Provider,
 			Region:          config.Region,
+			Version:         config.PrometheusVersion,
 		}
 
 		remoteWriteAPIEndpointConfigSecretResource, err = remotewriteapiendpointconfigsecret.New(c)

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -172,11 +172,8 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 								{
 									MatchExpressions: []corev1.NodeSelectorRequirement{
 										{
-											Key:      "role",
-											Operator: corev1.NodeSelectorOpNotIn,
-											Values: []string{
-												"control-plane",
-											},
+											Key:      "node-role.kubernetes.io/control-plane",
+											Operator: corev1.NodeSelectorOpDoesNotExist,
 										},
 									},
 								},

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -19,10 +19,8 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: role
-            operator: NotIn
-            values:
-            - control-plane
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
   apiserverConfig:
     host: https://master.alice:443
     tlsConfig:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -19,10 +19,8 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: role
-            operator: NotIn
-            values:
-            - control-plane
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
   apiserverConfig:
     host: https://master.foo:443
     tlsConfig:

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -19,10 +19,8 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: role
-            operator: NotIn
-            values:
-            - control-plane
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
   apiserverConfig:
     host: https://master.bar:443
     tlsConfig:

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -19,10 +19,8 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: role
-            operator: NotIn
-            values:
-            - control-plane
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
   apiserverConfig:
     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     host: https://kubernetes.default:443

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -19,10 +19,8 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
         - matchExpressions:
-          - key: role
-            operator: NotIn
-            values:
-            - control-plane
+          - key: node-role.kubernetes.io/control-plane
+            operator: DoesNotExist
   apiserverConfig:
     host: https://master.baz:443
     tlsConfig:

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
@@ -27,7 +27,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		// Get the current secret if it exists.
 		current, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			err = r.createSecret(ctx, cluster, name, namespace)
+			err = r.createSecret(ctx, cluster, name, namespace, r.Version)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -43,7 +43,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 				return microerror.Mask(err)
 			}
 
-			desired, err := r.desiredSecret(cluster, name, namespace, password)
+			desired, err := r.desiredSecret(cluster, name, namespace, password, r.Version)
 			if err != nil {
 				return microerror.Mask(err)
 			}

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/create.go
@@ -13,11 +13,6 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	// If we are in a management cluster, we do not need this secret
-	if key.IsManagementCluster(r.Installation, obj) {
-		return r.EnsureDeleted(ctx, obj)
-	}
-
 	r.logger.Debugf(ctx, "ensuring prometheus remote write api endpoint secret")
 	{
 		cluster, err := key.ToCluster(obj)
@@ -33,7 +28,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Installation)
+		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Provider)
 		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
 		// Get the current secret if it exists.
 		current, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/delete.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/delete.go
@@ -19,7 +19,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Installation)
+		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Provider)
 		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
 
 		_, err = r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/error.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/error.go
@@ -1,4 +1,4 @@
-package remotewritesecret
+package remotewriteapiendpointconfigsecret
 
 import (
 	"github.com/giantswarm/microerror"
@@ -11,13 +11,4 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
-}
-
-var remoteWriteNotFound = &microerror.Error{
-	Kind: "remoteWriteNotFound",
-}
-
-// IsRemoteWriteNotFound asserts remoteWriteNotFound.
-func IsRemoteWriteNotFound(err error) bool {
-	return microerror.Cause(err) == remoteWriteNotFound
 }

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -46,6 +46,34 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.BaseDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.BaseDomain must not be empty")
+	}
+	if config.Customer == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Customer must not be empty")
+	}
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Installation must not be empty")
+	}
+	if config.Pipeline == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Pipeline must not be empty")
+	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
+	}
+	if config.Region == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Region must not be empty")
+	}
+	if config.Version == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Version must not be empty")
+	}
+
 	r := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -67,9 +67,6 @@ func New(config Config) (*Resource, error) {
 	if config.Provider == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
 	}
-	if config.Region == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.Region must not be empty")
-	}
 	if config.Version == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Version must not be empty")
 	}

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -2,52 +2,47 @@ package remotewriteapiendpointconfigsecret
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
-	promv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
-	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
+	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
 const (
-	Name                           = "remotewriteapiendpointconfigsecret"
-	remoteWriteEndpointTemplateURL = "https://%s/%s/api/v1/write"
+	Name = "remotewriteapiendpointconfigsecret"
 )
 
 type Config struct {
-	K8sClient       k8sclient.Interface
-	Logger          micrologger.Logger
-	PasswordManager password.Manager
-	BaseDomain      string
-	Customer        string
-	Installation    string
-	InsecureCA      bool
-	Pipeline        string
-	Provider        string
-	Region          string
-	Version         string
+	K8sClient    k8sclient.Interface
+	Logger       micrologger.Logger
+	BaseDomain   string
+	Customer     string
+	Installation string
+	InsecureCA   bool
+	Pipeline     string
+	Provider     string
+	Region       string
+	Version      string
 }
 
 type Resource struct {
 	k8sClient k8sclient.Interface
 	logger    micrologger.Logger
 
-	PasswordManager password.Manager
-	BaseDomain      string
-	Customer        string
-	Installation    string
-	InsecureCA      bool
-	Pipeline        string
-	Provider        string
-	Region          string
-	Version         string
+	BaseDomain   string
+	Customer     string
+	Installation string
+	InsecureCA   bool
+	Pipeline     string
+	Provider     string
+	Region       string
+	Version      string
 }
 
 func New(config Config) (*Resource, error) {
@@ -55,15 +50,14 @@ func New(config Config) (*Resource, error) {
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,
 
-		PasswordManager: config.PasswordManager,
-		BaseDomain:      config.BaseDomain,
-		Customer:        config.Customer,
-		Installation:    config.Installation,
-		InsecureCA:      config.InsecureCA,
-		Pipeline:        config.Pipeline,
-		Provider:        config.Provider,
-		Region:          config.Region,
-		Version:         config.Version,
+		BaseDomain:   config.BaseDomain,
+		Customer:     config.Customer,
+		Installation: config.Installation,
+		InsecureCA:   config.InsecureCA,
+		Pipeline:     config.Pipeline,
+		Provider:     config.Provider,
+		Region:       config.Region,
+		Version:      config.Version,
 	}
 
 	return r, nil
@@ -73,78 +67,29 @@ func (r *Resource) Name() string {
 	return Name
 }
 
-type RemoteWrite struct {
-	Name        string             `yaml:"name" json:"name"`
-	Password    string             `yaml:"password" json:"password"`
-	Username    string             `yaml:"username" json:"username"`
-	URL         string             `yaml:"url" json:"url"`
-	QueueConfig promv1.QueueConfig `yaml:"queueConfig" json:"queueConfig"`
-	TLSConfig   promv1.TLSConfig   `yaml:"tlsConfig" json:"tlsConfig"`
-}
-
-type GlobalRemoteWriteValues struct {
-	Global                RemoteWriteValues     `yaml:"global" json:"global"`
-	PrometheusAgentConfig PrometheusAgentConfig `yaml:"prometheus-agent" json:"prometheus-agent"`
-}
-
-type PrometheusAgentConfig struct {
-	Shards  int                  `yaml:"shards" json:"shards"`
-	Version string               `yaml:"version" json:"version"`
-	Image   PrometheusAgentImage `yaml:"image" json:"image"`
-}
-
-type PrometheusAgentImage struct {
-	Tag string `yaml:"tag" json:"tag"`
-}
-
-type RemoteWriteValues struct {
-	RemoteWrite    []RemoteWrite     `yaml:"remoteWrite" json:"remoteWrite"`
-	ExternalLabels map[string]string `yaml:"externalLabels" json:"externalLabels"`
-}
-
 func (r *Resource) desiredSecret(cluster metav1.Object, name string, namespace string, password string, version string) (*corev1.Secret, error) {
-	url := fmt.Sprintf(remoteWriteEndpointTemplateURL, r.BaseDomain, key.ClusterID(cluster))
-	remoteWrites := []RemoteWrite{
-		{
-			Name:        key.PrometheusMetaOperatorRemoteWriteName,
-			URL:         url,
-			Username:    key.ClusterID(cluster),
-			Password:    password,
-			QueueConfig: defaultQueueConfig(),
-			TLSConfig: promv1.TLSConfig{
-				SafeTLSConfig: promv1.SafeTLSConfig{
-					InsecureSkipVerify: r.InsecureCA,
-				},
-			},
+	globalConfig := remotewriteconfiguration.GlobalConfig{
+		RemoteWrite: []remotewriteconfiguration.RemoteWrite{
+			remotewriteconfiguration.DefaultRemoteWrite(key.ClusterID(cluster), r.BaseDomain, password, r.InsecureCA),
+		},
+		ExternalLabels: map[string]string{
+			key.ClusterIDKey:       key.ClusterID(cluster),
+			key.ClusterTypeKey:     key.ClusterType(r.Installation, cluster),
+			key.CustomerKey:        r.Customer,
+			key.InstallationKey:    r.Installation,
+			key.OrganizationKey:    key.GetOrganization(cluster),
+			key.PipelineKey:        r.Pipeline,
+			key.ProviderKey:        r.Provider,
+			key.RegionKey:          r.Region,
+			key.ServicePriorityKey: key.GetServicePriority(cluster),
 		},
 	}
 
-	externalLabels := map[string]string{
-		key.ClusterIDKey:       key.ClusterID(cluster),
-		key.ClusterTypeKey:     key.ClusterType(r.Installation, cluster),
-		key.CustomerKey:        r.Customer,
-		key.InstallationKey:    r.Installation,
-		key.OrganizationKey:    key.GetOrganization(cluster),
-		key.PipelineKey:        r.Pipeline,
-		key.ProviderKey:        r.Provider,
-		key.RegionKey:          r.Region,
-		key.ServicePriorityKey: key.GetServicePriority(cluster),
+	remoteWriteConfig := remotewriteconfiguration.RemoteWriteConfig{
+		GlobalConfig: globalConfig,
 	}
 
-	values := RemoteWriteValues{
-		RemoteWrite:    remoteWrites,
-		ExternalLabels: externalLabels,
-	}
-
-	prometheusAgentConfig := PrometheusAgentConfig{
-		Shards:  4,
-		Version: r.Version,
-		Image: PrometheusAgentImage{
-			Tag: r.Version,
-		},
-	}
-
-	marshalledValues, err := yaml.Marshal(GlobalRemoteWriteValues{values, prometheusAgentConfig})
+	marshalledValues, err := yaml.Marshal(remoteWriteConfig)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
@@ -159,26 +104,17 @@ func (r *Resource) desiredSecret(cluster metav1.Object, name string, namespace s
 			},
 		},
 		Data: map[string][]byte{
-			"values": []byte(marshalledValues),
+			"values": marshalledValues,
 		},
 		Type: "Opaque",
 	}, nil
 }
 
-func (r *Resource) createSecret(ctx context.Context, cluster metav1.Object, name string, namespace string, version string) error {
-	r.logger.Debugf(ctx, "generating password for the prometheus agent")
-	password, err := r.PasswordManager.GeneratePassword(32)
-	if err != nil {
-		r.logger.Errorf(ctx, err, "failed to generate the prometheus agent password")
-		return microerror.Mask(err)
-	}
-
+func (r *Resource) createSecret(ctx context.Context, cluster metav1.Object, name string, namespace string, password, version string) error {
 	secret, err := r.desiredSecret(cluster, name, namespace, password, version)
 	if err != nil {
 		return microerror.Mask(err)
 	}
-
-	r.logger.Debugf(ctx, "generated password for the prometheus agent")
 
 	_, err = r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
 	return microerror.Mask(err)
@@ -187,12 +123,4 @@ func (r *Resource) createSecret(ctx context.Context, cluster metav1.Object, name
 func (r *Resource) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
 	err := r.k8sClient.K8sClient().CoreV1().Secrets(secret.Namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
 	return microerror.Mask(err)
-}
-
-func defaultQueueConfig() promv1.QueueConfig {
-	return promv1.QueueConfig{
-		Capacity:          30000,
-		MaxSamplesPerSend: 150000,
-		MaxShards:         10,
-	}
 }

--- a/service/controller/resource/monitoring/remotewriteconfig/create.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/create.go
@@ -1,4 +1,4 @@
-package remotewriteapiendpointconfigsecret
+package remotewriteconfig
 
 import (
 	"context"
@@ -8,37 +8,25 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
-	// If we are in a management cluster, we do not need this secret
-	if key.IsManagementCluster(r.Installation, obj) {
-		return r.EnsureDeleted(ctx, obj)
-	}
-
-	r.logger.Debugf(ctx, "ensuring prometheus remote write api endpoint secret")
+	r.logger.Debugf(ctx, "ensuring prometheus remote write config")
 	{
+
 		cluster, err := key.ToCluster(obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		// Get password from remote-write-secret
-		r.logger.Debugf(ctx, "looking up for secret remote write secret")
-		_, password, err := remotewriteconfiguration.GetUsernameAndPassword(r.k8sClient.K8sClient(), ctx, cluster, r.Installation, r.Provider)
-		if err != nil {
-			r.logger.Errorf(ctx, err, "lookup for remote write secret failed")
-			return microerror.Mask(err)
-		}
-
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Installation)
+		name := key.RemoteWriteConfigName(cluster)
 		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
-		// Get the current secret if it exists.
-		current, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+
+		// Get the current configmap if it exists.
+		current, err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
-			err = r.createSecret(ctx, cluster, name, namespace, password, r.Version)
+			err = r.createConfigMap(ctx, cluster, name, namespace, r.Version)
 			if err != nil {
 				return microerror.Mask(err)
 			}
@@ -47,13 +35,13 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		if current != nil {
-			desired, err := r.desiredSecret(cluster, name, namespace, password, r.Version)
+			desired, err := r.desiredConfigMap(cluster, name, namespace, r.Version)
 			if err != nil {
 				return microerror.Mask(err)
 			}
 			if !reflect.DeepEqual(current.Data, desired.Data) {
 				updateMeta(current, desired)
-				_, err := r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Update(ctx, desired, metav1.UpdateOptions{})
+				_, err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(namespace).Update(ctx, desired, metav1.UpdateOptions{})
 				if err != nil {
 					return microerror.Mask(err)
 				}
@@ -61,7 +49,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 	}
 
-	r.logger.Debugf(ctx, "ensured prometheus remote write api endpoint secret")
+	r.logger.Debugf(ctx, "ensured prometheus remote write config")
 
 	return nil
 }

--- a/service/controller/resource/monitoring/remotewriteconfig/error.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/error.go
@@ -1,4 +1,4 @@
-package remotewritesecret
+package remotewriteconfig
 
 import (
 	"github.com/giantswarm/microerror"
@@ -11,13 +11,4 @@ var invalidConfigError = &microerror.Error{
 // IsInvalidConfig asserts invalidConfigError.
 func IsInvalidConfig(err error) bool {
 	return microerror.Cause(err) == invalidConfigError
-}
-
-var remoteWriteNotFound = &microerror.Error{
-	Kind: "remoteWriteNotFound",
-}
-
-// IsRemoteWriteNotFound asserts remoteWriteNotFound.
-func IsRemoteWriteNotFound(err error) bool {
-	return microerror.Cause(err) == remoteWriteNotFound
 }

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -42,6 +42,31 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.Customer == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Customer must not be empty")
+	}
+	if config.Pipeline == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Pipeline must not be empty")
+	}
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Installation must not be empty")
+	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
+	}
+	if config.Region == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Region must not be empty")
+	}
+	if config.Version == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Version must not be empty")
+	}
+
 	r := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -1,0 +1,122 @@
+package remotewriteconfig
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const (
+	Name = "remotewriteconfig"
+)
+
+type Config struct {
+	K8sClient    k8sclient.Interface
+	Logger       micrologger.Logger
+	Customer     string
+	Installation string
+	Pipeline     string
+	Provider     string
+	Region       string
+	Version      string
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+
+	Customer     string
+	Installation string
+	Pipeline     string
+	Provider     string
+	Region       string
+	Version      string
+}
+
+func New(config Config) (*Resource, error) {
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		Customer:     config.Customer,
+		Installation: config.Installation,
+		Pipeline:     config.Pipeline,
+		Provider:     config.Provider,
+		Region:       config.Region,
+		Version:      config.Version,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) desiredConfigMap(cluster metav1.Object, name string, namespace string, version string) (*corev1.ConfigMap, error) {
+	externalLabels := map[string]string{
+		key.ClusterIDKey:       key.ClusterID(cluster),
+		key.ClusterTypeKey:     key.ClusterType(r.Installation, cluster),
+		key.CustomerKey:        r.Customer,
+		key.InstallationKey:    r.Installation,
+		key.OrganizationKey:    key.GetOrganization(cluster),
+		key.PipelineKey:        r.Pipeline,
+		key.ProviderKey:        r.Provider,
+		key.RegionKey:          r.Region,
+		key.ServicePriorityKey: key.GetServicePriority(cluster),
+	}
+
+	prometheusAgentConfig := remotewriteconfiguration.PrometheusAgentConfig{
+		ExternalLabels: externalLabels,
+		Image: remotewriteconfiguration.PrometheusAgentImage{
+			Tag: r.Version,
+		},
+		Shards:  4,
+		Version: r.Version,
+	}
+
+	marshalledValues, err := yaml.Marshal(remotewriteconfiguration.RemoteWriteConfig{
+		PrometheusAgentConfig: prometheusAgentConfig,
+	})
+
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    key.PrometheusLabels(cluster),
+			Finalizers: []string{
+				"monitoring.giantswarm.io/prometheus-remote-write",
+			},
+		},
+		Data: map[string]string{
+			"values": string(marshalledValues),
+		},
+	}, nil
+}
+
+func (r *Resource) createConfigMap(ctx context.Context, cluster metav1.Object, name string, namespace string, version string) error {
+	configMap, err := r.desiredConfigMap(cluster, name, namespace, version)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	_, err = r.k8sClient.K8sClient().CoreV1().ConfigMaps(namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	return microerror.Mask(err)
+}
+
+func (r *Resource) deleteConfigMap(ctx context.Context, configmap *corev1.ConfigMap) error {
+	err := r.k8sClient.K8sClient().CoreV1().ConfigMaps(configmap.Namespace).Delete(ctx, configmap.Name, metav1.DeleteOptions{})
+	return microerror.Mask(err)
+}

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -104,7 +104,7 @@ func (r *Resource) desiredConfigMap(cluster metav1.Object, name string, namespac
 		Image: remotewriteconfiguration.PrometheusAgentImage{
 			Tag: r.Version,
 		},
-		Shards:  4,
+		Shards:  1,
 		Version: r.Version,
 	}
 

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -60,9 +60,6 @@ func New(config Config) (*Resource, error) {
 	if config.Provider == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
 	}
-	if config.Region == "" {
-		return nil, microerror.Maskf(invalidConfigError, "config.Region must not be empty")
-	}
 	if config.Version == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Version must not be empty")
 	}

--- a/service/controller/resource/monitoring/remotewritesecret/delete.go
+++ b/service/controller/resource/monitoring/remotewritesecret/delete.go
@@ -1,4 +1,4 @@
-package remotewriteapiendpointconfigsecret
+package remotewritesecret
 
 import (
 	"context"
@@ -12,14 +12,14 @@ import (
 )
 
 func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
-	r.logger.Debugf(ctx, "deleting prometheus remote write api endpoint secret")
+	r.logger.Debugf(ctx, "deleting prometheus remote write secret")
 	{
 		cluster, err := key.ToCluster(obj)
 		if err != nil {
 			return microerror.Mask(err)
 		}
 
-		name := key.RemoteWriteAPIEndpointConfigSecretName(cluster, r.Installation)
+		name := key.RemoteWriteSecretName(cluster)
 		namespace := key.GetClusterAppsNamespace(cluster, r.Installation, r.Provider)
 
 		_, err = r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
@@ -43,7 +43,7 @@ func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
 		}
 
 	}
-	r.logger.Debugf(ctx, "deleted prometheus remote write api endpoint secret")
+	r.logger.Debugf(ctx, "deleted prometheus remote write secret")
 
 	return nil
 }

--- a/service/controller/resource/monitoring/remotewritesecret/error.go
+++ b/service/controller/resource/monitoring/remotewritesecret/error.go
@@ -1,17 +1,8 @@
-package remotewriteingressauth
+package remotewritesecret
 
 import (
 	"github.com/giantswarm/microerror"
 )
-
-var secretNotFound = &microerror.Error{
-	Kind: "secretNotFound",
-}
-
-// IsSecretNotFound asserts secretNotFound.
-func IsSecretNotFound(err error) bool {
-	return microerror.Cause(err) == secretNotFound
-}
 
 var remoteWriteNotFound = &microerror.Error{
 	Kind: "remoteWriteNotFound",

--- a/service/controller/resource/monitoring/remotewritesecret/resource.go
+++ b/service/controller/resource/monitoring/remotewritesecret/resource.go
@@ -1,0 +1,114 @@
+package remotewritesecret
+
+import (
+	"context"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
+	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
+)
+
+const (
+	Name = "remotewritesecret"
+)
+
+type Config struct {
+	K8sClient       k8sclient.Interface
+	Logger          micrologger.Logger
+	PasswordManager password.Manager
+	BaseDomain      string
+	InsecureCA      bool
+	Installation    string
+	Provider        string
+}
+
+type Resource struct {
+	k8sClient k8sclient.Interface
+	logger    micrologger.Logger
+
+	PasswordManager password.Manager
+	BaseDomain      string
+	InsecureCA      bool
+	Installation    string
+	Provider        string
+}
+
+func New(config Config) (*Resource, error) {
+	r := &Resource{
+		k8sClient: config.K8sClient,
+		logger:    config.Logger,
+
+		PasswordManager: config.PasswordManager,
+		BaseDomain:      config.BaseDomain,
+		InsecureCA:      config.InsecureCA,
+		Installation:    config.Installation,
+		Provider:        config.Provider,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) desiredSecret(cluster metav1.Object, name string, namespace string, password string) (*corev1.Secret, error) {
+	remoteWriteConfig := remotewriteconfiguration.RemoteWriteConfig{
+		PrometheusAgentConfig: remotewriteconfiguration.PrometheusAgentConfig{
+			RemoteWrite: []remotewriteconfiguration.RemoteWrite{
+				remotewriteconfiguration.DefaultRemoteWrite(key.ClusterID(cluster), r.BaseDomain, password, r.InsecureCA),
+			},
+		},
+	}
+
+	marshalledValues, err := yaml.Marshal(remoteWriteConfig)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels:    key.PrometheusLabels(cluster),
+			Finalizers: []string{
+				"monitoring.giantswarm.io/prometheus-remote-write",
+			},
+		},
+		Data: map[string][]byte{
+			"values": marshalledValues,
+		},
+		Type: "Opaque",
+	}, nil
+}
+
+func (r *Resource) createSecret(ctx context.Context, cluster metav1.Object, name string, namespace string) error {
+	r.logger.Debugf(ctx, "generating password for the prometheus agent")
+	password, err := r.PasswordManager.GeneratePassword(32)
+	if err != nil {
+		r.logger.Errorf(ctx, err, "failed to generate the prometheus agent password")
+		return microerror.Mask(err)
+	}
+
+	secret, err := r.desiredSecret(cluster, name, namespace, password)
+	if err != nil {
+		return microerror.Mask(err)
+	}
+
+	r.logger.Debugf(ctx, "generated password for the prometheus agent")
+
+	_, err = r.k8sClient.K8sClient().CoreV1().Secrets(namespace).Create(ctx, secret, metav1.CreateOptions{})
+	return microerror.Mask(err)
+}
+
+func (r *Resource) deleteSecret(ctx context.Context, secret *corev1.Secret) error {
+	err := r.k8sClient.K8sClient().CoreV1().Secrets(secret.Namespace).Delete(ctx, secret.Name, metav1.DeleteOptions{})
+	return microerror.Mask(err)
+}

--- a/service/controller/resource/monitoring/remotewritesecret/resource.go
+++ b/service/controller/resource/monitoring/remotewritesecret/resource.go
@@ -41,6 +41,24 @@ type Resource struct {
 }
 
 func New(config Config) (*Resource, error) {
+	if config.K8sClient == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.K8sClient must not be empty")
+	}
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.Logger must not be empty")
+	}
+	if config.PasswordManager == nil {
+		return nil, microerror.Maskf(invalidConfigError, "config.PasswordManager must not be empty")
+	}
+	if config.BaseDomain == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.BaseDomain must not be empty")
+	}
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Installation must not be empty")
+	}
+	if config.Provider == "" {
+		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
+	}
 	r := &Resource{
 		k8sClient: config.K8sClient,
 		logger:    config.Logger,

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -186,6 +186,10 @@ func New(config Config) ([]resource.Interface, error) {
 			K8sClient:       config.K8sClient,
 			Logger:          config.Logger,
 			PasswordManager: passwordManager,
+			BaseDomain:      config.PrometheusBaseDomain,
+			Installation:    config.Installation,
+			InsecureCA:      config.InsecureCA,
+			Provider:        config.Provider,
 		}
 
 		remoteWriteSecretResource, err = remotewritesecret.New(c)

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -172,6 +172,7 @@ func New(config Config) ([]resource.Interface, error) {
 			Pipeline:        config.Pipeline,
 			Provider:        config.Provider,
 			Region:          config.Region,
+			Version:         config.PrometheusVersion,
 		}
 
 		remoteWriteAPIEndpointConfigSecretResource, err = remotewriteapiendpointconfigsecret.New(c)


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2419

This PR adds sharding capabilities as well as prometheus-agent version override to this chart.

This PR also splits the current remote write secret into a configmap (remotewriteconfig) containing the prometheus agent configuration (version, external labels, shards) and a secret (remotewritesecret) that contains the remotewriteendpoints. 

This PR also keeps the old way of configuring the agent for older releases

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
