### PR TITLE
Only send `phoenix` SLOTH alerts to `phoenix`'s slack alert channel, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Only send silenced page-level SLOTH alerts to `phoenix`'s slack alert channel, rather than all alerts.
+
 ## [4.49.2] - 2023-09-22
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -88,9 +88,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-awsconfig.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-azureconfig.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-kvmconfig.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-control-plane.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-cluster-api-v1alpha3.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-6-cluster-api-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-6-cluster-api-eks.golden
@@ -66,9 +66,9 @@ route:
   # Team Phoenix Slack
   - receiver: team_phoenix_slack
     matchers:
-    - severity=~"page|notify"
     - team="phoenix"
-    - sloth_severity=~"page|ticket"
+    - sloth_severity="page"
+    - silence="true"
     continue: false
 
   # Team Shield Slack


### PR DESCRIPTION
…rather than all alerts.

towards: https://github.com/giantswarm/giantswarm/issues/28159

alert channel is too noisy for team phoenix, to the point of being ignored.
In order to make it used, we want to avoid "legacy" alerts from coming into slack and only have sloth alerts that are silenced in it.
this will allow us to "test" sloth alerts, before we make them page.

this PR does just that

## Checklist

I have:

- [x] Described why this change is being introduced
- [] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
