### PR TITLE
Increase prometheus-agent max shards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Increase `prometheus-agent` max shards to 50 to improve agent stability.
+
 ## [4.51.0] - 2023-09-25
 
 ### Changed

--- a/pkg/remotewrite/configuration/utils.go
+++ b/pkg/remotewrite/configuration/utils.go
@@ -70,7 +70,7 @@ func DefaultRemoteWrite(clusterID string, baseDomain string, password string, in
 		QueueConfig: promv1.QueueConfig{
 			Capacity:          30000,
 			MaxSamplesPerSend: 150000,
-			MaxShards:         10,
+			MaxShards:         50,
 		},
 		TLSConfig: promv1.TLSConfig{
 			SafeTLSConfig: promv1.SafeTLSConfig{


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28239 and https://github.com/giantswarm/giantswarm/issues/27937

We are increasing the number of prometheus-agent max shards from 10 to 50 to avoid issues like:

```
Warning  Unhealthy  34m (x42 over 21h)  kubelet  Liveness probe failed: Desired shards: 24 / max 10
ERROR - watchdog.sh: Overloaded - 24 desired chards for max 10 shards
```

After some testing on anteater/seu01, it at least did not worsen the situation so let's monitor it in real clusters.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
