### PR TITLE
Remove prometheus retention timed limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Free retention duration property of it's 2 weeks limitation if the free storage allows it.
+
 ## [4.65.0] - 2024-01-29
 
 ### Added

--- a/Documentation/storage.md
+++ b/Documentation/storage.md
@@ -10,8 +10,6 @@ As some installations do not support dynamic provisioning (some on-prem installa
 
 ## Retention
 
-Max Retention duration: **2 weeks**
-
 Max Retention size: **95 GB**
 
 ## Volume sizing

--- a/flag/service/prometheus/prometheus.go
+++ b/flag/service/prometheus/prometheus.go
@@ -8,11 +8,6 @@ type Prometheus struct {
 	EvaluationInterval      string
 	ImageRepository         string
 	LogLevel                string
-	Retention               PrometheusRetention
 	ScrapeInterval          string
 	Version                 string
-}
-
-type PrometheusRetention struct {
-	Duration string
 }

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -34,8 +34,6 @@ data:
         {{- end }}
         evaluationInterval: {{ .Values.prometheus.evaluationInterval }}
         logLevel: {{ .Values.prometheus.logLevel }}
-        retention:
-          duration: {{ .Values.prometheus.retention.duration }}
         scrapeInterval: {{ .Values.prometheus.scrapeInterval }}
         imageRepository: {{ .Values.prometheus.imageRepository }}
         {{- if .Values.prometheus.version }}

--- a/helm/prometheus-meta-operator/values.schema.json
+++ b/helm/prometheus-meta-operator/values.schema.json
@@ -240,14 +240,6 @@
                 "logLevel": {
                     "type": "string"
                 },
-                "retention": {
-                    "type": "object",
-                    "properties": {
-                        "duration": {
-                            "type": "string"
-                        }
-                    }
-                },
                 "scrapeInterval": {
                     "type": "string"
                 }

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -62,10 +62,6 @@ prometheus:
   letsencrypt: false
   clusterIssuerName: ""
 
-  retention:
-    ## Retention duration for prometheus.
-    duration: "2w"
-
   ## Default scrape interval for prometheus jobs.
   scrapeInterval: "60s"
 

--- a/main.go
+++ b/main.go
@@ -129,7 +129,6 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().StringSlice(f.Service.Prometheus.Bastions, make([]string, 0), "Address of the bastions.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.EvaluationInterval, "60s", "Evaluation interval for prometheus rules.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.LogLevel, "info", "Prometheus log level.")
-	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Retention.Duration, "2w", "Retention duration for prometheus.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.ScrapeInterval, "60s", "Default scrape interval for prometheus jobs.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.ImageRepository, "giantswarm/prometheus", "Prometheus container image repository.")
 	daemonCommand.PersistentFlags().String(f.Service.Prometheus.Version, "v2.47.1", "Prometheus container image version.")

--- a/service/controller/clusterapi/controller.go
+++ b/service/controller/clusterapi/controller.go
@@ -42,7 +42,6 @@ type ControllerConfig struct {
 	PrometheusBaseDomain         string
 	PrometheusEvaluationInterval string
 	PrometheusLogLevel           string
-	PrometheusRetentionDuration  string
 	PrometheusScrapeInterval     string
 	PrometheusImageRepository    string
 	PrometheusVersion            string

--- a/service/controller/managementcluster/controller.go
+++ b/service/controller/managementcluster/controller.go
@@ -45,7 +45,6 @@ type ControllerConfig struct {
 	PrometheusBaseDomain         string
 	PrometheusEvaluationInterval string
 	PrometheusLogLevel           string
-	PrometheusRetentionDuration  string
 	PrometheusScrapeInterval     string
 	PrometheusImageRepository    string
 	PrometheusVersion            string

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -62,7 +62,6 @@ type resourcesConfig struct {
 	PrometheusBaseDomain         string
 	PrometheusEvaluationInterval string
 	PrometheusLogLevel           string
-	PrometheusRetentionDuration  string
 	PrometheusScrapeInterval     string
 	PrometheusImageRepository    string
 	PrometheusVersion            string
@@ -185,7 +184,6 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			Registry:           config.Registry,
 			EvaluationInterval: config.PrometheusEvaluationInterval,
 			LogLevel:           config.PrometheusLogLevel,
-			RetentionDuration:  config.PrometheusRetentionDuration,
 			ImageRepository:    config.PrometheusImageRepository,
 			ScrapeInterval:     config.PrometheusScrapeInterval,
 		}

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -43,7 +43,6 @@ type Config struct {
 	Region             string
 	Registry           string
 	LogLevel           string
-	RetentionDuration  string
 	ScrapeInterval     string
 	Version            string
 }
@@ -252,7 +251,6 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 			},
 
 			EvaluationInterval: promv1.Duration(config.EvaluationInterval),
-			Retention:          promv1.Duration(config.RetentionDuration),
 			RetentionSize:      promv1.ByteSize(pvcresizing.GetRetentionSize(storageSize)),
 			// Fetches Prometheus rules from any namespace on the Management Cluster
 			// using https://v1-22.docs.kubernetes.io/docs/reference/labels-annotations-taints/#kubernetes-io-metadata-name

--- a/service/controller/resource/monitoring/prometheus/resource_test.go
+++ b/service/controller/resource/monitoring/prometheus/resource_test.go
@@ -80,13 +80,12 @@ func TestPrometheus(t *testing.T) {
 					Kind:   "aws",
 					Flavor: "vintage",
 				},
-				Region:            "onprem",
-				ImageRepository:   "giantswarm/prometheus",
-				LogLevel:          "debug",
-				Registry:          "quay.io",
-				RetentionDuration: "2w",
-				ScrapeInterval:    "60s",
-				Version:           "v2.28.1",
+				Region:          "onprem",
+				ImageRepository: "giantswarm/prometheus",
+				LogLevel:        "debug",
+				Registry:        "quay.io",
+				ScrapeInterval:  "60s",
+				Version:         "v2.28.1",
 			}
 
 			return toPrometheus(context.Background(), v, config)

--- a/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
@@ -66,7 +66,6 @@ spec:
     requests:
       cpu: 100m
       memory: "1073741824"
-  retention: 2w
   retentionSize: 85GiB
   routePrefix: /kubernetes
   ruleNamespaceSelector:

--- a/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
@@ -60,7 +60,6 @@ spec:
     requests:
       cpu: 100m
       memory: "1073741824"
-  retention: 2w
   retentionSize: 85GiB
   routePrefix: /alice
   ruleNamespaceSelector:

--- a/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
@@ -60,7 +60,6 @@ spec:
     requests:
       cpu: 100m
       memory: "1073741824"
-  retention: 2w
   retentionSize: 85GiB
   routePrefix: /baz
   ruleNamespaceSelector:

--- a/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
@@ -60,7 +60,6 @@ spec:
     requests:
       cpu: 100m
       memory: "1073741824"
-  retention: 2w
   retentionSize: 85GiB
   routePrefix: /foo
   ruleNamespaceSelector:

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -60,7 +60,6 @@ spec:
     requests:
       cpu: 100m
       memory: "1073741824"
-  retention: 2w
   retentionSize: 85GiB
   routePrefix: /eks-sample
   ruleNamespaceSelector:

--- a/service/controller/resource/resource.go
+++ b/service/controller/resource/resource.go
@@ -58,7 +58,6 @@ type Config struct {
 	PrometheusBaseDomain         string
 	PrometheusEvaluationInterval string
 	PrometheusLogLevel           string
-	PrometheusRetentionDuration  string
 	PrometheusScrapeInterval     string
 	PrometheusImageRepository    string
 	PrometheusVersion            string
@@ -254,7 +253,6 @@ func New(config Config) ([]resource.Interface, error) {
 			Region:             config.Region,
 			Registry:           config.Registry,
 			LogLevel:           config.PrometheusLogLevel,
-			RetentionDuration:  config.PrometheusRetentionDuration,
 			EvaluationInterval: config.PrometheusEvaluationInterval,
 			ImageRepository:    config.PrometheusImageRepository,
 			ScrapeInterval:     config.PrometheusScrapeInterval,

--- a/service/service.go
+++ b/service/service.go
@@ -164,7 +164,6 @@ func New(config Config) (*Service, error) {
 			PrometheusBaseDomain:         config.Viper.GetString(config.Flag.Service.Prometheus.BaseDomain),
 			PrometheusEvaluationInterval: config.Viper.GetString(config.Flag.Service.Prometheus.EvaluationInterval),
 			PrometheusLogLevel:           config.Viper.GetString(config.Flag.Service.Prometheus.LogLevel),
-			PrometheusRetentionDuration:  config.Viper.GetString(config.Flag.Service.Prometheus.Retention.Duration),
 			PrometheusScrapeInterval:     config.Viper.GetString(config.Flag.Service.Prometheus.ScrapeInterval),
 			PrometheusImageRepository:    config.Viper.GetString(config.Flag.Service.Prometheus.ImageRepository),
 			PrometheusVersion:            config.Viper.GetString(config.Flag.Service.Prometheus.Version),
@@ -209,7 +208,6 @@ func New(config Config) (*Service, error) {
 			PrometheusBaseDomain:         config.Viper.GetString(config.Flag.Service.Prometheus.BaseDomain),
 			PrometheusEvaluationInterval: config.Viper.GetString(config.Flag.Service.Prometheus.EvaluationInterval),
 			PrometheusLogLevel:           config.Viper.GetString(config.Flag.Service.Prometheus.LogLevel),
-			PrometheusRetentionDuration:  config.Viper.GetString(config.Flag.Service.Prometheus.Retention.Duration),
 			PrometheusImageRepository:    config.Viper.GetString(config.Flag.Service.Prometheus.ImageRepository),
 			PrometheusVersion:            config.Viper.GetString(config.Flag.Service.Prometheus.Version),
 


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/23526

This PR removes setting the prometheus retention to 2 weeks to keep as much data we can in Prometheus. This will not change anything on big clusters because we can only keep around 2 days of data but let's see :)


## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
