### PR TITLE
Remove alertmanager namespace injection in matchers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- To ensure that customers can define their own AlertmanagerConfig CRs, we need to remove the default alertmanager matcher injection (cf. upstream https://github.com/prometheus-operator/prometheus-operator/issues/4033)
+
 ## [4.72.0] - 2024-04-03
 
 ### Changed

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager.yaml
@@ -19,6 +19,8 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: alertmanager
       app.kubernetes.io/name: alertmanager
+  alertmanagerConfigMatcherStrategy:
+    type: None
   configSecret: alertmanager-config
   externalUrl: {{ .Values.alertmanager.address }}
   image: {{ printf "%s/%s:%s" .Values.registry.domain .Values.alertmanager.imageRepository .Values.alertmanager.version }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/wepa/issues/62

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
