### PR TITLE
add CiliumNetworkPolicy for managed Prometheuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `CiliumNetworkPolicy` for all created Prometheuses.
+
 ## [4.64.0] - 2024-01-19
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
+++ b/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
@@ -15,6 +15,13 @@ spec:
     - toEntities:
       - kube-apiserver
       - cluster
+    # the below allows access to the kubernetes API server - cilium seems to be mis-identifying
+    # some API server traffic and the `kube-apiserver` entity above is ignored.
+    - toEntities:
+      - world
+      toPorts:
+      - ports:
+        - port: "6443"
   ingress:
     - fromEntities:
       - cluster

--- a/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
+++ b/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
@@ -15,12 +15,14 @@ spec:
     - toEntities:
       - kube-apiserver
       - cluster
-    # the below allows access to the kubernetes API server - cilium seems to be mis-identifying
-    # some API server traffic and the `kube-apiserver` entity above is ignored.
+    # the below allows access to the kubernetes API server via the external
+    # loadbalancer - prometheus appears to talk to the apiserver directly on
+    # the master nodes and also via the loadbalancer.
     - toEntities:
       - world
       toPorts:
       - ports:
+        - port: "443"
         - port: "6443"
   ingress:
     - fromEntities:

--- a/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
+++ b/helm/prometheus-meta-operator/templates/prometheus/prometheus-cilium-network-policy.yaml
@@ -1,0 +1,25 @@
+{{ if .Values.ciliumNetworkPolicy.enabled }}
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" -}}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  namespace: {{ .Release.Namespace }}
+  name: prometheus
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: prometheus
+  egress:
+    - toEntities:
+      - kube-apiserver
+      - cluster
+  ingress:
+    - fromEntities:
+      - cluster
+      toPorts:
+      - ports:
+        - port: "9090"
+{{ end }}
+{{ end }}

--- a/helm/prometheus-meta-operator/values.schema.json
+++ b/helm/prometheus-meta-operator/values.schema.json
@@ -54,6 +54,14 @@
                 }
             }
         },
+        "ciliumNetworkPolicy": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean"
+                }
+            }
+        },
         "global": {
             "type": "object",
             "properties": {

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -5,6 +5,9 @@ global:
 registry:
   domain: gsoci.azurecr.io
 
+ciliumNetworkPolicy:
+  enabled: true
+
 ingress:
   externalDNS: false
   className: "nginx"


### PR DESCRIPTION
towards https://github.com/giantswarm/giantswarm/issues/29581

We need to add a netpol to allow managed Prometheuses to talk to the kubernetes API as this is blocked by a deny-all policy.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Updated changelog in `CHANGELOG.md`
