### PR TITLE
rename prometheus-agent inbitions to monitoring agent to be able to take alloy into account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Create new `monitoring-agent` inhibitions based on the `prometheus-agent` inhibitions to be agnostic to the tool used to monitor targets.
+
 ## [4.80.0] - 2024-10-21
 
 ### Added

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -628,6 +628,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -450,6 +450,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -469,6 +469,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -486,6 +486,18 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
+    - cluster_is_not_running_monitoring_agent=true
+  target_matchers:
+    - cancel_if_cluster_is_not_running_monitoring_agent=true
+  equal: [cluster_id]
+
+- source_matchers:
+    - inhibit_monitoring_agent_down=true
+  target_matchers:
+    - cancel_if_monitoring_agent_down=true
+  equal: [cluster_id]
+
+- source_matchers:
     - stack_failed=true
   target_matchers:
     - cancel_if_stack_failed=true


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3590.

We now use alloy as a monitoring agent so having the inhibition named prometheus-agent makes no sense. 

This PR renames both inbititions about missing prometheus agent to monitoring agent.

## Checklist

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
