### PR TITLE
remove useless prometheus-agent inhibitions as they were replaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Get rid of useless `prometheus-agent` after the migration to the new `monitoring-agent` inhibitions.
+
 ## [4.81.0] - 2024-10-30
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -616,18 +616,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -438,18 +438,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -457,18 +457,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -474,18 +474,6 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_prometheus_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_prometheus_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
-    - inhibit_prometheus_agent_down=true
-  target_matchers:
-    - cancel_if_prometheus_agent_down=true
-  equal: [cluster_id]
-
-- source_matchers:
     - cluster_is_not_running_monitoring_agent=true
   target_matchers:
     - cancel_if_cluster_is_not_running_monitoring_agent=true


### PR DESCRIPTION
## Checklist

This PR gets rid of the old prometheus-agent inhibitions as they were replaced by monitoring-agent inhibitions https://github.com/giantswarm/prometheus-meta-operator/pull/1753 and used in alerts https://github.com/giantswarm/prometheus-rules/pull/1405 and sloth alerts https://github.com/giantswarm/sloth-rules/pull/253 which were both released :)

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
