### PR TITLE
Support multi-provider MCs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Support multi-provider Management clusters.
+
 ## [4.65.0] - 2024-01-29
 
 ### Added

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -4,3 +4,29 @@ type Provider struct {
 	Kind   string
 	Flavor string
 }
+
+const (
+	AWSClusterKind         = "AWSCluster"
+	AWSClusterKindProvider = "capa"
+
+	AWSManagedClusterKind         = "AWSManagedCluster"
+	AWSManagedClusterKindProvider = "eks"
+
+	AzureClusterKind         = "AzureCluster"
+	AzureClusterKindProvider = "capz"
+
+	AzureManagedClusterKind         = "AzureManagedCluster"
+	AzureManagedClusterKindProvider = "aks"
+
+	VCDClusterKind         = "VCDCluster"
+	VCDClusterKindProvider = "cloud-director"
+
+	VSphereClusterKind         = "VSphereCluster"
+	VSphereClusterKindProvider = "vsphere"
+
+	GCPClusterKind         = "GCPCluster"
+	GCPClusterKindProvider = "gcp"
+
+	GCPManagedClusterKind         = "GCPManagedCluster"
+	GCPManagedClusterKindProvider = "gke"
+)

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -148,6 +148,10 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 
 	image := fmt.Sprintf("%s/%s:%s", config.Registry, config.ImageRepository, config.Version)
 	pageTitle := fmt.Sprintf("%s/%s Prometheus", config.Installation, key.ClusterID(cluster))
+	provider, err := key.ClusterProvider(cluster, config.Provider)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	prometheus := &promv1.Prometheus{
 		ObjectMeta: objectMeta,
 		Spec: promv1.PrometheusSpec{
@@ -193,7 +197,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 					key.CustomerKey:     config.Customer,
 					key.InstallationKey: config.Installation,
 					key.PipelineKey:     config.Pipeline,
-					key.ProviderKey:     key.ClusterProvider(cluster, config.Provider),
+					key.ProviderKey:     provider,
 					key.RegionKey:       config.Region,
 				},
 				ExternalURL:        externalURL.String(),

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -38,7 +38,7 @@ spec:
     customer: Giant Swarm
     installation: test-installation
     pipeline: testing
-    provider: eks
+    provider: aws
     region: onprem
   externalUrl: http://prometheus/eks-sample
   image: quay.io/giantswarm/prometheus:v2.28.1

--- a/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
+++ b/service/controller/resource/monitoring/remotewriteapiendpointconfigsecret/resource.go
@@ -107,6 +107,10 @@ func (r *Resource) desiredSecret(ctx context.Context, cluster metav1.Object, nam
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	provider, err := key.ClusterProvider(cluster, r.provider)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	globalConfig := remotewriteconfiguration.GlobalConfig{
 		RemoteWrite: []remotewriteconfiguration.RemoteWrite{
 			remotewriteconfiguration.DefaultRemoteWrite(key.ClusterID(cluster), r.baseDomain, password, r.insecureCA),
@@ -118,7 +122,7 @@ func (r *Resource) desiredSecret(ctx context.Context, cluster metav1.Object, nam
 			key.InstallationKey:    r.installation,
 			key.OrganizationKey:    organization,
 			key.PipelineKey:        r.pipeline,
-			key.ProviderKey:        key.ClusterProvider(cluster, r.provider),
+			key.ProviderKey:        provider,
 			key.RegionKey:          r.region,
 			key.ServicePriorityKey: key.GetServicePriority(cluster),
 		},

--- a/service/controller/resource/monitoring/remotewriteconfig/resource.go
+++ b/service/controller/resource/monitoring/remotewriteconfig/resource.go
@@ -101,6 +101,10 @@ func (r *Resource) desiredConfigMap(ctx context.Context, cluster metav1.Object, 
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}
+	provider, err := key.ClusterProvider(cluster, r.provider)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
 	externalLabels := map[string]string{
 		key.ClusterIDKey:       key.ClusterID(cluster),
 		key.ClusterTypeKey:     key.ClusterType(r.installation, cluster),
@@ -108,7 +112,7 @@ func (r *Resource) desiredConfigMap(ctx context.Context, cluster metav1.Object, 
 		key.InstallationKey:    r.installation,
 		key.OrganizationKey:    organization,
 		key.PipelineKey:        r.pipeline,
-		key.ProviderKey:        key.ClusterProvider(cluster, r.provider),
+		key.ProviderKey:        provider,
 		key.RegionKey:          r.region,
 		key.ServicePriorityKey: key.GetServicePriority(cluster),
 	}

--- a/service/controller/resource/monitoring/scrapeconfigs/resource.go
+++ b/service/controller/resource/monitoring/scrapeconfigs/resource.go
@@ -194,6 +194,11 @@ func getTemplateData(ctx context.Context, ctrlClient client.Client, cluster meta
 		return nil, microerror.Mask(err)
 	}
 
+	provider, err := key.ClusterProvider(cluster, config.Provider)
+	if err != nil {
+		return nil, microerror.Mask(err)
+	}
+
 	var authenticationType = ""
 	if !key.IsManagementCluster(config.Installation, cluster) {
 		authenticationType, err = key.ApiServerAuthenticationType(ctx, config.K8sClient, key.Namespace(cluster))
@@ -212,7 +217,7 @@ func getTemplateData(ctx context.Context, ctrlClient client.Client, cluster meta
 		ServicePriority:           key.GetServicePriority(cluster),
 		Customer:                  config.Customer,
 		Organization:              organization,
-		Provider:                  key.ClusterProvider(cluster, config.Provider),
+		Provider:                  provider,
 		Installation:              config.Installation,
 		SecretName:                key.APIServerCertificatesSecretName,
 		EtcdSecretName:            key.EtcdSecret(config.Installation, cluster),

--- a/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/aws/case-5-eks-v18.golden
@@ -33,7 +33,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: aws
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -106,7 +106,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: aws
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -177,7 +177,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: aws
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -269,7 +269,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: aws
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -401,7 +401,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: aws
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/azure/case-5-eks-v18.golden
@@ -35,7 +35,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: azure
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -110,7 +110,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: azure
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -183,7 +183,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: azure
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -277,7 +277,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: azure
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -409,7 +409,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: eks
+    replacement: azure
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/capa/case-4-azure-v18.golden
@@ -31,7 +31,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -84,7 +84,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -146,7 +146,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -228,7 +228,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -288,7 +288,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -371,7 +371,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -456,7 +456,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -532,7 +532,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -610,7 +610,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -688,7 +688,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -743,7 +743,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -842,7 +842,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -965,7 +965,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: capa
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-2-aws-v16.golden
@@ -31,7 +31,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -84,7 +84,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -146,7 +146,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -228,7 +228,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -288,7 +288,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -371,7 +371,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -456,7 +456,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -532,7 +532,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -610,7 +610,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -688,7 +688,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -743,7 +743,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -842,7 +842,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -965,7 +965,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-3-aws-v18.golden
@@ -36,7 +36,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -98,7 +98,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -180,7 +180,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -240,7 +240,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -314,7 +314,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -392,7 +392,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -470,7 +470,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -564,7 +564,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -690,7 +690,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/gcp/case-4-azure-v18.golden
@@ -31,7 +31,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -84,7 +84,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -146,7 +146,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -228,7 +228,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -288,7 +288,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -371,7 +371,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -456,7 +456,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -532,7 +532,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -610,7 +610,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -688,7 +688,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -743,7 +743,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -842,7 +842,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -965,7 +965,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: gcp
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-2-aws-v16.golden
@@ -31,7 +31,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -84,7 +84,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -146,7 +146,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -228,7 +228,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -288,7 +288,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -371,7 +371,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -456,7 +456,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -532,7 +532,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -610,7 +610,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -688,7 +688,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -743,7 +743,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -842,7 +842,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -965,7 +965,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-3-aws-v18.golden
@@ -36,7 +36,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -98,7 +98,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -180,7 +180,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -240,7 +240,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -314,7 +314,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -392,7 +392,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -470,7 +470,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -564,7 +564,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -690,7 +690,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capa
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/scrapeconfigs/test/openstack/case-4-azure-v18.golden
@@ -31,7 +31,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -84,7 +84,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -146,7 +146,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -228,7 +228,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -288,7 +288,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -371,7 +371,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -456,7 +456,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -532,7 +532,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -610,7 +610,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -688,7 +688,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -743,7 +743,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -842,7 +842,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation
@@ -965,7 +965,7 @@
     replacement: workload_cluster
   # Add provider label.
   - target_label: provider
-    replacement: openstack
+    replacement: capz
   # Add installation label.
   - target_label: installation
     replacement: test-installation

--- a/service/key/error.go
+++ b/service/key/error.go
@@ -12,3 +12,12 @@ var wrongTypeError = &microerror.Error{
 func IsWrongType(err error) bool {
 	return microerror.Cause(err) == wrongTypeError
 }
+
+var infrastructureRefNotFoundError = &microerror.Error{
+	Kind: "infrastructureRefNotFoundError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInfrastructureRefNotFoundError(err error) bool {
+	return microerror.Cause(err) == infrastructureRefNotFoundError
+}

--- a/service/key/key.go
+++ b/service/key/key.go
@@ -119,8 +119,30 @@ func IsCAPIManagementCluster(provider cluster.Provider) bool {
 }
 
 func ClusterProvider(cluster metav1.Object, provider cluster.Provider) string {
-	if IsEKSCluster(cluster) {
-		return "eks"
+	// We keep the existing behavior for vintage management clusters
+	if !IsCAPIManagementCluster(provider) {
+		return provider.Kind
+	}
+
+	if c, ok := cluster.(*capi.Cluster); ok {
+		switch c.Spec.InfrastructureRef.Kind {
+		case "AWSCluster":
+			return "capa"
+		case "AWSManagedCluster":
+			return "eks"
+		case "AzureCluster":
+			return "capz"
+		case "AzureManagedCluster":
+			return "aks"
+		case "VCDCluster":
+			return "cloud-director"
+		case "VSphereCluster":
+			return "vsphere"
+		case "GCPCluster":
+			return "gcp"
+		case "GCPManagedCluster²":
+			return "gke"
+		}
 	}
 	return provider.Kind
 }


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29703

This needs to be tested but this PR adds support for multi-provider MC. It basically configure the provider label depending on the actual infrastructure deployed. We keep it the same for vintage MCs

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
