### PR TITLE
ReRoute clippy alerts to phoenix until all team labels are changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- ReRoute clippy alerts to `phoenix slack` until all team labels are changed
+
 ## [4.41.0] - 2023-06-22
 
 ### Added

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -100,7 +100,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -216,33 +217,6 @@ receivers:
   - channel: '#alert-bigmac'
   [[- else ]]
   - channel: '#alert-bigmac-test'
-  [[- end ]]
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  [[- if eq .Pipeline "stable" ]]
-  - channel: '#alert-clippy'
-  [[- else ]]
-  - channel: '#alert-clippy-test'
   [[- end ]]
     send_resolved: true
     actions:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -88,7 +88,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -193,29 +194,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  - channel: '#alert-clippy-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -88,7 +88,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -193,29 +194,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  - channel: '#alert-clippy-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -88,7 +88,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -193,29 +194,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  - channel: '#alert-clippy-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -88,7 +88,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -193,29 +194,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  - channel: '#alert-clippy-test'
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -88,7 +88,8 @@ route:
     continue: false
 
   # Team Clippy Slack
-  - receiver: team_clippy_slack
+  # ReRoute to `phoenix` until we change all team ownership labels
+  - receiver: team_phoenix_slack
     matchers:
     - severity=~"page|notify"
     - team="clippy"
@@ -193,29 +194,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    send_resolved: true
-    actions:
-    - type: button
-      text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
-      style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
-    - type: button
-      text: ':coffin: Linked PMs'
-      url: '{{ template "__alert_linked_postmortems" . }}'
-    - type: button
-      text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
-    - type: button
-      text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
-    - type: button
-      text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" . }}'
-      style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
-
-- name: team_clippy_slack
-  slack_configs:
-  - channel: '#alert-clippy-test'
     send_resolved: true
     actions:
     - type: button


### PR DESCRIPTION
Clippy alert channels have been archived. 

ReRoute the clippy alerts to team-phoenix alert channels 

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
