### PR TITLE
Remove deprecated warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix how we enable `remote-write-receiver` to avoid deprecated warnings.
+
 ## [4.65.0] - 2024-01-29
 
 ### Added

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -186,7 +186,7 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 						},
 					},
 				},
-				EnableFeatures: []string{"remote-write-receiver"},
+				EnableRemoteWriteReceiver: true,
 				ExternalLabels: map[string]string{
 					key.ClusterIDKey:    key.ClusterID(cluster),
 					key.ClusterTypeKey:  key.ClusterType(config.Installation, cluster),

--- a/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-1-vintage-mc.golden
@@ -30,8 +30,7 @@ spec:
       cert: {}
       insecureSkipVerify: true
   arbitraryFSAccessThroughSMs: {}
-  enableFeatures:
-  - remote-write-receiver
+  enableRemoteWriteReceiver: true
   evaluationInterval: 60s
   externalLabels:
     cluster_id: kubernetes

--- a/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-2-aws-v16.golden
@@ -29,8 +29,7 @@ spec:
       caFile: /etc/prometheus/secrets/cluster-certificates/ca
       cert: {}
   arbitraryFSAccessThroughSMs: {}
-  enableFeatures:
-  - remote-write-receiver
+  enableRemoteWriteReceiver: true
   evaluationInterval: 60s
   externalLabels:
     cluster_id: alice

--- a/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-3-aws-v18.golden
@@ -29,8 +29,7 @@ spec:
       caFile: /etc/prometheus/secrets/cluster-certificates/ca
       cert: {}
   arbitraryFSAccessThroughSMs: {}
-  enableFeatures:
-  - remote-write-receiver
+  enableRemoteWriteReceiver: true
   evaluationInterval: 60s
   externalLabels:
     cluster_id: baz

--- a/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-4-azure-v18.golden
@@ -29,8 +29,7 @@ spec:
       caFile: /etc/prometheus/secrets/cluster-certificates/ca
       cert: {}
   arbitraryFSAccessThroughSMs: {}
-  enableFeatures:
-  - remote-write-receiver
+  enableRemoteWriteReceiver: true
   evaluationInterval: 60s
   externalLabels:
     cluster_id: foo

--- a/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/case-5-eks-v18.golden
@@ -29,8 +29,7 @@ spec:
       caFile: /etc/prometheus/secrets/cluster-certificates/ca
       cert: {}
   arbitraryFSAccessThroughSMs: {}
-  enableFeatures:
-  - remote-write-receiver
+  enableRemoteWriteReceiver: true
   evaluationInterval: 60s
   externalLabels:
     cluster_id: eks-sample


### PR DESCRIPTION
We are enabling remote-write-feature in a deprecated way:
`ts=2024-02-05T12:50:23.533Z caller=main.go:172 level=warn msg="Remote write receiver enabled via feature flag remote-write-receiver. This is DEPRECATED. Use --web.enable-remote-write-receiver."`

This PR should fix that

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
