### PR TITLE
increase duration before sending alerts in alertmanager config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Upgrade to go 1.21
 - Upgrade internal dependencies.
+- Increased `group_wait` in alertmanager config from 1 to 5m.
 
 ## [4.60.0] - 2023-11-02
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -12,7 +12,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
@@ -8,7 +8,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
@@ -8,7 +8,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
@@ -8,7 +8,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
@@ -8,7 +8,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
@@ -8,7 +8,7 @@ templates:
 route:
   group_by: [alertname, cluster_id, installation, status]
   group_interval: 15m
-  group_wait: 1m
+  group_wait: 5m
   repeat_interval: 4h
   receiver: root
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/28743

Normally, this should increase the duration before any alert is sent. Let's try this for now

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
