### PR TITLE
Remove custom SLO handling in alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove custom SLO handling in alertmanager config.
+
 ## [4.57.0] - 2023-10-04
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -55,16 +55,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  [[- if or (eq .Provider "aws") (eq .Provider "azure") (eq .Provider "gcp") (eq .Provider "capa") (eq .Provider "capz") ]]
-  - receiver: team_phoenix_slack
-  [[- else ]]
-  - receiver: team_rocket_slack
-  [[- end ]]
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -127,7 +127,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			K8sClient:      config.K8sClient,
 			Logger:         config.Logger,
 			Installation:   config.Installation,
-			Provider:       config.Provider,
 			Proxy:          config.Proxy,
 			OpsgenieKey:    config.OpsgenieKey,
 			GrafanaAddress: config.GrafanaAddress,

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -12,7 +12,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/template"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/generic"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -30,7 +29,6 @@ type Config struct {
 	Logger    micrologger.Logger
 
 	Installation   string
-	Provider       cluster.Provider
 	Proxy          func(reqURL *url.URL) (*url.URL, error)
 	OpsgenieKey    string
 	GrafanaAddress string
@@ -43,7 +41,6 @@ type NotificationTemplateData struct {
 }
 
 type AlertmanagerTemplateData struct {
-	Provider       string
 	Installation   string
 	ProxyURL       string
 	OpsgenieKey    string
@@ -150,7 +147,6 @@ func getTemplateData(config Config) (*AlertmanagerTemplateData, error) {
 	}
 
 	d := &AlertmanagerTemplateData{
-		Provider:       config.Provider.Kind,
 		Installation:   config.Installation,
 		OpsgenieKey:    config.OpsgenieKey,
 		GrafanaAddress: config.GrafanaAddress,

--- a/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
@@ -7,7 +7,6 @@ import (
 
 	"golang.org/x/net/http/httpproxy"
 
-	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
 )
 
@@ -58,11 +57,7 @@ func TestRenderingOfAlertmanagerConfig(t *testing.T) {
 			OpsgenieKey:    "opsgenie-key",
 			Proxy:          proxyConfig.ProxyFunc(),
 			Pipeline:       "testing",
-			Provider: cluster.Provider{
-				Kind:   "aws",
-				Flavor: "vintage",
-			},
-			SlackApiURL: "https://slack",
+			SlackApiURL:    "https://slack",
 		}
 		testFunc = func(v interface{}) (interface{}, error) {
 			return renderAlertmanagerConfig(unittest.ProjectRoot(), config)

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
@@ -32,12 +32,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  - receiver: team_phoenix_slack
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
@@ -32,12 +32,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  - receiver: team_phoenix_slack
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
@@ -32,12 +32,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  - receiver: team_phoenix_slack
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
@@ -32,12 +32,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  - receiver: team_phoenix_slack
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
@@ -32,12 +32,6 @@ route:
     - severity="page"
     continue: true
 
-  # Service Level slack -- chooses the slack channel based on the provider
-  - receiver: team_phoenix_slack
-    matchers:
-    - alertname="ServiceLevelBurnRateTooHigh"
-    continue: false
-
   # Team Atlas Slack
   - receiver: team_atlas_slack
     matchers:


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28302

This PR ensures the slo alerts are sent to the correct slack channels

To be released after https://github.com/giantswarm/prometheus-rules/pull/925

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
