### PR TITLE
Skip workload cluster alerts for stable-pipeline installations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Skip alerts named `workloadclusterapp*` in `stable-testing` installations.
+
 ## [4.45.0] - 2023-07-18
 
 ## Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
-- Skip alerts named `workloadclusterapp*` in `stable-testing` installations.
+- Skip alerts named `WorkloadClusterApp*` in `stable-testing` installations.
 
 ## [4.45.0] - 2023-07-18
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -27,7 +27,6 @@ route:
     - alertname=~"WorkloadClusterApp.*"
     continue: false
   [[- end ]]
-  
 
   # Falco noise Slack
   - receiver: falco_noise_slack

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -22,7 +22,12 @@ route:
     matchers:
     - cluster_type="workload_cluster"
     continue: false
+  - receiver: null
+    matchers:
+    - alertname=~"WorkloadClusterApp.*"
+    continue: false
   [[- end ]]
+  
 
   # Falco noise Slack
   - receiver: falco_noise_slack


### PR DESCRIPTION
This change ignores WorkloadClusterApps* alerts when the pipeline is set to stable-testing for the MC.

towards: https://github.com/giantswarm/giantswarm/issues/26718

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
