### PR TITLE
Fix Prometheus Source Link in Notification template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix missing prometheus link in notification template.
+
 ## [4.70.1] - 2024-03-12
 
 ### Fixed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -191,17 +191,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -218,17 +218,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -245,17 +245,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -272,17 +272,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -295,17 +295,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -322,17 +322,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -345,17 +345,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -377,17 +377,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -25,7 +25,7 @@
 {{ end }}
 
 [[- if .MimirEnabled ]]
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
+{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
 [[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -3,6 +3,13 @@
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
+[[- if .MimirEnabled ]]
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}[[ .PrometheusAddress ]]/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+[[- else ]]
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+[[- end ]]
+
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
@@ -24,10 +31,6 @@
 {{- end }}
 {{ end }}
 
-[[- if .MimirEnabled ]]
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
-[[- end ]]
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
@@ -45,11 +48,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -129,8 +129,8 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 	var alertmanagerConfigResource resource.Interface
 	{
 		c := alertmanagerconfig.Config{
-			K8sClient:      config.K8sClient,
-			Logger:         config.Logger,
+			K8sClient: config.K8sClient,
+			Logger:    config.Logger,
 
 			BaseDomain:     config.PrometheusBaseDomain,
 			GrafanaAddress: config.GrafanaAddress,

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -131,14 +131,15 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		c := alertmanagerconfig.Config{
 			K8sClient:      config.K8sClient,
 			Logger:         config.Logger,
-			BaseDomain: config.PrometheusBaseDomain,
-			Installation:   config.Installation,
-			Proxy:          config.Proxy,
-			OpsgenieKey:    config.OpsgenieKey,
+
+			BaseDomain:     config.PrometheusBaseDomain,
 			GrafanaAddress: config.GrafanaAddress,
-			SlackApiURL:    config.SlackApiURL,
+			Installation:   config.Installation,
+			MimirEnabled:   config.MimirEnabled,
+			OpsgenieKey:    config.OpsgenieKey,
 			Pipeline:       config.Pipeline,
-			MimirEnabled: config.MimirEnabled,
+			Proxy:          config.Proxy,
+			SlackApiURL:    config.SlackApiURL,
 		}
 
 		alertmanagerConfigResource, err = alertmanagerconfig.New(c)

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -131,12 +131,14 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		c := alertmanagerconfig.Config{
 			K8sClient:      config.K8sClient,
 			Logger:         config.Logger,
+			BaseDomain: config.PrometheusBaseDomain,
 			Installation:   config.Installation,
 			Proxy:          config.Proxy,
 			OpsgenieKey:    config.OpsgenieKey,
 			GrafanaAddress: config.GrafanaAddress,
 			SlackApiURL:    config.SlackApiURL,
 			Pipeline:       config.Pipeline,
+			MimirEnabled: config.MimirEnabled,
 		}
 
 		alertmanagerConfigResource, err = alertmanagerconfig.New(c)

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -46,12 +46,11 @@ type NotificationTemplateData struct {
 }
 
 type AlertmanagerTemplateData struct {
-	GrafanaAddress string
-	Installation   string
-	OpsgenieKey    string
-	Pipeline       string
-	ProxyURL       string
-	SlackApiURL    string
+	Installation string
+	OpsgenieKey  string
+	Pipeline     string
+	ProxyURL     string
+	SlackApiURL  string
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -156,11 +155,10 @@ func getTemplateData(config Config) (*AlertmanagerTemplateData, error) {
 	}
 
 	d := &AlertmanagerTemplateData{
-		Installation:   config.Installation,
-		OpsgenieKey:    config.OpsgenieKey,
-		GrafanaAddress: config.GrafanaAddress,
-		SlackApiURL:    config.SlackApiURL,
-		Pipeline:       config.Pipeline,
+		Installation: config.Installation,
+		OpsgenieKey:  config.OpsgenieKey,
+		Pipeline:     config.Pipeline,
+		SlackApiURL:  config.SlackApiURL,
 	}
 
 	if proxyURL != nil {

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -29,30 +29,29 @@ type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
-	Installation   string
-	Proxy          func(reqURL *url.URL) (*url.URL, error)
-	OpsgenieKey    string
+	BaseDomain     string
 	GrafanaAddress string
-	SlackApiURL    string
+	Installation   string
+	MimirEnabled   bool
+	OpsgenieKey    string
 	Pipeline       string
-
-	MimirEnabled bool
-	BaseDomain string
+	Proxy          func(reqURL *url.URL) (*url.URL, error)
+	SlackApiURL    string
 }
 
 type NotificationTemplateData struct {
-	GrafanaAddress string
-	MimirEnabled   bool
+	GrafanaAddress    string
+	MimirEnabled      bool
 	PrometheusAddress string
 }
 
 type AlertmanagerTemplateData struct {
-	Installation   string
-	ProxyURL       string
-	OpsgenieKey    string
 	GrafanaAddress string
-	SlackApiURL    string
+	Installation   string
+	OpsgenieKey    string
 	Pipeline       string
+	ProxyURL       string
+	SlackApiURL    string
 }
 
 func New(config Config) (*generic.Resource, error) {
@@ -119,8 +118,8 @@ func toSecret(v interface{}, config Config) (*corev1.Secret, error) {
 
 func renderNotificationTemplate(templateDirectory string, config Config) ([]byte, error) {
 	templateData := NotificationTemplateData{
-		GrafanaAddress: config.GrafanaAddress,
-		MimirEnabled:   config.MimirEnabled,
+		GrafanaAddress:    config.GrafanaAddress,
+		MimirEnabled:      config.MimirEnabled,
 		PrometheusAddress: fmt.Sprintf("https://%s", config.BaseDomain),
 	}
 

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -2,6 +2,7 @@ package alertmanagerconfig
 
 import (
 	"context"
+	"fmt"
 	"net/url"
 	"path"
 	"reflect"
@@ -34,10 +35,15 @@ type Config struct {
 	GrafanaAddress string
 	SlackApiURL    string
 	Pipeline       string
+
+	MimirEnabled bool
+	BaseDomain string
 }
 
 type NotificationTemplateData struct {
 	GrafanaAddress string
+	MimirEnabled   bool
+	PrometheusAddress string
 }
 
 type AlertmanagerTemplateData struct {
@@ -112,7 +118,11 @@ func toSecret(v interface{}, config Config) (*corev1.Secret, error) {
 }
 
 func renderNotificationTemplate(templateDirectory string, config Config) ([]byte, error) {
-	templateData := NotificationTemplateData{config.GrafanaAddress}
+	templateData := NotificationTemplateData{
+		GrafanaAddress: config.GrafanaAddress,
+		MimirEnabled:   config.MimirEnabled,
+		PrometheusAddress: fmt.Sprintf("https://%s", config.BaseDomain),
+	}
 
 	data, err := template.RenderTemplate(templateData, path.Join(templateDirectory, notificationTemplatePath))
 	if err != nil {

--- a/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource_test.go
@@ -12,7 +12,7 @@ import (
 
 var update = flag.Bool("update", false, "update the output file")
 
-func TestRenderingOfAlertmanagerNotificationTemplate(t *testing.T) {
+func TestRenderingOfAlertmanagerNotificationTemplateWithLegacyMonitoring(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{
 		config := Config{
@@ -25,7 +25,7 @@ func TestRenderingOfAlertmanagerNotificationTemplate(t *testing.T) {
 	}
 
 	for _, flavor := range unittest.ProviderFlavors {
-		outputDir, err := filepath.Abs("./test/notification-template/" + flavor)
+		outputDir, err := filepath.Abs("./test/notification-template/classic/" + flavor)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -49,6 +49,47 @@ func TestRenderingOfAlertmanagerNotificationTemplate(t *testing.T) {
 		}
 	}
 }
+
+func TestRenderingOfAlertmanagerNotificationTemplateWithMimirEnabled(t *testing.T) {
+	var testFunc unittest.TestFunc
+	{
+		config := Config{
+			Installation:   "test-installation",
+			GrafanaAddress: "https://grafana",
+			MimirEnabled:   true,
+			BaseDomain:     "prometheus.installation-prometheus.svc",
+		}
+		testFunc = func(v interface{}) (interface{}, error) {
+			return renderNotificationTemplate(unittest.ProjectRoot(), config)
+		}
+	}
+
+	for _, flavor := range unittest.ProviderFlavors {
+		outputDir, err := filepath.Abs("./test/notification-template/mimir-enabled/" + flavor)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		c := unittest.Config{
+			OutputDir:            outputDir,
+			T:                    t,
+			TestFunc:             testFunc,
+			Flavor:               flavor,
+			TestFuncReturnsBytes: true,
+			Update:               *update,
+		}
+		runner, err := unittest.NewRunner(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = runner.Run()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
 func TestRenderingOfAlertmanagerConfig(t *testing.T) {
 	var testFunc unittest.TestFunc
 	{

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-1-capa-mc.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-2-capa.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-3-capz.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-4-eks.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/capi/case-5-gcp.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-1-vintage-mc.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-2-aws-v16.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-3-aws-v18.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/vintage/case-4-azure-v18.golden
@@ -118,17 +118,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -141,17 +141,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -164,17 +164,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -187,17 +187,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -210,17 +210,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -233,17 +233,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -256,17 +256,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -279,17 +279,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" .}}'
@@ -307,17 +307,17 @@ receivers:
     actions:
     - type: button
       text: ':green_book: OpsRecipe'
-      url: 'https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}'
+      url: '{{ template "__runbookurl" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ (index .Alerts 0).GeneratorURL }}'
+      url: '{{ template "__prometheusurl" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: 'https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}'
+      url: '{{ template "__dashboardurl" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-4-azure-v18.golden
@@ -2,6 +2,7 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheusurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -41,7 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-4-azure-v18.golden
@@ -24,7 +24,6 @@
 {{- end }}
 {{ end }}
 
-
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-4-azure-v18.golden
@@ -2,6 +2,8 @@
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__prometheus_query_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }}{{ (index .Alerts 0).Labels.cluster_id }}{{ else }}{{ (index .Alerts 0).Labels.installation }}{{ end }}{{ end }}
+{{ define "__prometheusurl" }}https://prometheus.installation-prometheus.svc/{{ template "__prometheus_query_cluster_id" . }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -23,7 +25,6 @@
 {{ end }}
 {{- end }}
 {{ end }}
-{{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -42,7 +43,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
+👀 Prometheus: {{ template "__prometheusurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-4-azure-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-4-azure-v18.golden
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 {{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
+{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
@@ -23,10 +23,7 @@
 {{ end }}
 {{- end }}
 {{ end }}
-
-[[- if .MimirEnabled ]]
 {{ define "prometheus_cluster_id" }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ else }}(index .Alerts 0).Labels.installation{{ end }}{{ end }}
-[[- end ]]
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
@@ -45,11 +42,7 @@
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-[[- if .MimirEnabled ]]
-👀 Prometheus: [[ .PrometheusAddress ]]/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
-[[- else ]]
-👀 Prometheus: {{ (index .Alerts 0).GeneratorURL }}
-[[- end ]]
+👀 Prometheus: https://prometheus.installation-prometheus.svc/{{ template "prometheus_cluster_id" . }}/{{ (index .Alerts 0).GeneratorURL }}
 
 ---
 


### PR DESCRIPTION
This PR builds the prometheus link for mimir-enabled installations. This will work as long as we do not tear down our old prometheus

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
