### PR TITLE
Remove alerting from Prometheus if mimir is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove alerting from Prometheus if mimir is enabled.
+
 ## [4.69.0] - 2024-03-12
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/giantswarm/prometheus-meta-operator/v2
 
-go 1.22.1
+go 1.22.0
 
 require (
 	github.com/Masterminds/sprig v2.22.0+incompatible

--- a/service/controller/clusterapi/resource.go
+++ b/service/controller/clusterapi/resource.go
@@ -32,6 +32,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/namespace"
+	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/noop"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/rbac"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/wrapper/monitoringdisabledresource"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -352,7 +353,10 @@ func New(config Config) ([]resource.Interface, error) {
 	}
 
 	var alertmanagerWiringResource resource.Interface
-	{
+	// This resource creates a static secret to connect Prometheus to Alertmanager. When using mimir, this is not needed anymore
+	if config.MimirEnabled {
+		alertmanagerWiringResource = &noop.Resource{}
+	} else {
 		c := alertmanagerwiring.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -33,6 +33,7 @@ import (
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/scrapeconfigs"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/monitoring/verticalpodautoscaler"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/namespace"
+	noop "github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/noop"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/rbac"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/controller/resource/wrapper/monitoringdisabledresource"
 	"github.com/giantswarm/prometheus-meta-operator/v2/service/key"
@@ -145,7 +146,10 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	}
 
 	var alertmanagerWiringResource resource.Interface
-	{
+	// This resource creates a static secret to connect Prometheus to Alertmanager. When using mimir, this is not needed anymore
+	if config.MimirEnabled {
+		alertmanagerWiringResource = &noop.Resource{}
+	} else {
 		c := alertmanagerwiring.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,

--- a/service/controller/resource/alerting/alertmanagerwiring/resource.go
+++ b/service/controller/resource/alerting/alertmanagerwiring/resource.go
@@ -73,7 +73,7 @@ func getObjectMeta(ctx context.Context, v interface{}) (metav1.ObjectMeta, error
 	}, nil
 }
 
-func toData(v interface{}) []byte {
+func toData() []byte {
 	return []byte(alertmanagerConfig)
 }
 
@@ -86,7 +86,7 @@ func toSecret(ctx context.Context, v interface{}) (metav1.Object, error) {
 	secret := &corev1.Secret{
 		ObjectMeta: objectMeta,
 		Data: map[string][]byte{
-			key.AlertmanagerKey(): toData(v),
+			key.AlertmanagerKey(): toData(),
 		},
 	}
 

--- a/service/controller/resource/alerting/alertmanagerwiring/resource_test.go
+++ b/service/controller/resource/alerting/alertmanagerwiring/resource_test.go
@@ -23,7 +23,7 @@ func TestAlertmanagerconfig(t *testing.T) {
 			OutputDir: outputDir,
 			T:         t,
 			TestFunc: func(v interface{}) (interface{}, error) {
-				return toData(v), nil
+				return toData(), nil
 			},
 			TestFuncReturnsBytes: true,
 			Update:               *update,

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-1-capa-mc.golden
@@ -8,9 +8,6 @@ metadata:
   name: test-installation
   namespace: test-installation-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-2-capa.golden
@@ -8,9 +8,6 @@ metadata:
   name: baz
   namespace: baz-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-3-capz.golden
@@ -8,9 +8,6 @@ metadata:
   name: foo
   namespace: foo-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-4-eks.golden
@@ -8,9 +8,6 @@ metadata:
   name: eks-sample
   namespace: eks-sample-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/capi/case-5-gcp.golden
@@ -8,9 +8,6 @@ metadata:
   name: gcp-sample
   namespace: gcp-sample-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -8,9 +8,6 @@ metadata:
   name: kubernetes
   namespace: kubernetes-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -8,9 +8,6 @@ metadata:
   name: alice
   namespace: alice-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -8,9 +8,6 @@ metadata:
   name: baz
   namespace: baz-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/mimir-enabled/vintage/case-4-azure-v18.golden
@@ -8,9 +8,6 @@ metadata:
   name: foo
   namespace: foo-prometheus
 spec:
-  additionalAlertManagerConfigs:
-    key: alertmanager-additional.yaml
-    name: alertmanager-config
   additionalScrapeConfigs:
     key: prometheus-additional.yaml
     name: additional-scrape-configs

--- a/service/controller/resource/noop/noop.go
+++ b/service/controller/resource/noop/noop.go
@@ -1,0 +1,41 @@
+package noop
+
+import (
+	"context"
+
+	"github.com/giantswarm/micrologger"
+)
+
+const (
+	Name = "noop"
+)
+
+type Config struct {
+	Logger micrologger.Logger
+}
+
+type Resource struct {
+	logger micrologger.Logger
+}
+
+func New(config Config) (*Resource, error) {
+	r := &Resource{
+		logger: config.Logger,
+	}
+
+	return r, nil
+}
+
+func (r *Resource) Name() string {
+	return Name
+}
+
+func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	r.logger.Debugf(ctx, "noop create")
+	return nil
+}
+
+func (r *Resource) EnsureDeleted(ctx context.Context, obj interface{}) error {
+	r.logger.Debugf(ctx, "noop delete")
+	return nil
+}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3160

This PR removes alerting from prometheus to alertmanager if mimir is enabled to avoid duplicate alerts.

Alerting will keep working thanks to https://github.com/giantswarm/shared-configs/commit/bcd2f81fe326c06d7cd3f076006e3d642d866fa6

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
