### PR TITLE
Replace apiserver down with controlplane unhealthy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `cluster_control_plane_unhealthy` inhibition.
 
+### Removed
+
+- Removed `apiserver_down` inhibition.
+
 ## [4.74.0] - 2024-05-02
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -677,17 +677,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
-
-- source_matchers:
   - outside_working_hours=true
   target_matchers:
   - cancel_if_outside_working_hours=true

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -618,6 +618,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -427,6 +427,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -479,17 +484,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -446,6 +446,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -498,17 +503,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -467,6 +467,11 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+  - cluster_control_plane_unhealthy=true
+  target_matchers:
+  - cancel_if_any_cluster_control_plane_unhealthy=true
+
+- source_matchers:
   - instance_state_not_running=true
   target_matchers:
   - cancel_if_instance_state_not_running=true
@@ -519,17 +524,6 @@ inhibit_rules:
   target_matchers:
   - cancel_if_control_plane_node_down=true
   equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_apiserver_down=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - apiserver_down=true
-  target_matchers:
-  - cancel_if_any_apiserver_down=true
 
 - source_matchers:
   - outside_working_hours=true


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/26508

Removes "apiserver_down" dummy inhibition, substituted by "cluster_control_plane_unhealthy". 

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Updated changelog in `CHANGELOG.md`
