### PR TITLE
Mimir enabled: Delete per cluster heartbeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Delete per cluster heartbeats when Mimir is enabled.
+
 ## [4.75.1] - 2024-05-23
 
 ### Changed

--- a/service/controller/clusterapi/resource.go
+++ b/service/controller/clusterapi/resource.go
@@ -363,6 +363,8 @@ func New(config Config) ([]resource.Interface, error) {
 			Installation: config.Installation,
 			OpsgenieKey:  config.OpsgenieKey,
 			Pipeline:     config.Pipeline,
+
+			MimirEnabled: config.MimirEnabled,
 		}
 
 		heartbeatResource, err = heartbeat.New(c)

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -290,6 +290,8 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			Logger:       config.Logger,
 			OpsgenieKey:  config.OpsgenieKey,
 			Pipeline:     config.Pipeline,
+
+			MimirEnabled: config.MimirEnabled,
 		}
 
 		heartbeatResource, err = heartbeat.New(c)

--- a/service/controller/resource/alerting/heartbeat/create.go
+++ b/service/controller/resource/alerting/heartbeat/create.go
@@ -8,6 +8,11 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	if r.mimirEnabled {
+		r.logger.Debugf(ctx, "mimir is enabled, deleting heartbeat if it exists")
+		return r.EnsureDeleted(ctx, obj)
+	}
+
 	desired, err := toHeartbeat(obj, r.installation, r.pipeline)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/alerting/heartbeat/resource.go
+++ b/service/controller/resource/alerting/heartbeat/resource.go
@@ -25,6 +25,8 @@ type Config struct {
 	Installation string
 	OpsgenieKey  string
 	Pipeline     string
+
+	MimirEnabled bool
 }
 
 type Resource struct {
@@ -32,6 +34,8 @@ type Resource struct {
 	heartbeatClient *heartbeat.Client
 	installation    string
 	pipeline        string
+
+	mimirEnabled bool
 }
 
 func New(config Config) (*Resource, error) {
@@ -64,6 +68,7 @@ func New(config Config) (*Resource, error) {
 		heartbeatClient: client,
 		installation:    config.Installation,
 		pipeline:        config.Pipeline,
+		mimirEnabled:    config.MimirEnabled,
 	}
 
 	return r, nil

--- a/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
+++ b/service/controller/resource/alerting/heartbeatwebhookconfig/resource.go
@@ -39,7 +39,7 @@ func New(config Config) (*generic.Resource, error) {
 		Logger:     config.Logger,
 		Name:       Name,
 		GetObjectMeta: func(ctx context.Context, v interface{}) (metav1.ObjectMeta, error) {
-			return getObjectMeta(v, config)
+			return getObjectMeta(v)
 		},
 		GetDesiredObject: func(ctx context.Context, v interface{}) (metav1.Object, error) {
 			return toAlertmanagerConfig(v, config)
@@ -54,7 +54,7 @@ func New(config Config) (*generic.Resource, error) {
 	return r, nil
 }
 
-func getObjectMeta(v interface{}, config Config) (metav1.ObjectMeta, error) {
+func getObjectMeta(v interface{}) (metav1.ObjectMeta, error) {
 	cluster, err := key.ToCluster(v)
 	if err != nil {
 		return metav1.ObjectMeta{}, microerror.Mask(err)
@@ -72,7 +72,7 @@ func toAlertmanagerConfig(v interface{}, config Config) (metav1.Object, error) {
 		return nil, nil
 	}
 
-	objectMeta, err := getObjectMeta(v, config)
+	objectMeta, err := getObjectMeta(v)
 	if err != nil {
 		return nil, microerror.Mask(err)
 	}


### PR DESCRIPTION
## Checklist

Towards https://github.com/giantswarm/roadmap/issues/3218 this PR gets rids of olds heartbeats when Mimir is enabled

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
