### PR TITLE
Update Alertmanager notification template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Alertmanager notification template
+  - Update alert and query URLs for Mimir to point to the Active notification rather than the rule page
+  - Move link section (runbook, dashboard, explors) before instance to avoid them being lost due to OpsGenie max description being reached
+  - Move the warnings for missing runbook and dashboard up into the link section
+
+
 ### Removed
 
 - Get rid of useless `prometheus-agent` after the migration to the new `monitoring-agent` inhibitions.

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -2,7 +2,7 @@
 
 {{ define "__alerturl" }}
 [[- if .MimirEnabled -]]
-[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+[[ .GrafanaAddress ]]/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager
 [[- else -]]
 {{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
 [[- end -]]
@@ -13,7 +13,7 @@
 
 {{ define "__queryurl" }}
 [[- if .MimirEnabled -]]
-[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
+[[ .GrafanaAddress ]]/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager
 [[- else -]]
 {{ (index .Alerts 0).GeneratorURL }}
 [[- end -]]
@@ -42,19 +42,16 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 [[- if .MimirEnabled ]]
 👀 Explore: {{ template "__queryurl" . }}
@@ -65,8 +62,10 @@
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -30,27 +30,26 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 🔔 Alertmanager {{ template "__alerturl" . }}
 👀 Query: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
@@ -30,26 +30,25 @@
 
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
-{{ define "opsgenie.default.description" }}* Team: {{ (index .Alerts 0).Labels.team }}
-* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
-
-* Instances:{{ range .Alerts.Firing }}
-🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
-
----
-
+{{ define "opsgenie.default.description" }}
 {{ if (index .Alerts 0).Annotations.opsrecipe -}}
 📗 Runbook: {{ template "__runbookurl" . }}
-{{ end -}}
+{{ else -}}
+📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
+{{- end }}
 {{ if (index .Alerts 0).Annotations.dashboard -}}
 📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ else -}}
+📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
 
 ---
 
-{{ if not (index .Alerts 0).Annotations.opsrecipe }}⚠️ There is no **runbook** for this alert, time to get your pen.{{- end }}
-{{ if not (index .Alerts 0).Annotations.dashboard }}⚠️ There is no **dashboard** for this alert, time to sketch.{{- end }}
+* Team: {{ (index .Alerts 0).Labels.team }}
+* Area: {{ (index .Alerts 0).Labels.area }} / {{ (index .Alerts 0).Labels.topic }}
+* Instances:{{ range .Alerts.Firing }}
+🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
 # This builds the silence URL.  We exclude the alertname in the range


### PR DESCRIPTION
This PR introduces the following changes into the Alertmanager notification template:

- Update alert and query URLs for Mimir to point to the Active notification rather than the rule page
- Move link section (runbook, dashboard, explors) before instance to avoid them being lost due to OpsGenie max description being reached
- Move the warnings for missing runbook and dashboard up into the link section