### PR TITLE
Remove AlertManager link in opsgenie and slack templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Remove AlertManager link in opsgenie and slack templating.
+
 ### Changed
 
 - Remove unused scrape_timeout inhibition.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
-- Remove AlertManager link in opsgenie and slack templating.
+- Remove AlertManager link in opsgenie and slack templating when mimir is enabled.
 
 ### Changed
 

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -219,7 +219,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -255,7 +255,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -291,7 +291,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -327,7 +327,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -363,7 +363,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -395,7 +395,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -431,7 +431,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -463,7 +463,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -495,7 +495,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -536,7 +536,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -57,7 +57,7 @@
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
 [[- if .MimirEnabled ]]
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 [[- else ]]
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -1,13 +1,23 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alertmanagerurl" }}
+[[- if .MimirEnabled ]]
+[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+[[- else ]]
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+[[- end ]]
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
+{{ define "__queryurl" }}
 [[- if .MimirEnabled ]]
-{{ define "__queryurl" }}[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 [[- else ]]
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+{{ (index .Alerts 0).GeneratorURL }}
 [[- end ]]
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -43,11 +53,15 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+[[- if .MimirEnabled ]]
+👀 Details: {{ template "__queryurl" . }}
+[[- else ]]
+🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 👀 Query: {{ template "__queryurl" . }}
+[[- end ]]
 
 ---
 

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alertmanagerurl" }}
+{{ define "__alerturl" }}
 [[- if .MimirEnabled ]]
 [[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 [[- else ]]
@@ -23,7 +23,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -59,7 +59,7 @@
 [[- if .MimirEnabled ]]
 👀 Details: {{ template "__queryurl" . }}
 [[- else ]]
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 [[- end ]]
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -133,7 +133,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -156,7 +156,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -179,7 +179,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -202,7 +202,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -225,7 +225,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -248,7 +248,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -271,7 +271,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -294,7 +294,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -317,7 +317,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -345,7 +345,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -152,7 +152,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -175,7 +175,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -198,7 +198,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -221,7 +221,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -244,7 +244,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -267,7 +267,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -290,7 +290,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -313,7 +313,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -336,7 +336,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -364,7 +364,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -137,7 +137,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -164,7 +164,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -191,7 +191,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -218,7 +218,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -245,7 +245,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -272,7 +272,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -299,7 +299,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -326,7 +326,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -353,7 +353,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'
@@ -385,7 +385,7 @@ receivers:
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__prometheusurl" . }}'
+      url: '{{ template "__alerturl" . }}'
     - type: button
       text: ':grafana: Dashboard'
       url: '{{ template "__dashboardurl" . }}'

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{end}}
+
+{{ define "__queryurl" }}
+{{ (index .Alerts 0).GeneratorURL }}
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,10 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
+🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -48,7 +48,7 @@ https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Details: {{ template "__queryurl" . }}
+👀 Explore: {{ template "__queryurl" . }}
 
 ---
 

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,14 +1,21 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
-{{ define "__alertmanagerurl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+
+{{ define "__alerturl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
+
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{end}}
+
+{{ define "__queryurl" }}
+https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alertmanagerurl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -38,11 +45,10 @@
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
 {{ end -}}
-🔔 Alertmanager {{ template "__alertmanagerurl" . }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
 {{ end -}}
-👀 Query: {{ template "__queryurl" . }}
+👀 Details: {{ template "__queryurl" . }}
 
 ---
 


### PR DESCRIPTION
## Checklist

towards https://github.com/giantswarm/roadmap/issues/3510
And fix issue with non existing __prometheusurl  variable in alertmanager config

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
