### PR TITLE
improve agent shards calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- computation of number of shards: rely on max number of series over the last 6h.
+
 ## [4.48.0] - 2023-09-19
 
 ### Changed

--- a/pkg/prometheusquerier/querier.go
+++ b/pkg/prometheusquerier/querier.go
@@ -29,7 +29,7 @@ func QueryTSDBHeadSeries(cluster string) (float64, error) {
 	api := v1.NewAPI(c)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	val, _, err := api.Query(ctx, "prometheus_tsdb_head_series", time.Now()) // Ignoring warnings for now.
+	val, _, err := api.Query(ctx, "max_over_time(prometheus_tsdb_head_series[6h])", time.Now()) // Ignoring warnings for now.
 	cancel()
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28174

Improve agent shards calculation:
we base our calculations on the max number of series for the last 6 hours, so it changes less often.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
