### PR TITLE
Remove cpu requests=limit ratio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set Prometheus CPU requests=limits to avoid vpa from going crazy.
+
 ## [4.38.2] - 2023-06-02
 
 ### Added

--- a/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-awsconfig.golden
@@ -55,7 +55,7 @@ spec:
   replicas: 1
   resources:
     limits:
-      cpu: 150m
+      cpu: 100m
       memory: "1073741824"
     requests:
       cpu: 100m

--- a/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-azureconfig.golden
@@ -55,7 +55,7 @@ spec:
   replicas: 1
   resources:
     limits:
-      cpu: 150m
+      cpu: 100m
       memory: "1073741824"
     requests:
       cpu: 100m

--- a/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-kvmconfig.golden
@@ -55,7 +55,7 @@ spec:
   replicas: 1
   resources:
     limits:
-      cpu: 150m
+      cpu: 100m
       memory: "1073741824"
     requests:
       cpu: 100m

--- a/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-control-plane.golden
@@ -60,7 +60,7 @@ spec:
   replicas: 1
   resources:
     limits:
-      cpu: 150m
+      cpu: 100m
       memory: "1073741824"
     requests:
       cpu: 100m

--- a/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-cluster-api-v1alpha3.golden
@@ -55,7 +55,7 @@ spec:
   replicas: 1
   resources:
     limits:
-      cpu: 150m
+      cpu: 100m
       memory: "1073741824"
     requests:
       cpu: 100m

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-1-awsconfig.golden
@@ -13,7 +13,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
-        cpu: "4"
+        cpu: "6"
         memory: "13743895347"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-2-azureconfig.golden
@@ -13,7 +13,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
-        cpu: "4"
+        cpu: "6"
         memory: "13743895347"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-3-kvmconfig.golden
@@ -13,7 +13,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
-        cpu: "4"
+        cpu: "6"
         memory: "13743895347"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-4-control-plane.golden
@@ -13,7 +13,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
-        cpu: "4"
+        cpu: "6"
         memory: "13743895347"
       minAllowed:
         cpu: 100m

--- a/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/test/case-5-cluster-api-v1alpha3.golden
@@ -13,7 +13,7 @@ spec:
     - containerName: prometheus
       controlledValues: RequestsAndLimits
       maxAllowed:
-        cpu: "4"
+        cpu: "6"
         memory: "13743895347"
       minAllowed:
         cpu: 100m

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -28,7 +28,7 @@ const (
 	TeamLabel            string = "application.giantswarm.io/team"
 	// PrometheusCPULimitCoefficient is the number used to compute the CPU limit from the CPU request.
 	// It is used when computing VPA settings, to set `max requests` so that `max limits` respects MaxCPU factor.
-	PrometheusCPULimitCoefficient float64 = 1.5
+	PrometheusCPULimitCoefficient float64 = 1
 	// PrometheusMemoryLimitCoefficient is the number used to compute the memory limit from the memory request.
 	// It is used when computing VPA settings, to set `max request` so that `max limits` respect MaxMemory factor.
 	PrometheusMemoryLimitCoefficient      float64 = 1


### PR DESCRIPTION
Towards https://github.com/giantswarm/babymarkt/issues/1213

This PR removes Prometheus requests/limits cpu ratio so VPA does not overprovision CPU on machines

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
