### PR TITLE
Support absolute Grafana dashboard URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Support absolute Grafana dashboard URLs
+
 ## [4.48.0] - 2023-09-19
 
 ### Changed
@@ -48,7 +50,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- When the cluster pipeline is set to stable-testing, only route management cluster alerts to opsgenie. 
+- When the cluster pipeline is set to stable-testing, only route management cluster alerts to opsgenie.
 
 ### Removed
 
@@ -422,7 +424,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `.provider.flavor` property in Helm chart. 
+- Add `.provider.flavor` property in Helm chart.
 
 ## [4.20.4] - 2023-02-07
 
@@ -511,7 +513,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Change HasPrometheusAgent function to ignore prometheus-agent scraping targets on CAPA and CAPVCD.
 - Do not reconcile service monitors in kube-system for CAPA and CAPVCD MCs.
-- Change label selector used to discover `PodMonitors` and `ServiceMonitors` 
+- Change label selector used to discover `PodMonitors` and `ServiceMonitors`
   to avoid a duplicate scrape introduced in https://github.com/giantswarm/observability-bundle/pull/18.
 - README: how to generate test
 

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}


### PR DESCRIPTION
This is to support URLs such as `dashboard: https://giantswarm.grafana.net/d/a2f4976Zk/certificates?orgId=1` which do not point to the installation's Grafana, but a Grafana Cloud dashboard. Right now, such URLs get joined to something wrong like `https://installation-grafana/d/https://giantswarm.grafana.net/d/a2f4976Zk/certificates?orgId=1`.

I didn't find a good way of testing this. Should we maybe update `service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case*.golden` with the fixed `{{ define "__dashboardurl" -}}` and add a test in there?

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
