### PR TITLE
Fix VPA for latest prom-operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix VPA to support latest Prometheus-operator version (based on observability-bundle 1.2.0) as the latest version of the Prometheus CR now supports the `scale` subresource which causes issues with VPA.
+
 ## [4.66.0] - 2024-02-06
 
 ### Changed

--- a/service/controller/clusterapi/resource.go
+++ b/service/controller/clusterapi/resource.go
@@ -267,9 +267,11 @@ func New(config Config) ([]resource.Interface, error) {
 	var verticalPodAutoScalerResource resource.Interface
 	{
 		c := verticalpodautoscaler.Config{
-			Logger:    config.Logger,
-			K8sClient: config.K8sClient,
-			VpaClient: config.VpaClient,
+			Logger:       config.Logger,
+			K8sClient:    config.K8sClient,
+			VpaClient:    config.VpaClient,
+			Installation: config.Installation,
+			Provider:     config.Provider,
 		}
 
 		verticalPodAutoScalerResource, err = verticalpodautoscaler.New(c)

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -197,9 +197,11 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var verticalPodAutoScalerResource resource.Interface
 	{
 		c := verticalpodautoscaler.Config{
-			Logger:    config.Logger,
-			K8sClient: config.K8sClient,
-			VpaClient: config.VpaClient,
+			Logger:       config.Logger,
+			K8sClient:    config.K8sClient,
+			VpaClient:    config.VpaClient,
+			Installation: config.Installation,
+			Provider:     config.Provider,
 		}
 
 		verticalPodAutoScalerResource, err = verticalpodautoscaler.New(c)

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -24,7 +24,8 @@ import (
 )
 
 const (
-	Name = "verticalpodautoscaler"
+	Name                              = "verticalpodautoscaler"
+	unknownObservabilityBundleVersion = "0.0.0"
 )
 
 type Config struct {
@@ -172,8 +173,6 @@ func (r *Resource) getObject(ctx context.Context, v interface{}) (*vpa_types.Ver
 
 	return vpa, nil
 }
-
-const unknownObservabilityBundleVersion = "0.0.0"
 
 // We get the management cluster observability bundle app version for the management cluster to know if we need to configure the VPA CR to target the StatefulSet or the Prometheus CR.
 // We need to do this because VPA uses the scale subresource to scale the target object, and the Prometheus CR has a scale subresource since the observability-bundle 1.2.0.

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource.go
@@ -2,18 +2,24 @@ package verticalpodautoscaler
 
 import (
 	"context"
+	"fmt"
 
+	"github.com/blang/semver"
+	appsv1alpha1 "github.com/giantswarm/apiextensions-application/api/v1alpha1"
 	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	autoscaling "k8s.io/api/autoscaling/v1"
 	v1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	vpa_types "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	vpa_clientset "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
 )
 
@@ -25,12 +31,18 @@ type Config struct {
 	K8sClient k8sclient.Interface
 	VpaClient vpa_clientset.Interface
 	Logger    micrologger.Logger
+
+	Installation string
+	Provider     cluster.Provider
 }
 
 type Resource struct {
 	k8sClient k8sclient.Interface
 	vpaClient vpa_clientset.Interface
 	logger    micrologger.Logger
+
+	installation string
+	provider     cluster.Provider
 }
 
 func New(config Config) (*Resource, error) {
@@ -44,10 +56,16 @@ func New(config Config) (*Resource, error) {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
+	if config.Installation == "" {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Installation must not be empty", config)
+	}
+
 	r := &Resource{
-		k8sClient: config.K8sClient,
-		vpaClient: config.VpaClient,
-		logger:    config.Logger,
+		k8sClient:    config.K8sClient,
+		vpaClient:    config.VpaClient,
+		logger:       config.Logger,
+		installation: config.Installation,
+		provider:     config.Provider,
 	}
 
 	return r, nil
@@ -103,11 +121,6 @@ func (r *Resource) getObject(ctx context.Context, v interface{}) (*vpa_types.Ver
 	vpa := &vpa_types.VerticalPodAutoscaler{
 		ObjectMeta: objectMeta,
 		Spec: vpa_types.VerticalPodAutoscalerSpec{
-			TargetRef: &autoscaling.CrossVersionObjectReference{
-				Kind:       "StatefulSet",
-				Name:       key.PrometheusSTSName(cluster),
-				APIVersion: "apps/v1",
-			},
 			UpdatePolicy: &vpa_types.PodUpdatePolicy{
 				UpdateMode: &updateModeAuto,
 			},
@@ -131,7 +144,65 @@ func (r *Resource) getObject(ctx context.Context, v interface{}) (*vpa_types.Ver
 		},
 	}
 
+	mcObservabilityBundleAppVersion, err := r.getManagementClusterObservabilityBundleAppVersion(ctx, cluster)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
+	version, err := semver.Parse(mcObservabilityBundleAppVersion)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+	if version.LT(semver.MustParse("1.2.0")) {
+		// Set target reference to Prometheus StatefulSet
+		vpa.Spec.TargetRef = &autoscaling.CrossVersionObjectReference{
+			Kind:       "StatefulSet",
+			Name:       key.PrometheusSTSName(cluster),
+			APIVersion: "apps/v1",
+		}
+	} else {
+		// Set target reference to Prometheus CR
+		vpa.Spec.TargetRef = &autoscaling.CrossVersionObjectReference{
+			Kind:       "Prometheus",
+			Name:       key.ClusterID(cluster),
+			APIVersion: "monitoring.coreos.com/v1",
+		}
+
+	}
+
 	return vpa, nil
+}
+
+const unknownObservabilityBundleVersion = "0.0.0"
+
+// We get the management cluster observability bundle app version for the management cluster to know if we need to configure the VPA CR to target the StatefulSet or the Prometheus CR.
+// We need to do this because VPA uses the scale subresource to scale the target object, and the Prometheus CR has a scale subresource since the observability-bundle 1.2.0.
+func (r *Resource) getManagementClusterObservabilityBundleAppVersion(ctx context.Context, cluster metav1.Object) (string, error) {
+	var appName string
+	var appNamespace string
+	if key.IsCAPIManagementCluster(r.provider) {
+		appName = fmt.Sprintf("%s-observability-bundle", r.installation)
+		appNamespace = "org-giantswarm"
+	} else {
+		appName = "observability-bundle"
+		appNamespace = "giantswarm"
+	}
+
+	app := &appsv1alpha1.App{}
+	objectKey := types.NamespacedName{Namespace: appNamespace, Name: appName}
+	err := r.k8sClient.CtrlClient().Get(ctx, objectKey, app)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return unknownObservabilityBundleVersion, nil
+		}
+		return "", err
+	}
+
+	if app.Status.Version != "" {
+		return app.Status.Version, nil
+	}
+	// This avoids a race condition where the app is created for the cluster but not deployed.
+	return unknownObservabilityBundleVersion, nil
 }
 
 func (r *Resource) listWorkerNodes(ctx context.Context) (*v1.NodeList, error) {

--- a/service/controller/resource/monitoring/verticalpodautoscaler/resource_test.go
+++ b/service/controller/resource/monitoring/verticalpodautoscaler/resource_test.go
@@ -17,7 +17,6 @@ import (
 	vpa_clientsetfake "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/client/clientset/versioned/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 
-	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/cluster"
 	"github.com/giantswarm/prometheus-meta-operator/v2/pkg/unittest"
 )
 
@@ -70,13 +69,9 @@ func TestVerticalPodAutoScaler(t *testing.T) {
 
 	testFunc := func(v interface{}) (interface{}, error) {
 		c := Config{
-			Logger:    logger,
-			K8sClient: k8sClient,
-			VpaClient: vpa_clientsetfake.NewSimpleClientset(),
-			Provider: cluster.Provider{
-				Kind:   "aws",
-				Flavor: "vintage",
-			},
+			Logger:       logger,
+			K8sClient:    k8sClient,
+			VpaClient:    vpa_clientsetfake.NewSimpleClientset(),
 			Installation: "test-installation",
 		}
 		r, err := New(c)


### PR DESCRIPTION
This PR should fix VPA issues that arise with the latest kube-prometheus-stack 9.0.0 release.

The issue are coming from the new `scale` subresource that was added to the prometheus CR so the prometheus operator can scale the number of shards of a Prometheus CR using tools like KEDA or the prometheus adapter.

VPA also relies on the scale subresource to find the resoruces that VPA needs to manage (recommend metrics) and to do that, the vpa controllers go up the  topmost controller that has the scale subresource.

Prior to the upgrade of prometheus operator, the topmost controller was  the statefulsetcontroller, but it is not the Prometheus CR.

TO be able to support slow CAPI upgrades, this PR actually uses the version of the observability bundle that runs on the MC to know if PMO should set VPA to use the Prometheus CR as a topmost controller (olly bundle >= 1.2.0 with kube-prometheus-stack > 9.0.0) or the statefulset controller (1.2.0 with kube-prometheus-stack 8.x or lesser)

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
