### PR TITLE
group alerts by team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Group alerts by teams.
+
 ## [4.61.0] - 2023-11-22
 
 ### Changed
@@ -1071,7 +1075,6 @@ This release was created on release-v3.5.x branch to fix release 3.6.0 see PR#99
 ### Fixed
 
 - Prevent panic when encountering a different user in the CAPI kubeconfig.
-
 
 ## [2.1.0] - 2022-01-10
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -10,7 +10,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-1-vintage-mc.golden
@@ -6,7 +6,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-2-aws-v16.golden
@@ -6,7 +6,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-3-aws-v18.golden
@@ -6,7 +6,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-4-azure-v18.golden
@@ -6,7 +6,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/case-5-eks-v18.golden
@@ -6,7 +6,7 @@ templates:
 - '/etc/alertmanager/config/*.tmpl'
 
 route:
-  group_by: [alertname, cluster_id, installation, status]
+  group_by: [alertname, cluster_id, installation, status, team]
   group_interval: 15m
   group_wait: 5m
   repeat_interval: 4h


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/28751

This PR groups alerts by team in alertmanager so ServiceLevelBurnRateTooHigh alerts are sent to the correct teams

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
