### PR TITLE
Include ReplicaSet in PolicyException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Apply Kyverno policy exception to the PMO replicaset as well.
+
 ## [4.45.0] - 2023-07-18
 
-## Changed
+### Changed
 
 - When the cluster pipeline is set to stable-testing, only route management cluster alerts to opsgenie. 
 

--- a/helm/prometheus-meta-operator/templates/kyverno-policy-exception.yaml
+++ b/helm/prometheus-meta-operator/templates/kyverno-policy-exception.yaml
@@ -39,6 +39,7 @@ spec:
     - resources:
         kinds:
         - Deployment
+        - ReplicaSet
         - Pod
         namespaces:
         - {{ include "resource.default.namespace" . }}


### PR DESCRIPTION
Autogen policies also apply to ReplicaSets, so the current RS would still be blocked.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
