### PR TITLE
Fix API Server url for Managed EKS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix api server url in case the CAPI provider sets https prefix in the CAPI CR status.
+
 ## [4.48.0] - 2023-09-19
 
 ### Changed

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -272,7 +273,8 @@ func APIUrl(obj interface{}) string {
 	case *v1.Service:
 		return "kubernetes.default:443"
 	case *capi.Cluster:
-		return fmt.Sprintf("%s:%d", v.Spec.ControlPlaneEndpoint.Host, v.Spec.ControlPlaneEndpoint.Port)
+		// We remove any https:// prefix from the api-server host due to a bug in CAPA Managed EKS clusters (cf. https://gigantic.slack.com/archives/C02HLSDH3DZ/p1695213116360889)
+		return fmt.Sprintf("%s:%d", strings.TrimPrefix(v.Spec.ControlPlaneEndpoint.Host, "https://"), v.Spec.ControlPlaneEndpoint.Port)
 	case metav1.Object:
 		return fmt.Sprintf("master.%s:443", v.GetName())
 	}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2832

On Managed EKS clusters, the api-server URL populated by the CAPA provider starts with `https://` and this causes issue in PMO as it cannot access the following url:
`https://https/F5AB99CD4973C48F8F80414C4693ED04.gr7.eu-west-2.eks.amazonaws.com:443`

This PR should fix it.

This will be tested on Gauss, Grizzly (CAPA and CAPA EKS) and Snail (Imported EKS)

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
