### PR TITLE
Always set shards to 1 for all created Prometheuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add `CiliumNetworkPolicy` for all created Prometheuses.
+- Always set `shards` to 1 for all created Prometheuses.
 
 ## [4.64.0] - 2024-01-19
 

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -115,6 +115,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 	// Prometheus default image runs using the nobody user (65534)
 	var gid int64 = 65534
 	var walCompression bool = true
+	var prometheusShards int32 = 1
 
 	annotationValue := cluster.GetAnnotations()[key.PrometheusVolumeSizeAnnotation]
 	volumeSize := pvcresizing.PrometheusVolumeSize(annotationValue)
@@ -229,6 +230,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},
 				},
+				Shards:  &prometheusShards,
 				Storage: &storage,
 				TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
 					{

--- a/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
@@ -98,6 +98,7 @@ spec:
     matchExpressions:
     - key: application.giantswarm.io/team
       operator: DoesNotExist
+  shards: 1
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
@@ -95,6 +95,7 @@ spec:
     matchExpressions:
     - key: nonexistentkey
       operator: Exists
+  shards: 1
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
@@ -95,6 +95,7 @@ spec:
     matchExpressions:
     - key: nonexistentkey
       operator: Exists
+  shards: 1
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
@@ -95,6 +95,7 @@ spec:
     matchExpressions:
     - key: nonexistentkey
       operator: Exists
+  shards: 1
   storage:
     volumeClaimTemplate:
       metadata: {}

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -95,6 +95,7 @@ spec:
     matchExpressions:
     - key: nonexistentkey
       operator: Exists
+  shards: 1
   storage:
     volumeClaimTemplate:
       metadata: {}


### PR DESCRIPTION
I encountered an error with VPA failing because of this:
```
'Error checking if target is a topmost well-known or scalable controller:                                                                                                                                                      
        Unhandled targetRef monitoring.coreos.com/v1 / Prometheus / gaia, last error                                                                                                                                                          
        Internal error occurred: the spec replicas field ".spec.shards" does not exist'
```

I'm not exactly sure what causes VPA to complain about that, but it does not hurt to set it explicitly.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
