### PR TITLE
Add team-turtles alerting for slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add back Prometheus CPU limits.
+- Add alert routing for `team-turtles`
 
 ## [4.39.0] - 2023-06-07
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -130,6 +130,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -343,6 +350,33 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  [[- if eq .Pipeline "stable" ]]
+  - channel: '#alert-turtles'
+  [[- else ]]
+  - channel: '#alert-turtles-test'
+  [[- end ]]
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -114,6 +114,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -303,6 +310,29 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  - channel: '#alert-turtles-test'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -114,6 +114,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -303,6 +310,29 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  - channel: '#alert-turtles-test'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -114,6 +114,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -303,6 +310,29 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  - channel: '#alert-turtles-test'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -114,6 +114,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -303,6 +310,29 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  - channel: '#alert-turtles-test'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -114,6 +114,13 @@ route:
     - severity=~"page|notify"
     continue: true
 
+  # Team Turtles Slack
+  - receiver: team_turtles_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="turtles"
+    continue: false
+
 receivers:
 - name: root
 
@@ -303,6 +310,29 @@ receivers:
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
+      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
+
+- name: team_turtles_slack
+  slack_configs:
+  - channel: '#alert-turtles-test'
+    send_resolved: true
+    actions:
+    - type: button
+      text: ':green_book: OpsRecipe'
+      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
+    - type: button
+      text: ':coffin: Linked PMs'
+      url: '{{ template "__alert_linked_postmortems" . }}'
+    - type: button
+      text: ':mag: Query'
+      url: '{{ (index .Alerts 0).GeneratorURL }}'
+    - type: button
+      text: ':grafana: Dashboard'
+      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+    - type: button
+      text: ':no_bell: Silence'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/26997

Add alerting pipeline for `team-turtles` slack channels

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
