### PR TITLE
Add ClusterIssuerName configuration option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add cert-manager clusterIssuer configuration option for Ingresses.
+
 ## [4.53.0] - 2023-09-27
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-ingress.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-ingress.yaml
@@ -2,7 +2,12 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
-    kubernetes.io/tls-acme: "{{ .Values.prometheus.letsencrypt }}"
+    {{- if .Values.prometheus.letsencrypt }}
+    kubernetes.io/tls-acme: "true"
+    {{- with .Values.prometheus.clusterIssuerName }}
+    cert-manager.io/cluster-issuer: "{{ . }}"
+    {{- end }}
+    {{- end }}
     nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
     nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
     {{- if .Values.security.restrictAccess.enabled }}

--- a/helm/prometheus-meta-operator/templates/ingress-oauth.yaml
+++ b/helm/prometheus-meta-operator/templates/ingress-oauth.yaml
@@ -3,6 +3,11 @@ kind: Ingress
 metadata:
   annotations:
     kubernetes.io/tls-acme: "{{ .Values.prometheus.letsencrypt }}"
+    {{- if .Values.prometheus.letsencrypt }}
+    {{- with .Values.prometheus.clusterIssuerName }}
+    cert-manager.io/cluster-issuer: "{{ . }}"
+    {{- end }}
+    {{- end }}
     {{- if .Values.ingress.externalDNS }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.alertmanager.host }},{{ .Values.prometheus.host }}
     giantswarm.io/external-dns: managed

--- a/helm/prometheus-meta-operator/values.schema.json
+++ b/helm/prometheus-meta-operator/values.schema.json
@@ -179,6 +179,9 @@
                 "bastions": {
                     "type": "array"
                 },
+                "clusterIssuerName" :{
+                    "type": "string"
+                },
                 "etcdClientCertificates": {
                     "type": "object",
                     "properties": {

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -53,6 +53,7 @@ prometheus:
   imageRepository: giantswarm/prometheus
   logLevel: info
   letsencrypt: false
+  clusterIssuerName: ""
 
   retention:
     ## Retention duration for prometheus.


### PR DESCRIPTION
This PR introduces a new configuration option to specify the name of the cert-manager ClusterIssuer to be used on Ingress resources installed by the chart in this repository.

Towards https://github.com/giantswarm/roadmap/issues/2844

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
