### PR TITLE
Fix routing rule stable testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Apply Kyverno policy exception to the PMO replicaset as well.
+- Do not alert for `stable-testing` cluster WC heartbeats and `WorkloadClusterAppNotInstalled` alerts.
 
 ## [4.45.1] - 2023-07-18
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -24,8 +24,14 @@ route:
     continue: false
   - receiver: null
     matchers:
-    - alertname=~"WorkloadClusterApp.*"
+    - alertname="WorkloadClusterAppNotInstalled"
     continue: false
+  - receiver: null
+    matchers:
+    - alertname="Heartbeat"
+      cluster_id!=[[ .Installation ]]
+    continue: false
+    
   [[- end ]]
 
   # Falco noise Slack


### PR DESCRIPTION
Related slack thread: https://gigantic.slack.com/archives/CLPMFRVU6/p1690791155331859

Fix stable-testing pipeline alerting rules.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
