### PR TITLE
refactor provider into proper type

### DIFF
--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -1,0 +1,6 @@
+package cluster
+
+type Provider struct {
+	Kind   string
+	Flavor string
+}

--- a/pkg/organization/reader.go
+++ b/pkg/organization/reader.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
@@ -22,10 +23,10 @@ type Reader interface {
 type NamespaceReader struct {
 	client       kubernetes.Interface
 	installation string
-	provider     string
+	provider     cluster.Provider
 }
 
-func NewNamespaceReader(client kubernetes.Interface, installation string, provider string) Reader {
+func NewNamespaceReader(client kubernetes.Interface, installation string, provider cluster.Provider) Reader {
 	return NamespaceReader{client, installation, provider}
 }
 

--- a/pkg/remotewrite/configuration/utils.go
+++ b/pkg/remotewrite/configuration/utils.go
@@ -11,12 +11,13 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
 const remoteWriteEndpointTemplateURL = "https://%s/%s/api/v1/write"
 
-func GetUsernameAndPassword(client kubernetes.Interface, ctx context.Context, cluster v1.Object, installation string, provider string) (string, string, error) {
+func GetUsernameAndPassword(client kubernetes.Interface, ctx context.Context, cluster v1.Object, installation string, provider cluster.Provider) (string, string, error) {
 	secretName := key.RemoteWriteSecretName(cluster)
 	secretNamespace := key.GetClusterAppsNamespace(cluster, installation, provider)
 

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -14,6 +14,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/project"
 	controllerresource "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource"
 )
@@ -31,7 +32,7 @@ type ControllerConfig struct {
 	Installation            string
 	InsecureCA              bool
 	Pipeline                string
-	Provider                string
+	Provider                cluster.Provider
 	Region                  string
 	Registry                string
 

--- a/service/controller/managementcluster/controller.go
+++ b/service/controller/managementcluster/controller.go
@@ -15,6 +15,7 @@ import (
 	capi "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/project"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
@@ -32,7 +33,7 @@ type ControllerConfig struct {
 	Installation            string
 	InsecureCA              bool
 	Pipeline                string
-	Provider                string
+	Provider                cluster.Provider
 	Region                  string
 	Registry                string
 

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -12,6 +12,7 @@ import (
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerconfig"
@@ -49,7 +50,7 @@ type resourcesConfig struct {
 	Installation            string
 	InsecureCA              bool
 	Pipeline                string
-	Provider                string
+	Provider                cluster.Provider
 	Region                  string
 	Registry                string
 

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/template"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -29,7 +30,7 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	Installation   string
-	Provider       string
+	Provider       cluster.Provider
 	Proxy          func(reqURL *url.URL) (*url.URL, error)
 	OpsgenieKey    string
 	GrafanaAddress string
@@ -149,7 +150,7 @@ func getTemplateData(config Config) (*AlertmanagerTemplateData, error) {
 	}
 
 	d := &AlertmanagerTemplateData{
-		Provider:       config.Provider,
+		Provider:       config.Provider.Kind,
 		Installation:   config.Installation,
 		OpsgenieKey:    config.OpsgenieKey,
 		GrafanaAddress: config.GrafanaAddress,

--- a/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/net/http/httpproxy"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
 )
 
@@ -57,8 +58,11 @@ func TestRenderingOfAlertmanagerConfig(t *testing.T) {
 			OpsgenieKey:    "opsgenie-key",
 			Proxy:          proxyConfig.ProxyFunc(),
 			Pipeline:       "testing",
-			Provider:       "aws",
-			SlackApiURL:    "https://slack",
+			Provider: cluster.Provider{
+				Kind:   "aws",
+				Flavor: "vintage",
+			},
+			SlackApiURL: "https://slack",
 		}
 		testFunc = func(v interface{}) (interface{}, error) {
 			return renderAlertmanagerConfig(unittest.ProjectRoot(), config)

--- a/service/controller/resource/certificates/resource.go
+++ b/service/controller/resource/certificates/resource.go
@@ -14,12 +14,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
 type Config struct {
 	Name      string
-	Provider  string
+	Provider  cluster.Provider
 	Sources   []CertificateSource
 	Target    string
 	K8sClient k8sclient.Interface
@@ -35,7 +36,7 @@ type CertificateSource struct {
 
 type Resource struct {
 	name      string
-	provider  string
+	provider  cluster.Provider
 	sources   []CertificateSource
 	target    string
 	k8sClient k8sclient.Interface
@@ -46,7 +47,7 @@ func New(config Config) (*Resource, error) {
 	if config.Name == "" {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Name must not be empty", config)
 	}
-	if config.Provider == "" {
+	if reflect.ValueOf(config.Provider).IsZero() {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Provider must not be empty", config)
 	}
 	if config.K8sClient == nil {

--- a/service/controller/resource/etcd-certificates/resource.go
+++ b/service/controller/resource/etcd-certificates/resource.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
 )
 
@@ -22,7 +23,7 @@ type Config struct {
 
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
-	Provider  string
+	Provider  cluster.Provider
 }
 
 // secretCopier provides a way to create a new secret from different data source.

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -17,6 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/pvcresizing"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -38,7 +39,7 @@ type Config struct {
 	ImageRepository    string
 	Installation       string
 	Pipeline           string
-	Provider           string
+	Provider           cluster.Provider
 	Region             string
 	Registry           string
 	LogLevel           string

--- a/service/controller/resource/monitoring/prometheus/resource_test.go
+++ b/service/controller/resource/monitoring/prometheus/resource_test.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
@@ -39,7 +40,7 @@ func TestPrometheus(t *testing.T) {
 		OutputDir: outputDir,
 		T:         t,
 		TestFunc: func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -48,7 +49,7 @@ func TestPrometheus(t *testing.T) {
 				secret = &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"token": []byte("my-token"),
@@ -75,14 +76,17 @@ func TestPrometheus(t *testing.T) {
 				Installation:       "test-installation",
 				Pipeline:           "testing",
 				K8sClient:          k8sClient,
-				Provider:           "provider",
-				Region:             "onprem",
-				ImageRepository:    "giantswarm/prometheus",
-				LogLevel:           "debug",
-				Registry:           "quay.io",
-				RetentionDuration:  "2w",
-				ScrapeInterval:     "60s",
-				Version:            "v2.28.1",
+				Provider: cluster.Provider{
+					Kind:   "aws",
+					Flavor: "vintage",
+				},
+				Region:            "onprem",
+				ImageRepository:   "giantswarm/prometheus",
+				LogLevel:          "debug",
+				Registry:          "quay.io",
+				RetentionDuration: "2w",
+				ScrapeInterval:    "60s",
+				Version:           "v2.28.1",
 			}
 
 			return toPrometheus(context.Background(), v, config)

--- a/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
@@ -39,7 +39,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: provider
+    provider: aws
     region: onprem
   externalUrl: http://prometheus/kubernetes
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
@@ -38,7 +38,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: provider
+    provider: aws
     region: onprem
   externalUrl: http://prometheus/alice
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
@@ -38,7 +38,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: provider
+    provider: aws
     region: onprem
   externalUrl: http://prometheus/baz
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
@@ -38,7 +38,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: provider
+    provider: aws
     region: onprem
   externalUrl: http://prometheus/foo
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -2,6 +2,7 @@ package remotewriteapiendpointconfigsecret
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -29,7 +31,7 @@ type Config struct {
 	Installation string
 	InsecureCA   bool
 	Pipeline     string
-	Provider     string
+	Provider     cluster.Provider
 	Region       string
 	Version      string
 }
@@ -44,7 +46,7 @@ type Resource struct {
 	installation string
 	insecureCA   bool
 	pipeline     string
-	provider     string
+	provider     cluster.Provider
 	region       string
 	version      string
 }
@@ -71,7 +73,7 @@ func New(config Config) (*Resource, error) {
 	if config.Pipeline == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Pipeline must not be empty")
 	}
-	if config.Provider == "" {
+	if reflect.ValueOf(config.Provider).IsZero() {
 		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
 	}
 	if config.Version == "" {

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -12,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/prometheusquerier"
 	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
@@ -30,7 +32,7 @@ type Config struct {
 	Customer     string
 	Installation string
 	Pipeline     string
-	Provider     string
+	Provider     cluster.Provider
 	Region       string
 	Version      string
 }
@@ -43,7 +45,7 @@ type Resource struct {
 	customer     string
 	installation string
 	pipeline     string
-	provider     string
+	provider     cluster.Provider
 	region       string
 	version      string
 }
@@ -67,7 +69,7 @@ func New(config Config) (*Resource, error) {
 	if config.Installation == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Installation must not be empty")
 	}
-	if config.Provider == "" {
+	if reflect.ValueOf(config.Provider).IsZero() {
 		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
 	}
 	if config.Version == "" {

--- a/service/controller/resource/monitoring/remotewriteingressauth/resource.go
+++ b/service/controller/resource/monitoring/remotewriteingressauth/resource.go
@@ -11,6 +11,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
@@ -26,7 +27,7 @@ type Config struct {
 	Logger          micrologger.Logger
 	PasswordManager password.Manager
 	Installation    string
-	Provider        string
+	Provider        cluster.Provider
 }
 
 func New(config Config) (*generic.Resource, error) {

--- a/service/controller/resource/monitoring/remotewritesecret/resource.go
+++ b/service/controller/resource/monitoring/remotewritesecret/resource.go
@@ -2,6 +2,7 @@ package remotewritesecret
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
@@ -10,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	remotewriteconfiguration "github.com/giantswarm/prometheus-meta-operator/v2/pkg/remotewrite/configuration"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -26,7 +28,7 @@ type Config struct {
 	BaseDomain      string
 	InsecureCA      bool
 	Installation    string
-	Provider        string
+	Provider        cluster.Provider
 }
 
 type Resource struct {
@@ -37,7 +39,7 @@ type Resource struct {
 	BaseDomain      string
 	InsecureCA      bool
 	Installation    string
-	Provider        string
+	Provider        cluster.Provider
 }
 
 func New(config Config) (*Resource, error) {
@@ -56,7 +58,7 @@ func New(config Config) (*Resource, error) {
 	if config.Installation == "" {
 		return nil, microerror.Maskf(invalidConfigError, "config.Installation must not be empty")
 	}
-	if config.Provider == "" {
+	if reflect.ValueOf(config.Provider).IsZero() {
 		return nil, microerror.Maskf(invalidConfigError, "config.Provider must not be empty")
 	}
 	r := &Resource{

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/template"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
@@ -40,7 +41,7 @@ type Config struct {
 	Bastions                  []string
 	Customer                  string
 	Installation              string
-	Provider                  string
+	Provider                  cluster.Provider
 	Vault                     string
 	TemplatePath              string
 	WorkloadClusterETCDDomain string

--- a/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource_test.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
@@ -82,7 +83,7 @@ func TestAWSScrapeconfigs(t *testing.T) {
 		}
 
 		testFunc = func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -91,7 +92,7 @@ func TestAWSScrapeconfigs(t *testing.T) {
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"token": []byte("token"),
@@ -114,12 +115,15 @@ func TestAWSScrapeconfigs(t *testing.T) {
 			config := Config{
 				TemplatePath:       path,
 				OrganizationReader: FakeReader{},
-				Provider:           "aws",
-				Customer:           "pmo",
-				K8sClient:          k8sClient,
-				Vault:              "vault1.some-installation.test",
-				Installation:       "test-installation",
-				Logger:             logger,
+				Provider: cluster.Provider{
+					Kind:   "aws",
+					Flavor: "vintage",
+				},
+				Customer:     "pmo",
+				K8sClient:    k8sClient,
+				Vault:        "vault1.some-installation.test",
+				Installation: "test-installation",
+				Logger:       logger,
 			}
 			return toData(context.Background(), client, v, config)
 		}
@@ -183,7 +187,7 @@ func TestAzureScrapeconfigs(t *testing.T) {
 		}
 
 		testFunc = func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -192,7 +196,7 @@ func TestAzureScrapeconfigs(t *testing.T) {
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"crt": []byte("crt"),
@@ -216,12 +220,15 @@ func TestAzureScrapeconfigs(t *testing.T) {
 			config := Config{
 				TemplatePath:       path,
 				OrganizationReader: FakeReader{},
-				Provider:           "azure",
-				Customer:           "pmo",
-				K8sClient:          k8sClient,
-				Vault:              "vault1.some-installation.test",
-				Installation:       "test-installation",
-				Logger:             logger,
+				Provider: cluster.Provider{
+					Kind:   "azure",
+					Flavor: "vintage",
+				},
+				Customer:     "pmo",
+				K8sClient:    k8sClient,
+				Vault:        "vault1.some-installation.test",
+				Installation: "test-installation",
+				Logger:       logger,
 			}
 			return toData(context.Background(), client, v, config)
 		}
@@ -305,7 +312,7 @@ func TestOpenStackScrapeconfigs(t *testing.T) {
 	{
 		path := path.Join(unittest.ProjectRoot(), templatePath)
 		testFunc = func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -314,7 +321,7 @@ func TestOpenStackScrapeconfigs(t *testing.T) {
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"crt": []byte("crt"),
@@ -339,12 +346,15 @@ func TestOpenStackScrapeconfigs(t *testing.T) {
 				AdditionalScrapeConfigs: additionalScrapeConfigs,
 				TemplatePath:            path,
 				OrganizationReader:      FakeReader{},
-				Provider:                "openstack",
-				Customer:                "pmo",
-				K8sClient:               k8sClient,
-				Vault:                   "vault1.some-installation.test",
-				Installation:            "test-installation",
-				Logger:                  logger,
+				Provider: cluster.Provider{
+					Kind:   "openstack",
+					Flavor: "capi",
+				},
+				Customer:     "pmo",
+				K8sClient:    k8sClient,
+				Vault:        "vault1.some-installation.test",
+				Installation: "test-installation",
+				Logger:       logger,
 			}
 			return toData(context.Background(), client, v, config)
 		}
@@ -428,7 +438,7 @@ func TestGCPScrapeconfigs(t *testing.T) {
 	{
 		path := path.Join(unittest.ProjectRoot(), templatePath)
 		testFunc = func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -437,7 +447,7 @@ func TestGCPScrapeconfigs(t *testing.T) {
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"crt": []byte("crt"),
@@ -462,12 +472,15 @@ func TestGCPScrapeconfigs(t *testing.T) {
 				AdditionalScrapeConfigs: additionalScrapeConfigs,
 				TemplatePath:            path,
 				OrganizationReader:      FakeReader{},
-				Provider:                "gcp",
-				Customer:                "pmo",
-				K8sClient:               k8sClient,
-				Vault:                   "vault1.some-installation.test",
-				Installation:            "test-installation",
-				Logger:                  logger,
+				Provider: cluster.Provider{
+					Kind:   "gcp",
+					Flavor: "capi",
+				},
+				Customer:     "pmo",
+				K8sClient:    k8sClient,
+				Vault:        "vault1.some-installation.test",
+				Installation: "test-installation",
+				Logger:       logger,
 			}
 			return toData(context.Background(), client, v, config)
 		}
@@ -551,7 +564,7 @@ func TestCAPAScrapeconfigs(t *testing.T) {
 	{
 		path := path.Join(unittest.ProjectRoot(), templatePath)
 		testFunc = func(v interface{}) (interface{}, error) {
-			cluster, err := key.ToCluster(v)
+			testCluster, err := key.ToCluster(v)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -560,7 +573,7 @@ func TestCAPAScrapeconfigs(t *testing.T) {
 				secret = &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "cluster-certificates",
-						Namespace: key.Namespace(cluster),
+						Namespace: key.Namespace(testCluster),
 					},
 					Data: map[string][]byte{
 						"crt": []byte("crt"),
@@ -585,12 +598,15 @@ func TestCAPAScrapeconfigs(t *testing.T) {
 				AdditionalScrapeConfigs: additionalScrapeConfigs,
 				TemplatePath:            path,
 				OrganizationReader:      FakeReader{},
-				Provider:                "capa",
-				Customer:                "pmo",
-				K8sClient:               k8sClient,
-				Vault:                   "vault1.some-installation.test",
-				Installation:            "test-installation",
-				Logger:                  logger,
+				Provider: cluster.Provider{
+					Kind:   "capa",
+					Flavor: "capi",
+				},
+				Customer:     "pmo",
+				K8sClient:    k8sClient,
+				Vault:        "vault1.some-installation.test",
+				Installation: "test-installation",
+				Logger:       logger,
 			}
 			return toData(context.Background(), client, v, config)
 		}

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -12,6 +12,7 @@ import (
 	promclient "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/organization"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/password"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/alerting/alertmanagerwiring"
@@ -47,7 +48,7 @@ type Config struct {
 	Installation            string
 	InsecureCA              bool
 	Pipeline                string
-	Provider                string
+	Provider                cluster.Provider
 	Region                  string
 	Registry                string
 

--- a/service/service.go
+++ b/service/service.go
@@ -26,6 +26,7 @@ import (
 
 	pmov1alpha1 "github.com/giantswarm/prometheus-meta-operator/v2/api/v1alpha1"
 	"github.com/giantswarm/prometheus-meta-operator/v2/flag"
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/project"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/clusterapi"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/managementcluster"
@@ -125,7 +126,10 @@ func New(config Config) (*Service, error) {
 		}
 	}
 
-	var provider = config.Viper.GetString(config.Flag.Service.Provider.Kind)
+	var provider = cluster.Provider{
+		Kind:   config.Viper.GetString(config.Flag.Service.Provider.Kind),
+		Flavor: config.Viper.GetString(config.Flag.Service.Provider.Flavor),
+	}
 
 	var proxyConfig = httpproxy.FromEnvironment()
 	var clusterapiController *clusterapi.Controller


### PR DESCRIPTION
This PR refactors the provider into a better provider type to be able to use the Flavor field of either CAPI or Vintage.

This will be the basis of other refactorings


As you can see, no golden file was changed for this PR (only the Prometheus one because provider was set to, well, provider)

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
