### PR TITLE
do not load log based alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do not load log based alerts in Prometheus.
+
 ## [4.87.0] - 2025-02-25
 
 ### Changed

--- a/service/controller/resource/monitoring/prometheus/resource.go
+++ b/service/controller/resource/monitoring/prometheus/resource.go
@@ -285,6 +285,11 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 					Key:      key.TeamLabel,
 					Operator: metav1.LabelSelectorOpExists,
 				},
+				{
+					Key:      "application.giantswarm.io/prometheus-rule-kind",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"loki"},
+				},
 			},
 		}
 
@@ -335,6 +340,11 @@ func toPrometheus(ctx context.Context, v interface{}, config Config) (metav1.Obj
 				{
 					Key:      key.TeamLabel,
 					Operator: metav1.LabelSelectorOpExists,
+				},
+				{
+					Key:      "application.giantswarm.io/prometheus-rule-kind",
+					Operator: metav1.LabelSelectorOpNotIn,
+					Values:   []string{"loki"},
 				},
 			},
 		}

--- a/service/controller/resource/monitoring/prometheus/test/classic/capi/case-1-capa-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/capi/case-1-capa-mc.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/capi/case-2-capa.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/capi/case-2-capa.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/capi/case-3-capz.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/capi/case-3-capz.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/capi/case-4-eks.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/capi/case-4-eks.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/capi/case-5-gcp.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/capi/case-5-gcp.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-1-vintage-mc.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-1-vintage-mc.golden
@@ -73,6 +73,10 @@ spec:
       - workload_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-2-aws-v16.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-2-aws-v16.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s

--- a/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-3-aws-v18.golden
+++ b/service/controller/resource/monitoring/prometheus/test/classic/vintage/case-3-aws-v18.golden
@@ -67,6 +67,10 @@ spec:
       - management_cluster
     - key: application.giantswarm.io/team
       operator: Exists
+    - key: application.giantswarm.io/prometheus-rule-kind
+      operator: NotIn
+      values:
+      - loki
   rules:
     alert: {}
   scrapeInterval: 60s


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3678

## Checklist

Without this, prometheus operator on vintage installation tries to load loki rules into prometheus and this might create some alerts.

This makes sure we do not load loki rules in vintage Prometheus

I have:

- [x] Described why this change is being introduced
- [x] Separated out refactoring/reformatting in a dedicated PR
- [x] Updated changelog in `CHANGELOG.md`
