### PR TITLE
Add alertmanager missing CNP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing ciliumnetworkpolicy for alertmanager.
+
 ## [4.68.1] - 2024-02-15
 
 ### Added

--- a/helm/prometheus-meta-operator/templates/alertmanager/cilium-network-policy.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/cilium-network-policy.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.ciliumNetworkPolicy.enabled -}}
+{{- if .Capabilities.APIVersions.Has "cilium.io/v2" -}}
+apiVersion: "cilium.io/v2"
+kind: CiliumNetworkPolicy
+metadata:
+  labels:
+    {{- include "labels.common" . | nindent 4 }}
+  name: alertmanager
+  namespace: {{ include "resource.default.namespace" . }}
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: alertmanager
+  egress:
+    - toEntities:
+      ## Needed to access opsgenie.
+      - world
+  ingress:
+    - fromEntities:
+      - cluster
+      toPorts:
+      - ports:
+        - port: "9093"
+          protocol: "TCP"
+{{ end }}
+{{ end }}


### PR DESCRIPTION
Alertmanager is failing to work on gcapeverde, because it's lacking a CNP

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
