### PR TITLE
Add missing seccomp profile to Prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set Prometheus seccomp profile to RuntimeDefault.
+
 ## [4.55.0] - 2023-10-02
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -222,6 +222,9 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 					RunAsGroup:   &gid,
 					RunAsNonRoot: &runAsNonRoot,
 					FSGroup:      &fsGroup,
+					SeccompProfile: &corev1.SeccompProfile{
+						Type: corev1.SeccompProfileTypeRuntimeDefault,
+					},
 				},
 				Storage: &storage,
 				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{

--- a/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
@@ -90,6 +90,8 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceMonitorNamespaceSelector: {}
   serviceMonitorSelector:
     matchExpressions:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
@@ -84,6 +84,8 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceMonitorNamespaceSelector:
     matchExpressions:
     - key: nonexistentkey

--- a/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
@@ -84,6 +84,8 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceMonitorNamespaceSelector:
     matchExpressions:
     - key: nonexistentkey

--- a/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
@@ -84,6 +84,8 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceMonitorNamespaceSelector:
     matchExpressions:
     - key: nonexistentkey

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -84,6 +84,8 @@ spec:
     runAsGroup: 65534
     runAsNonRoot: true
     runAsUser: 1000
+    seccompProfile:
+      type: RuntimeDefault
   serviceMonitorNamespaceSelector:
     matchExpressions:
     - key: nonexistentkey


### PR DESCRIPTION
Closes https://github.com/giantswarm/giantswarm/issues/28396

This PR sets the seccomp profile for the MC prometheus

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
