### PR TITLE
Add app tag to OpsGenie alert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `app:NAME` tag to alerts.
+
 ### Changed
 
 - Enable Opsgenie alerts for Shield.

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -349,7 +349,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: [[ .OpsgenieKey ]]
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},[[ .Provider ]],[[ .Installation ]],[[ .Pipeline ]]"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},[[ .Provider ]],[[ .Installation ]],[[ .Pipeline ]]"
 
 - name: team_ops_slack
   slack_configs:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -349,7 +349,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: [[ .OpsgenieKey ]]
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},[[ .Provider ]],[[ .Installation ]],[[ .Pipeline ]]"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}[[ .Provider ]],[[ .Installation ]],[[ .Pipeline ]]"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},app:{{ (index .Alerts 0).Labels.app }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},app:{{ (index .Alerts 0).Labels.app }},{{ (index .Alerts 0).Labels.service_priority }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -303,7 +303,7 @@ receivers:
 - name: opsgenie_router
   opsgenie_configs:
   - api_key: opsgenie-key
-    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},app:{{ (index .Alerts 0).Labels.app }},aws,test-installation,testing"
+    tags: "{{ (index .Alerts 0).Labels.alertname }},{{ (index .Alerts 0).Labels.cluster_type }},{{ (index .Alerts 0).Labels.severity }},{{ (index .Alerts 0).Labels.team }},{{ (index .Alerts 0).Labels.area }},{{ (index .Alerts 0).Labels.service_priority }},{{ with (index .Alerts 0).Labels.app }}app:{{ . }},{{ end }}aws,test-installation,testing"
 
 - name: team_ops_slack
   slack_configs:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28076

This PR adds a tag to enable linking from a developer portal component page to alerts regarding the component. Example:

`app:app-exporter`

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
