### PR TITLE
Ignore PMO reconciliation issues on stable-testing installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore `PrometheusMetaOperatorReconcileErrors` alerts on `stable-testing`.
+
 ## [4.49.2] - 2023-09-22
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -26,6 +26,10 @@ route:
     matchers:
     - alertname=~"WorkloadClusterApp.*"
     continue: false
+  - receiver: blackhole
+    matchers:
+    - alertname="PrometheusMetaOperatorReconcileErrors"
+    continue: false
   [[- end ]]
 
   # Falco noise Slack


### PR DESCRIPTION
Grizzly clusters are causing a lot of PMO reconcilation errors because clusters are created a lot and some with issues. Let's not get paged everytime there is an issue on grizzly

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
