### PR TITLE
Fix restore previous Alerts link and fix see source link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
 - Restore previous link for alerts, as the new one breaks the `see source` link in Grafana, leading to a page not found.
 
 ## [4.83.0] - 2024-12-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Restore previous link for alerts, as the new one breaks the `see source` link in Grafana, leading to a page not found.
+
 ## [4.83.0] - 2024-12-17
 
 ### Changed

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -2,7 +2,7 @@
 
 {{ define "__alerturl" }}
 [[- if .MimirEnabled -]]
-[[ .GrafanaAddress ]]/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager
+[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 [[- else -]]
 {{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D
 [[- end -]]
@@ -13,7 +13,7 @@
 
 {{ define "__queryurl" }}
 [[- if .MimirEnabled -]]
-[[ .GrafanaAddress ]]/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager
+[[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 [[- else -]]
 {{ (index .Alerts 0).GeneratorURL }}
 [[- end -]]

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,11 +1,11 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
 {{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
 
-{{ define "__queryurl" }}https://grafana/alerting/groups?queryString=alertname%3D%22{{ .CommonLabels.alertname}}%22&alertmanager=Alertmanager{{ end }}
+{{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{ define "slack.default.title" }}{{ .Status | toUpper }}[{{ if eq .Status "firing" }}{{ .Alerts.Firing | len }}{{- else }}{{ .Alerts.Resolved | len }}{{- end }}] {{ (index .Alerts 0).Labels.alertname }} - Team {{ (index .Alerts 0).Labels.team }}{{ end }}
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}


### PR DESCRIPTION
The new link is misleading as user lands on a page where they should be able to explore data using the `see source` link in Grafana, but this leads to a page not found.

This PR restores the previous link for Alerts. We can revisit this in the future when we have Mimir Alertmanager.