### PR TITLE
Remove harbor-implementation integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove #harbor-implementation integration.
+
 ## [4.44.0] - 2023-07-04
 
 ### Removed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -18,11 +18,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -129,10 +124,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -14,11 +14,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -117,10 +112,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -14,11 +14,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -117,10 +112,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -14,11 +14,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -117,10 +112,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -14,11 +14,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -117,10 +112,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -14,11 +14,6 @@ route:
 
   routes:
 
-  - receiver: harbor_implementation
-    matchers:
-    - app="harbor"
-    continue: false
-
   # Falco noise Slack
   - receiver: falco_noise_slack
     matchers:
@@ -117,10 +112,6 @@ route:
 
 receivers:
 - name: root
-
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
 
 - name: falco_noise_slack
   slack_configs:


### PR DESCRIPTION
Removing unused harbor-implementation channel

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
