### PR TITLE
Replace silence link with silence repo, also on Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Replace the silence link on Slack with silence repository link
+
 ## [4.82.0] - 2024-12-17
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Update alert and query URLs for Mimir to point to the Active notification rather than the rule page
   - Move link section (runbook, dashboard, explors) before instance to avoid them being lost due to OpsGenie max description being reached
   - Move the warnings for missing runbook and dashboard up into the link section
-  - Replace Alertmanager link with silence repository
+  - Replace Alertmanager and silence link with silence repository
 
 ### Removed
 

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -58,7 +58,7 @@
 [[- else ]]
 👀 Query: {{ template "__queryurl" . }}
 [[- end ]]
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -68,17 +68,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Query: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -42,7 +42,7 @@
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
 👀 Explore: {{ template "__queryurl" . }}
-🔔 Silence: https://github.com/giantswarm/silences#silences
+🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---
 
@@ -52,17 +52,9 @@
 🔥 {{ if .Labels.instance }}{{ .Labels.instance }}: {{ end }}{{ .Annotations.description }}{{ end }}
 {{- end }}
 
-# This builds the silence URL.  We exclude the alertname in the range
-# to avoid the issue of having trailing comma separator (%2C) at the end
-# of the generated URL
+# Link to the silence repository where silences should be created
 {{ define "__alert_silence_link" -}}
-    {{ .ExternalURL }}/#/silences/new?filter=%7B
-    {{- range .CommonLabels.SortedPairs -}}
-        {{- if ne .Name "alertname" -}}
-            {{- .Name }}%3D"{{- .Value -}}"%2C%20
-        {{- end -}}
-    {{- end -}}
-    alertname%3D"{{ .CommonLabels.alertname }}"%7D
+https://github.com/giantswarm/silences#silences
 {{- end }}
 
 # Link to related PMs


### PR DESCRIPTION
Replacing the silence link also on Slack, and points it to the Silences repository.