### PR TITLE
support disabling alertmanager and its resources on mimir backed installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Added support to be able to disable alertmanager on mimir installations.
+
 ## [4.77.3] - 2024-06-19
 
 ### Fixed

--- a/flag/service/alertmanager/alertmanager.go
+++ b/flag/service/alertmanager/alertmanager.go
@@ -1,0 +1,5 @@
+package alertmanager
+
+type Alertmanager struct {
+	Enabled string
+}

--- a/flag/service/service.go
+++ b/flag/service/service.go
@@ -3,6 +3,7 @@ package service
 import (
 	"github.com/giantswarm/operatorkit/v7/pkg/flag/service/kubernetes"
 
+	"github.com/giantswarm/prometheus-meta-operator/v2/flag/service/alertmanager"
 	"github.com/giantswarm/prometheus-meta-operator/v2/flag/service/grafana"
 	"github.com/giantswarm/prometheus-meta-operator/v2/flag/service/ingress"
 	"github.com/giantswarm/prometheus-meta-operator/v2/flag/service/installation"
@@ -17,6 +18,7 @@ import (
 
 // Service is an intermediate data structure for command line configuration flags.
 type Service struct {
+	Alertmanager    alertmanager.Alertmanager
 	Grafana         grafana.Grafana
 	Ingress         ingress.Ingress
 	Installation    installation.Installation

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-global-secret.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-global-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ data:
   slackApiUrl: {{ .Values.alertmanager.slack.apiURL | b64enc | quote }}
   opsGenieApiUrl: {{ printf "api.opsgenie.com" | b64enc | quote }}
   opsGenieApiKey: {{ .Values.prometheus.heartbeat.opsgenieKey | b64enc | quote }}
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-ingress.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-ingress.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- if not .Values.mimir.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
@@ -35,4 +36,5 @@ spec:
             name: alertmanager-operated
             port:
               number: 9093
+{{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-psp.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
@@ -38,5 +39,6 @@ spec:
     - 'secret'
     - 'downwardAPI'
     - 'persistentVolumeClaim'
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: rbac.authorization.k8s.io/v1
@@ -31,5 +32,6 @@ roleRef:
   kind: ClusterRole
   name: alertmanager
   apiGroup: rbac.authorization.k8s.io
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-service-account.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-service-account.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -5,3 +6,4 @@ metadata:
     {{- include "labels.common" . | nindent 4 }}
   name: alertmanager
   namespace: {{ include "resource.default.namespace" . }}
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-tls-secret.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager-tls-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- if not .Values.mimir.enabled }}
 {{- if eq .Values.prometheus.letsencrypt false }}
 apiVersion: v1
@@ -11,5 +12,6 @@ type: kubernetes.io/tls
 data:
   tls.crt: {{ .Values.certificate.monitoring.crtPem | quote }}
   tls.key: {{ .Values.certificate.monitoring.keyPem | quote }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/alertmanager.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/alertmanager.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: Alertmanager
 metadata:
@@ -62,3 +63,4 @@ spec:
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
   version: {{ .Values.alertmanager.version }}
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/cilium-network-policy.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/cilium-network-policy.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 {{- if .Values.ciliumNetworkPolicy.enabled -}}
 {{- if .Capabilities.APIVersions.Has "cilium.io/v2" -}}
 apiVersion: "cilium.io/v2"
@@ -41,3 +42,4 @@ spec:
           protocol: "TCP"
 {{ end }}
 {{ end }}
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/alertmanager/servicemonitor.yaml
+++ b/helm/prometheus-meta-operator/templates/alertmanager/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.alertmanager.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -16,3 +17,4 @@ spec:
   selector:
     matchLabels:
       operated-alertmanager: "true"
+{{- end }}

--- a/helm/prometheus-meta-operator/templates/configmap.yaml
+++ b/helm/prometheus-meta-operator/templates/configmap.yaml
@@ -23,6 +23,8 @@ data:
           keyFile: ''
       mimir:
         enabled: {{ .Values.mimir.enabled }}
+      alertmanager:
+        enabled: {{ .Values.alertmanager.enabled }}
       prometheus:
         {{- if .Values.prometheus.additionalScrapeConfigs }}
         additionalScrapeConfigs: |-

--- a/helm/prometheus-meta-operator/templates/prometheus/prometheus-psp.yaml
+++ b/helm/prometheus-meta-operator/templates/prometheus/prometheus-psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.mimir.enabled }}
 {{- if not .Values.global.podSecurityStandards.enforced }}
 {{- if .Capabilities.APIVersions.Has "policy/v1beta1/PodSecurityPolicy" }}
 apiVersion: policy/v1beta1
@@ -37,5 +38,6 @@ spec:
     - 'configMap'
     - 'persistentVolumeClaim'
     - 'projected'
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/templates/prometheus/prometheus-rbac.yaml
+++ b/helm/prometheus-meta-operator/templates/prometheus/prometheus-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.mimir.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -40,5 +41,6 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/prometheus-meta-operator/values.yaml
+++ b/helm/prometheus-meta-operator/values.yaml
@@ -18,6 +18,7 @@ kyvernoPolicyExceptions:
   namespace: giantswarm
 
 alertmanager:
+  enabled: true
   address: "https://alertmanager:9093"
   host: "alertmanager:9093"
   imageRepository: giantswarm/alertmanager

--- a/main.go
+++ b/main.go
@@ -121,6 +121,7 @@ func mainE(ctx context.Context) error {
 	daemonCommand.PersistentFlags().String(f.Service.Installation.Registry, "", "Container image registry.")
 	daemonCommand.PersistentFlags().Bool(f.Service.Installation.InsecureCA, false, "Is the management cluter CA insecure?")
 
+	daemonCommand.PersistentFlags().Bool(f.Service.Alertmanager.Enabled, true, "Is Alertmanager enabled?")
 	daemonCommand.PersistentFlags().Bool(f.Service.Mimir.Enabled, false, "Is Mimir enabled?")
 	daemonCommand.PersistentFlags().String(f.Service.Opsgenie.Key, "", "Opsgenie Key used for API authentication.")
 

--- a/service/controller/managementcluster/controller.go
+++ b/service/controller/managementcluster/controller.go
@@ -45,7 +45,8 @@ type ControllerConfig struct {
 	SlackApiToken  string
 	SlackApiURL    string
 
-	MimirEnabled bool
+	AlertmanagerEnabled bool
+	MimirEnabled        bool
 
 	PrometheusAddress            string
 	PrometheusBaseDomain         string

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -64,7 +64,8 @@ type resourcesConfig struct {
 	SlackApiToken  string
 	SlackApiURL    string
 
-	MimirEnabled bool
+	AlertmanagerEnabled bool
+	MimirEnabled        bool
 
 	PrometheusAddress            string
 	PrometheusBaseDomain         string
@@ -142,6 +143,8 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 		c := alertmanagerconfig.Config{
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
+
+			AlertmanagerEnabled: config.AlertmanagerEnabled && config.MimirEnabled,
 
 			BaseDomain:     config.PrometheusBaseDomain,
 			GrafanaAddress: config.GrafanaAddress,

--- a/service/controller/resource/alerting/alertmanagerconfig/create.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/create.go
@@ -11,6 +11,10 @@ import (
 )
 
 func (r *Resource) EnsureCreated(ctx context.Context, obj interface{}) error {
+	if !r.config.AlertmanagerEnabled {
+		r.config.Logger.Debugf(ctx, "alertmanager is disabled, deleting alertmanager config if it exists")
+		return r.EnsureDeleted(ctx, obj)
+	}
 	desired, err := r.toSecret()
 	if err != nil {
 		return microerror.Mask(err)

--- a/service/controller/resource/alerting/alertmanagerconfig/resource.go
+++ b/service/controller/resource/alerting/alertmanagerconfig/resource.go
@@ -27,6 +27,8 @@ type Config struct {
 	K8sClient k8sclient.Interface
 	Logger    micrologger.Logger
 
+	AlertmanagerEnabled bool
+
 	BaseDomain     string
 	GrafanaAddress string
 	Installation   string

--- a/service/service.go
+++ b/service/service.go
@@ -225,7 +225,8 @@ func New(config Config) (*Service, error) {
 			SlackApiToken:  config.Viper.GetString(config.Flag.Service.Slack.ApiToken),
 			SlackApiURL:    config.Viper.GetString(config.Flag.Service.Slack.ApiURL),
 
-			MimirEnabled: config.Viper.GetBool(config.Flag.Service.Mimir.Enabled),
+			AlertmanagerEnabled: config.Viper.GetBool(config.Flag.Service.Alertmanager.Enabled),
+			MimirEnabled:        config.Viper.GetBool(config.Flag.Service.Mimir.Enabled),
 
 			PrometheusAddress:            config.Viper.GetString(config.Flag.Service.Prometheus.Address),
 			PrometheusBaseDomain:         config.Viper.GetString(config.Flag.Service.Prometheus.BaseDomain),


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3513
Add support to disable alertmanager if monitoring is disabled at the installation level 

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
