### PR TITLE
Improve stable-testing blackhole routing of alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Improved the blackhole routing for `stable-testing` MCs to silence more alerts related to test WCs
+
 ## [4.63.1] - 2023-12-12
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -24,11 +24,19 @@ route:
     continue: false
   - receiver: blackhole
     matchers:
+    - cluster_id=~"t-.*"
+    continue: false
+  - receiver: blackhole
+    matchers:
     - alertname=~"WorkloadClusterApp.*"
     continue: false
   - receiver: blackhole
     matchers:
     - alertname="PrometheusMetaOperatorReconcileErrors"
+    continue: false
+  - receiver: blackhole
+    matchers:
+    - alertname="ClusterUnhealthyPhase"
     continue: false
   - receiver: blackhole
     matchers:
@@ -41,6 +49,7 @@ route:
     matchers:
     - alertname="ManagementClusterAppFailed"
     - namespace=~"org-.*"
+    continue: false
   [[- end ]]
 
   # Falco noise Slack


### PR DESCRIPTION
Fixes https://github.com/giantswarm/giantswarm/issues/29526
Towards: https://github.com/giantswarm/giantswarm/issues/29553

This PR adds some extra matches to the `stable-testing` blackhole routing so that more alerts related to the test WCs get ignored instead of paging.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
