### PR TITLE
Stable-testing pipeline only route MC alerts to opsgenie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- When the cluster pipeline is set to stable-testing, only route management cluster alerts to opsgenie. 
+
 ## [4.44.0] - 2023-07-04
 
 ### Removed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -17,6 +17,12 @@ route:
   receiver: root
 
   routes:
+  [[- if eq .Pipeline "stable-testing" ]]
+  - receiver: null
+    matchers:
+    - cluster_type="workload_cluster"
+    continue: false
+  [[- end ]]
 
   - receiver: harbor_implementation
     matchers:
@@ -40,13 +46,9 @@ route:
     continue: false
 
   # Team Ops Opsgenie
-  # if the pipeline is stable-testing only page for WCs
   - receiver: opsgenie_router
     matchers:
     - severity="page"
-    [[- if eq .Pipeline "stable-testing" ]]
-    - cluster_type="management_cluster"
-    [[- end ]]
     continue: true
 
   # Service Level slack -- chooses the slack channel based on the provider
@@ -133,6 +135,10 @@ route:
 
 receivers:
 - name: root
+
+[[- if eq .Pipeline "stable-testing" ]]
+- name: null
+[[- end ]]
 
 - name: 'harbor_implementation'
   slack_configs:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -40,9 +40,13 @@ route:
     continue: false
 
   # Team Ops Opsgenie
+  # if the pipeline is stable-testing only page for WCs
   - receiver: opsgenie_router
     matchers:
     - severity="page"
+    [[- if eq .Pipeline "stable-testing" ]]
+    - cluster_type="management_cluster"
+    [[- end ]]
     continue: true
 
   # Service Level slack -- chooses the slack channel based on the provider
@@ -348,6 +352,8 @@ receivers:
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 inhibit_rules:
+
+
 - source_matchers:
   - inhibit_kube_state_metrics_down=true
   target_matchers:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -135,10 +135,6 @@ receivers:
 - name: null
 [[- end ]]
 
-- name: 'harbor_implementation'
-  slack_configs:
-  - channel: '#harbor-implementation'
-
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -352,8 +352,6 @@ receivers:
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 inhibit_rules:
-
-
 - source_matchers:
   - inhibit_kube_state_metrics_down=true
   target_matchers:


### PR DESCRIPTION
This change routes only MC alerts to opsgenie when the pipeline is set to stable-testing for the MC.

towards: https://github.com/giantswarm/giantswarm/issues/26718
Related other changes:
- https://github.com/giantswarm/prometheus-rules/pull/825
- https://github.com/giantswarm/installations/pull/2208
- https://github.com/giantswarm/config/pull/1877

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
