### PR TITLE
Route ClusterUnhealthyPhase for test clusters to blackhole

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Routing rule for `ClusterUnhealthyPhase` and test clusters on stable-testing MCs to route to blackhole
+
 ## [4.54.0] - 2023-09-28
 
 ### Added
@@ -53,7 +57,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.49.1] - 2023-09-21
 
-### Changed 
+### Changed
 
 - Ignore kube-proxy target on EKS or clusters with observability bundle >= 0.8.3 (where the kube-proxy service monitor is enabled).
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -30,6 +30,11 @@ route:
     matchers:
     - alertname="PrometheusMetaOperatorReconcileErrors"
     continue: false
+  - receiver: blackhole
+    matchers:
+    - alertname="ClusterUnhealthyPhase"
+    - name=~"t-.*"
+    continue: false
   [[- end ]]
 
   # Falco noise Slack


### PR DESCRIPTION
The `ClusterUnhealthyPhase` alert should only page for Workload Clusters that aren't E2E test clusters. The best we have to work this out is the cluster name starting with `t-` as is the convention in the test suites.


## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
