### PR TITLE
Fix AlertManager configuration generation on Vintage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix AlertManager configuration generation on Vintage.
+
 ## [4.78.0] - 2024-07-03
 
 ### Added

--- a/service/controller/managementcluster/resource.go
+++ b/service/controller/managementcluster/resource.go
@@ -144,7 +144,7 @@ func newResources(config resourcesConfig) ([]resource.Interface, error) {
 			K8sClient: config.K8sClient,
 			Logger:    config.Logger,
 
-			AlertmanagerEnabled: config.AlertmanagerEnabled && config.MimirEnabled,
+			AlertmanagerEnabled: config.AlertmanagerEnabled || !key.IsCAPIManagementCluster(config.Provider),
 
 			BaseDomain:     config.PrometheusBaseDomain,
 			GrafanaAddress: config.GrafanaAddress,


### PR DESCRIPTION
Current AlertManager configuration on Vintage is broken.

## Checklist

I have:

- [x] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
