### PR TITLE
add logging to debug issue with already existing cilium netpols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix error for already existing `ciliumNetworkPolicy`.
+
 ## [4.67.0] - 2024-02-12
 
 ### Added

--- a/service/controller/resource/ciliumnetpol/create.go
+++ b/service/controller/resource/ciliumnetpol/create.go
@@ -24,7 +24,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 		}
 
 		ciliumnetpol, err := r.dynamicK8sClient.Resource(resource).Get(ctx, desired.GetName(), metav1.GetOptions{})
-		r.logger.Log(ciliumnetpol)
+		r.logger.Debugf(ctx, "ciliumnetpol: %#v", ciliumnetpol)
 		if apierrors.IsNotFound(err) {
 			_, err = r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Create(ctx, desired, metav1.CreateOptions{})
 		}

--- a/service/controller/resource/ciliumnetpol/create.go
+++ b/service/controller/resource/ciliumnetpol/create.go
@@ -23,7 +23,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		ciliumnetpol, err := r.dynamicK8sClient.Resource(resource).Get(ctx, desired.GetName(), metav1.GetOptions{})
+		ciliumnetpol, err := r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Get(ctx, desired.GetName(), metav1.GetOptions{})
 		r.logger.Debugf(ctx, "ciliumnetpol: %#v", ciliumnetpol)
 		if apierrors.IsNotFound(err) {
 			_, err = r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Create(ctx, desired, metav1.CreateOptions{})

--- a/service/controller/resource/ciliumnetpol/create.go
+++ b/service/controller/resource/ciliumnetpol/create.go
@@ -23,8 +23,7 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		ciliumnetpol, err := r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Get(ctx, desired.GetName(), metav1.GetOptions{})
-		r.logger.Debugf(ctx, "ciliumnetpol: %#v", ciliumnetpol)
+		_, err = r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Get(ctx, desired.GetName(), metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			_, err = r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Create(ctx, desired, metav1.CreateOptions{})
 		}

--- a/service/controller/resource/ciliumnetpol/create.go
+++ b/service/controller/resource/ciliumnetpol/create.go
@@ -23,7 +23,8 @@ func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
 			return microerror.Mask(err)
 		}
 
-		_, err = r.dynamicK8sClient.Resource(resource).Get(ctx, desired.GetName(), metav1.GetOptions{})
+		ciliumnetpol, err := r.dynamicK8sClient.Resource(resource).Get(ctx, desired.GetName(), metav1.GetOptions{})
+		r.logger.Log(ciliumnetpol)
 		if apierrors.IsNotFound(err) {
 			_, err = r.dynamicK8sClient.Resource(resource).Namespace(desired.GetNamespace()).Create(ctx, desired, metav1.CreateOptions{})
 		}


### PR DESCRIPTION
This PR aims to fix the current issue with PMO which throws error when a ciliumnetpol already exist for prometheus on the MC. Example log : 
```
{"caller":"github.com/giantswarm/micrologger@v1.1.1/logger.go:88","controller":"prometheus-meta-operator-cluster-api-controller","event":"update","level":"error","loop":"186","message":"retrying due to error","object":"org-adidas/deu01","resource":"ciliumnetpol","stack":{"annotatio
n":"ciliumnetworkpolicies.cilium.io \"deu01-prometheus\" already exists","kind":"unknown","stack":[{"file":"/root/project/service/controller/resource/ciliumnetpol/create.go","line":31},{"file":"/go/pkg/mod/github.com/giantswarm/operatorkit/v7@v7.2.0/pkg/resource/wrapper/retryresour
ce/basic_resource.go","line":52}]},"time":"2024-02-12T14:59:38.510872+00:00","version":"1684122888"} 
```

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
