### PR TITLE
Add support for eks as a provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add cert-manager clusterIssuer configuration option for Ingresses.
+- Add support for EKS as a provider.
 
 ## [4.53.0] - 2023-09-27
 

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -190,7 +190,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 					key.CustomerKey:     config.Customer,
 					key.InstallationKey: config.Installation,
 					key.PipelineKey:     config.Pipeline,
-					key.ProviderKey:     config.Provider,
+					key.ProviderKey:     key.ClusterProvider(cluster, config.Provider),
 					key.RegionKey:       config.Region,
 				},
 				ExternalURL: externalURL.String(),

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -38,7 +38,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: provider
+    provider: eks
     region: onprem
   externalUrl: http://prometheus/eks-sample
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -116,7 +116,7 @@ func (r *Resource) desiredSecret(ctx context.Context, cluster metav1.Object, nam
 			key.InstallationKey:    r.installation,
 			key.OrganizationKey:    organization,
 			key.PipelineKey:        r.pipeline,
-			key.ProviderKey:        r.provider,
+			key.ProviderKey:        key.ClusterProvider(cluster, r.provider),
 			key.RegionKey:          r.region,
 			key.ServicePriorityKey: key.GetServicePriority(cluster),
 		},

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -106,7 +106,7 @@ func (r *Resource) desiredConfigMap(ctx context.Context, cluster metav1.Object, 
 		key.InstallationKey:    r.installation,
 		key.OrganizationKey:    organization,
 		key.PipelineKey:        r.pipeline,
-		key.ProviderKey:        r.provider,
+		key.ProviderKey:        key.ClusterProvider(cluster, r.provider),
 		key.RegionKey:          r.region,
 		key.ServicePriorityKey: key.GetServicePriority(cluster),
 	}

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -211,7 +211,7 @@ func getTemplateData(ctx context.Context, ctrlClient client.Client, cluster meta
 		ServicePriority:           key.GetServicePriority(cluster),
 		Customer:                  config.Customer,
 		Organization:              organization,
-		Provider:                  config.Provider,
+		Provider:                  key.ClusterProvider(cluster, config.Provider),
 		Installation:              config.Installation,
 		SecretName:                key.APIServerCertificatesSecretName,
 		EtcdSecretName:            key.EtcdSecret(config.Installation, cluster),

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-eks-v18.golden
@@ -33,7 +33,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: aws
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -106,7 +106,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: aws
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -177,7 +177,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: aws
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -269,7 +269,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: aws
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -401,7 +401,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: aws
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-eks-v18.golden
@@ -35,7 +35,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: azure
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -110,7 +110,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: azure
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -183,7 +183,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: azure
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -277,7 +277,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: azure
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -409,7 +409,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: azure
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-5-eks-v18.golden
@@ -54,7 +54,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -127,7 +127,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -221,7 +221,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -353,7 +353,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-5-eks-v18.golden
@@ -54,7 +54,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -127,7 +127,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -221,7 +221,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -353,7 +353,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-5-eks-v18.golden
@@ -54,7 +54,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -127,7 +127,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -221,7 +221,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -353,7 +353,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: eks
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -125,6 +125,13 @@ func IsCAPIManagementCluster(provider string) bool {
 	return false
 }
 
+func ClusterProvider(cluster metav1.Object, mcProvider string) string {
+	if IsEKSCluster(cluster) {
+		return "eks"
+	}
+	return mcProvider
+}
+
 func AlertmanagerLabels() map[string]string {
 	return map[string]string{
 		"app.kubernetes.io/name":       "alertmanager",


### PR DESCRIPTION
This PR sets the EKS provider when the workload cluster is an EKS cluster towards https://github.com/giantswarm/roadmap/issues/2843

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
