### PR TITLE
use the new alert annotations for runbook and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add deprecation notice.
 
+### Changed
+
+- update the notification template to take into account the new alert annotations
+  - `opsrecipe` => `runbook_url`
+  - `dashboard` => `dashboardUid`
+
 ### Removed
 
 - Remove deployment to CAPI installations.

--- a/files/templates/alertmanager/alertmanager.yaml
+++ b/files/templates/alertmanager/alertmanager.yaml
@@ -205,21 +205,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -241,21 +241,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -277,18 +277,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -313,18 +313,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -349,18 +349,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -381,21 +381,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -417,18 +417,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -449,21 +449,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -481,21 +481,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/files/templates/alertmanager/notification-template.tmpl
+++ b/files/templates/alertmanager/notification-template.tmpl
@@ -1,6 +1,6 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}
+{{ define "__alert_url" }}
 [[- if .MimirEnabled -]]
 [[ .GrafanaAddress ]]/alerting/Mimir/{{ .CommonLabels.alertname }}/find
 [[- else -]]
@@ -8,8 +8,8 @@
 [[- end -]]
 {{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}[[ .GrafanaAddress ]]/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}
 [[- if .MimirEnabled -]]
@@ -23,7 +23,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -43,13 +43,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-1-capa-mc.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-2-capa.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-3-capz.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-4-eks.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/capi/case-5-gcp.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-1-vintage-mc.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-2-aws-v16.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/classic/vintage/case-3-aws-v18.golden
@@ -119,21 +119,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -142,21 +142,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -165,18 +165,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -188,18 +188,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -211,18 +211,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -234,21 +234,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -257,18 +257,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -280,21 +280,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -303,21 +303,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-1-capa-mc.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-2-capa.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-3-capz.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-4-eks.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/capi/case-5-gcp.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -138,21 +138,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -161,21 +161,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -184,18 +184,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -207,18 +207,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -230,18 +230,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -253,21 +253,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -276,18 +276,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -299,21 +299,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -322,21 +322,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-1-capa-mc.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-2-capa.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-3-capz.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-4-eks.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/capi/case-5-gcp.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-1-vintage-mc.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-2-aws-v16.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/alertmanager-config/slack-token/vintage/case-3-aws-v18.golden
@@ -123,21 +123,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_atlas_slack
@@ -150,21 +150,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_phoenix_slack
@@ -177,18 +177,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -204,18 +204,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -231,18 +231,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -258,21 +258,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_turtles_slack
@@ -285,18 +285,18 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{ template "__alert_silence_link" . }}'
@@ -312,21 +312,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: team_honeybadger_slack
@@ -339,21 +339,21 @@ receivers:
     send_resolved: true
     actions:
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{ template "__runbookurl" . }}'
+      text: ':green_book: Runbook'
+      url: '{{ template "__runbook_url" . }}'
       style: '{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{ template "__alert_linked_postmortems" . }}'
     - type: button
       text: ':mag: Query'
-      url: '{{ template "__alerturl" . }}'
+      url: '{{ template "__alert_url" . }}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{ template "__dashboardurl" . }}'
+      url: '{{ template "__dashboard_url" . }}'
     - type: button
       text: ':no_bell: Silence'
-      url: '{{ template "__alert_silence_link" .}}'
+      url: '{{ template "__alert_silence_link" . }}'
       style: '{{ if eq .Status "firing" }}danger{{ else }}default{{ end }}'
 
 - name: opsgenie_router

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-1-capa-mc.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-2-capa.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-3-capz.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-4-eks.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/capi/case-5-gcp.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-1-vintage-mc.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-2-aws-v16.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/classic/vintage/case-3-aws-v18.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
+{{ define "__alert_url" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver }}&silenced=false&inhibited=false&active=true&filter=%7Balertname%3D%22{{ .CommonLabels.alertname }}%22%7D{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}{{ (index .Alerts 0).GeneratorURL }}{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-1-capa-mc.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-2-capa.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-3-capz.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-4-eks.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/capi/case-5-gcp.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-1-vintage-mc.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-2-aws-v16.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}

--- a/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/alerting/alertmanagerconfig/test/notification-template/mimir-enabled/vintage/case-3-aws-v18.golden
@@ -1,9 +1,9 @@
 {{ define "__alertmanager" }}Alertmanager{{ end }}
 
-{{ define "__alerturl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
-{{ define "__dashboardurl" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboard }}{{ end }}{{- end }}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__dashboard_url" -}}{{ if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid }}{{ else }}https://grafana/d/{{ (index .Alerts 0).Annotations.dashboardUid }}{{ end }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 
 {{ define "__queryurl" }}https://grafana/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
@@ -11,7 +11,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -31,13 +31,13 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" }}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}


### PR DESCRIPTION
## Checklist

This pull request includes several changes to update the alert notification templates and related files to use new alert annotations added https://github.com/giantswarm/prometheus-rules/pull/1509, https://github.com/giantswarm/sloth-rules/pull/280 and https://github.com/giantswarm/observability-operator/pull/269 as part of https://github.com/giantswarm/giantswarm/issues/28089

I have:

- [ ] Described why this change is being introduced
- [ ] Separated out refactoring/reformatting in a dedicated PR
- [ ] Updated changelog in `CHANGELOG.md`
