### PR TITLE
fix slack_configs http_config missing proxy_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ensure proxy url is set when needed within slack_configs
+
 ## [4.73.0] - 2024-04-30
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -204,6 +204,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -237,6 +240,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -270,6 +276,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -303,6 +312,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -336,6 +348,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -365,6 +380,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -398,6 +416,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -427,6 +448,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -456,6 +480,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -494,6 +521,9 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/30612

Ensure when a Proxy URL is configured it is also set within the http_config for slack.