### PR TITLE
Add kyverno policy exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added scrape for `vault-etcd-backups-exporter` towards legacy vault VMs.
+- Add Kyverno Policy Exceptions.
 
 ## [4.40.0] - 2023-06-19
 

--- a/helm/prometheus-meta-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/prometheus-meta-operator/templates/kyverno-policy-exception.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.kyvernoPolicyExceptions.enabled }}
+{{- if .Capabilities.APIVersions.Has "kyverno.io/v2alpha1/PolicyException" -}}
+apiVersion: kyverno.io/v2alpha1
+kind: PolicyException
+metadata:
+  annotations:
+    "helm.sh/hook": "pre-install,pre-upgrade"
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: {{ include "resource.default.name" . }}
+  namespace: {{ .Values.kyvernoPolicyExceptions.namespace | default (include "resource.default.namespace" .) }}
+spec:
+  exceptions:
+  - policyName: disallow-host-path
+    ruleNames:
+    - host-path
+    - autogen-host-path
+  - policyName: disallow-capabilities-strict
+    ruleNames:
+    - require-drop-all
+    - autogen-require-drop-all
+  - policyName: disallow-privilege-escalation
+    ruleNames:
+    - privilege-escalation
+    - autogen-privilege-escalation
+  - policyName: require-run-as-non-root-user
+    ruleNames:
+    - run-as-non-root-user
+    - autogen-run-as-non-root-user
+  - policyName: require-run-as-nonroot
+    ruleNames:
+    - run-as-non-root
+    - autogen-run-as-non-root
+  - policyName: restrict-seccomp-strict
+    ruleNames:
+    - check-seccomp-strict
+    - autogen-check-seccomp-strict
+  - policyName: restrict-volume-types
+    ruleNames:
+    - restricted-volumes
+    - autogen-restricted-volumes
+  match:
+    any:
+    - resources:
+        kinds:
+        - Deployment
+        - Pod
+        namespaces:
+        - {{ include "resource.default.namespace" . }}
+        names:
+        - {{ include "resource.default.name" . }}*
+  {{- end -}}
+{{- end -}}

--- a/helm/prometheus-meta-operator/values.schema.json
+++ b/helm/prometheus-meta-operator/values.schema.json
@@ -84,6 +84,17 @@
                 }
             }
         },
+        "kyvernoPolicyExceptions": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                },
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
         "managementCluster": {
             "type": "object",
             "properties": {

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -15,6 +15,11 @@ ingress:
   externalDNS: false
   className: "nginx"
 
+# Enable Kyverno PolicyException
+kyvernoPolicyExceptions:
+  enabled: true
+  namespace: giantswarm
+
 alertmanager:
   address: "https://alertmanager:9093"
   host: "alertmanager:9093"


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27340 this makes sure PMO can run in 1.25+ clusters

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
