### PR TITLE
Enable Shield opsgenie alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Enable Opsgenie alerts for Shield.
+
 ## [4.46.0] - 2023-08-21
 
 ### Added

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -40,16 +40,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -101,6 +91,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -26,16 +26,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -79,6 +69,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -26,16 +26,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -79,6 +69,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -26,16 +26,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -79,6 +69,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -26,16 +26,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -79,6 +69,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -26,16 +26,6 @@ route:
     - team="tinkerers"
     continue: false
 
-  # Team Shield Slack
-  # Shield doesn't have a proper support and on-call rotation yet, we're only forwarding
-  # alerts to the slack channel. Once the proper rotation is in place, we have to move it below
-  # the default opsgenie route
-  - receiver: team_shield_slack
-    matchers:
-    - severity=~"page|notify"
-    - team="shield"
-    continue: false
-
   # Team Ops Opsgenie
   - receiver: opsgenie_router
     matchers:
@@ -79,6 +69,13 @@ route:
     - severity=~"page|notify"
     - team="phoenix"
     - sloth_severity=~"page|ticket"
+    continue: false
+
+  # Team Shield Slack
+  - receiver: team_shield_slack
+    matchers:
+    - severity=~"page|notify"
+    - team="shield"
     continue: false
 
   # Team BigMac Slack


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27693, we have combined with Honeybadger for oncall, so we can now let Shield alerts through to the opsgenie receiver.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
