### PR TITLE
Revert "Use proxy_from_environment in Alertmanager (#1782)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert `proxy_from_environment: true`, as this is only compatible with observability-bundle >= v1.8.0.
+
 ## [4.84.0] - 2025-01-06
 
 ### Changed

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -1,7 +1,9 @@
 global:
   resolve_timeout: 5m
+[[- if .ProxyURL ]]
   http_config:
-    proxy_from_environment: true
+    proxy_url:  [[ .ProxyURL ]]
+[[- end ]]
 [[- if .SlackApiToken ]]
   slack_api_url: "https://slack.com/api/chat.postMessage"
 [[- else ]]
@@ -178,7 +180,9 @@ receivers:
         credentials: [[ .OpsgenieKey ]]
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
+      [[- end ]]
     url: https://api.opsgenie.com/v2/heartbeats/[[ .Installation ]]/ping
 [[- end ]]
 
@@ -189,13 +193,15 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -223,13 +229,15 @@ receivers:
   [[- else ]]
   - channel: '#alert-atlas-test'
   [[- end ]]
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -257,13 +265,15 @@ receivers:
   [[- else ]]
   - channel: '#alert-phoenix-test'
   [[- end ]]
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -291,13 +301,15 @@ receivers:
   [[- else ]]
   - channel: '#alert-bigmac-test'
   [[- end ]]
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -325,13 +337,15 @@ receivers:
   [[- else ]]
   - channel: '#alert-rocket-test'
   [[- end ]]
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -355,13 +369,15 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -389,13 +405,15 @@ receivers:
   [[- else ]]
   - channel: '#alert-turtles-test'
   [[- end ]]
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -419,13 +437,15 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button
@@ -449,13 +469,15 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
+    [[- if .SlackApiToken ]]
     http_config:
-      [[- if .SlackApiToken ]]
       authorization:
         type: Bearer
         credentials: [[ .SlackApiToken ]]
+      [[- if .ProxyURL ]]
+      proxy_url:  [[ .ProxyURL ]]
       [[- end ]]
-      proxy_from_environment: true
+    [[- end ]]
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -118,8 +116,6 @@ receivers:
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -143,8 +139,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -168,8 +162,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -193,8 +185,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -218,8 +208,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -243,8 +231,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -268,8 +254,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -293,8 +277,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,8 +300,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: https://slack
 
 templates:
@@ -132,14 +130,11 @@ receivers:
         credentials: opsgenie-key
       follow_redirects: true
       enable_http2: true
-      proxy_from_environment: true
     url: https://api.opsgenie.com/v2/heartbeats/test-installation/ping
 
 - name: falco_noise_slack
   slack_configs:
   - channel: '#noise-falco'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -163,8 +158,6 @@ receivers:
 - name: team_atlas_slack
   slack_configs:
   - channel: '#alert-atlas-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -188,8 +181,6 @@ receivers:
 - name: team_phoenix_slack
   slack_configs:
   - channel: '#alert-phoenix-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -213,8 +204,6 @@ receivers:
 - name: team_bigmac_slack
   slack_configs:
   - channel: '#alert-bigmac-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -238,8 +227,6 @@ receivers:
 - name: team_rocket_slack
   slack_configs:
   - channel: '#alert-rocket-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -263,8 +250,6 @@ receivers:
 - name: team_shield_slack
   slack_configs:
   - channel: '#alert-shield'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -288,8 +273,6 @@ receivers:
 - name: team_turtles_slack
   slack_configs:
   - channel: '#alert-turtles-test'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -313,8 +296,6 @@ receivers:
 - name: team_tenet_slack
   slack_configs:
   - channel: '#alert-tenet'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -338,8 +319,6 @@ receivers:
 - name: team_honeybadger_slack
   slack_configs:
   - channel: '#alert-honeybadger'
-    http_config:
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -1,7 +1,5 @@
 global:
   resolve_timeout: 5m
-  http_config:
-    proxy_from_environment: true
   slack_api_url: "https://slack.com/api/chat.postMessage"
 
 templates:
@@ -122,7 +120,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -150,7 +147,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -178,7 +174,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -206,7 +201,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -234,7 +228,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -262,7 +255,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -290,7 +282,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -318,7 +309,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button
@@ -346,7 +336,6 @@ receivers:
       authorization:
         type: Bearer
         credentials: some-token
-      proxy_from_environment: true
     send_resolved: true
     actions:
     - type: button


### PR DESCRIPTION
This reverts commit 3f42eba776926ba4c89b19312c3b59b733f25731.

This is because `proxy_from_environment` breaks in most of our installations currently, as its only supported from observability-bundle >= 1.8

- https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.77.0
- https://github.com/prometheus-community/helm-charts/blob/kube-prometheus-stack-65.1.1/charts/kube-prometheus-stack/Chart.yaml#L27
- https://github.com/giantswarm/kube-prometheus-stack-app/blob/v12.0.0/helm/kube-prometheus-stack/Chart.yaml#L16
- https://github.com/giantswarm/observability-bundle/blob/v1.8.0/helm/observability-bundle/values.yaml#L111