### PR TITLE
Use proxy_from_environment in Alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Use `proxy_from_environment: true` in Alertmanager configuration to read proxy settings from the environment.
+
 ## [4.83.0] - 2024-12-17
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -1,9 +1,7 @@
 global:
   resolve_timeout: 5m
-[[- if .ProxyURL ]]
   http_config:
-    proxy_url:  [[ .ProxyURL ]]
-[[- end ]]
+    proxy_from_environment: true
 [[- if .SlackApiToken ]]
   slack_api_url: "https://slack.com/api/chat.postMessage"
 [[- else ]]
@@ -180,9 +178,6 @@ receivers:
         credentials: [[ .OpsgenieKey ]]
       follow_redirects: true
       enable_http2: true
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     url: https://api.opsgenie.com/v2/heartbeats/[[ .Installation ]]/ping
 [[- end ]]
 
@@ -198,9 +193,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -234,9 +226,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -270,9 +259,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -306,9 +292,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -342,9 +325,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -374,9 +354,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -410,9 +387,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -442,9 +416,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:
@@ -474,9 +445,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
-      [[- if .ProxyURL ]]
-      proxy_url:  [[ .ProxyURL ]]
-      [[- end ]]
     [[- end ]]
     send_resolved: true
     actions:

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -189,13 +189,13 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -223,13 +223,13 @@ receivers:
   [[- else ]]
   - channel: '#alert-atlas-test'
   [[- end ]]
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -257,13 +257,13 @@ receivers:
   [[- else ]]
   - channel: '#alert-phoenix-test'
   [[- end ]]
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -291,13 +291,13 @@ receivers:
   [[- else ]]
   - channel: '#alert-bigmac-test'
   [[- end ]]
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -325,13 +325,13 @@ receivers:
   [[- else ]]
   - channel: '#alert-rocket-test'
   [[- end ]]
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -355,13 +355,13 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -389,13 +389,13 @@ receivers:
   [[- else ]]
   - channel: '#alert-turtles-test'
   [[- end ]]
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -419,13 +419,13 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -449,13 +449,13 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    [[- if .SlackApiToken ]]
     http_config:
+      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- end ]]
       proxy_from_environment: true
-    [[- end ]]
     send_resolved: true
     actions:
     - type: button

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -178,6 +178,7 @@ receivers:
         credentials: [[ .OpsgenieKey ]]
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/[[ .Installation ]]/ping
 [[- end ]]
 
@@ -193,6 +194,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -226,6 +228,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -259,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -292,6 +296,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -325,6 +330,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -354,6 +360,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -387,6 +394,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -416,6 +424,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:
@@ -445,6 +454,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      proxy_from_environment: true
     [[- end ]]
     send_resolved: true
     actions:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -118,6 +118,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -141,6 +143,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -164,6 +168,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -187,6 +193,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -210,6 +218,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -233,6 +243,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -256,6 +268,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -279,6 +293,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -302,6 +318,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -132,6 +132,7 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
+      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -138,6 +138,8 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -161,6 +163,8 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -184,6 +188,8 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -207,6 +213,8 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +238,8 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -253,6 +263,8 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -276,6 +288,8 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -299,6 +313,8 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -322,6 +338,8 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    http_config:
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -1,5 +1,7 @@
 global:
   resolve_timeout: 5m
+  http_config:
+    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -122,6 +122,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -149,6 +150,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -176,6 +178,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -203,6 +206,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -230,6 +234,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -257,6 +262,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -284,6 +290,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -311,6 +318,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,6 +346,7 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
+      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button


### PR DESCRIPTION
Use the `proxy_from_environment` option in the Alertmanager configuration to make it read the proxy settings from environment variables (HTTP_PROXY, HTTPS_PROXY, NO_PROXY, etc...) rather having the operator setting proxy via `proxy_url`.

See https://prometheus.io/docs/alerting/0.26/configuration/#http_config

2 things are happening here:
- Replace `proxy_url` in favor of `proxy_from_environment`
- Move the `SlackApiToken` condition so `proxy_from_environment` is not dependent on it
