### PR TITLE
add-delete-if-mimir-enabled to generic resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Internal rework to remove the use generic resource to ease out the migration to Mimir.
+- Update generic resource so we can delete resources if mimir is enabled.
 - Remove unused scrape_timeout inhibition.
 
 ## [4.76.0] - 2024-06-03

--- a/service/controller/resource/generic/create.go
+++ b/service/controller/resource/generic/create.go
@@ -11,6 +11,9 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	if r.deleteIfMimirEnabled {
+		return r.EnsureDeleted(ctx, obj)
+	}
 	desired, err := r.getDesiredObject(ctx, obj)
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/generic/resource.go
+++ b/service/controller/resource/generic/resource.go
@@ -42,15 +42,18 @@ type Config struct {
 	// the given resource and returns true if there is a difference between
 	// them and therefore state needs to be reconciled to match the desired.
 	HasChangedFunc func(metav1.Object, metav1.Object) bool
+
+	DeleteIfMimirEnabled bool
 }
 
 type Resource struct {
-	clientFunc       func(string) Interface
-	logger           micrologger.Logger
-	name             string
-	getObjectMeta    func(context.Context, interface{}) (metav1.ObjectMeta, error)
-	getDesiredObject func(context.Context, interface{}) (metav1.Object, error)
-	hasChangedFunc   func(metav1.Object, metav1.Object) bool
+	clientFunc           func(string) Interface
+	logger               micrologger.Logger
+	name                 string
+	getObjectMeta        func(context.Context, interface{}) (metav1.ObjectMeta, error)
+	getDesiredObject     func(context.Context, interface{}) (metav1.Object, error)
+	hasChangedFunc       func(metav1.Object, metav1.Object) bool
+	deleteIfMimirEnabled bool
 }
 
 func New(config Config) (*Resource, error) {
@@ -74,12 +77,13 @@ func New(config Config) (*Resource, error) {
 	}
 
 	r := &Resource{
-		clientFunc:       config.ClientFunc,
-		logger:           config.Logger,
-		name:             config.Name,
-		getObjectMeta:    config.GetObjectMeta,
-		getDesiredObject: config.GetDesiredObject,
-		hasChangedFunc:   config.HasChangedFunc,
+		clientFunc:           config.ClientFunc,
+		logger:               config.Logger,
+		name:                 config.Name,
+		getObjectMeta:        config.GetObjectMeta,
+		getDesiredObject:     config.GetDesiredObject,
+		hasChangedFunc:       config.HasChangedFunc,
+		deleteIfMimirEnabled: config.DeleteIfMimirEnabled,
 	}
 
 	return r, nil


### PR DESCRIPTION
This PR replaces all the generic resource removal PRs to make sure we can delete resources when moving to Mimir

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
