### PR TITLE
Revert support absolute Grafana dashboard URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reverted support absolute Grafana dashboard URLs.
+
 ## [4.49.1] - 2023-09-21
 
 ### Changed 

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-1-awsconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-2-azureconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-3-kvmconfig.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-4-control-plane.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-5-cluster-api-v1alpha3.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-6-cluster-api-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/case-6-cluster-api-eks.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if hasPrefix "https://" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}


### PR DESCRIPTION
Since support for absolute Grafana dashboard URLs (https://github.com/giantswarm/prometheus-meta-operator/pull/1374), alertmanager crashes at startup.

This PR reverts it, so we can take time to properly test and re-introduce this feature later.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
